### PR TITLE
Add CI for js-legacy client

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,33 @@
+name: Setup environment
+
+inputs:
+  solana:
+    description: Install Solana if `true`. Defaults to `false`.
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v3
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: "pnpm"
+
+    - name: Install Dependencies
+      run: pnpm install --frozen-lockfile
+      shell: bash
+
+    - name: Set Environment Variables
+      shell: bash
+      run: pnpm zx ./scripts/ci/set-env.mjs
+
+    - name: Install Solana
+      if: ${{ inputs.solana == 'true' }}
+      uses: solana-program/actions/install-solana@v1
+      with:
+        version: ${{ env.SOLANA_VERSION }}
+        cache: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,40 @@
+name: Main
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  format_and_lint_client_js_legacy:
+    name: Format & Lint Client JS Legacy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+
+      - name: Format Client JS Legacy
+        run: pnpm clients:js-legacy:format
+
+      - name: Lint Client JS Legacy
+        run: pnpm clients:js-legacy:lint
+
+  test_client_js_legacy:
+    name: Test Client JS Legacy
+    runs-on: ubuntu-latest
+    needs: [format_and_lint_client_js_legacy]
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          solana: true
+
+      - name: Test Client JS Legacy
+        run: pnpm clients:js-legacy:test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,2 @@
+[workspace.metadata.cli]
+solana = "2.1.0"

--- a/clients/js-legacy/.eslintignore
+++ b/clients/js-legacy/.eslintignore
@@ -1,3 +1,1 @@
 test-ledger
-
-package-lock.json

--- a/clients/js-legacy/package.json
+++ b/clients/js-legacy/package.json
@@ -18,7 +18,7 @@
         "lint:fix": "eslint --fix .",
         "format": "prettier --check src test",
         "format:fix": "prettier --write src test",
-        "test": "start-server-and-test 'solana-test-validator --reset --quiet' http://127.0.0.1:8899/health 'mocha test'"
+        "test": "mocha test/*"
     },
     "dependencies": {
         "@solana/web3.js": "^1.95.5",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "private": true,
+  "scripts": {
+    "solana:check": "zx ./scripts/check-solana-version.mjs",
+    "solana:link": "zx ./scripts/link-solana-version.mjs",
+    "validator:start": "zx ./scripts/start-validator.mjs",
+    "validator:restart": "pnpm validator:start --restart",
+    "validator:stop": "zx ./scripts/stop-validator.mjs",
+    "template:upgrade": "zx ./scripts/upgrade-template.mjs",
+    "rust:spellcheck": "cargo spellcheck --code 1",
+    "rust:audit": "zx ./scripts/audit-rust.mjs",
+    "rust:semver": "cargo semver-checks",
+    "clients:js-legacy:format": "zx ./scripts/js/format.mjs clients/js-legacy",
+    "clients:js-legacy:lint": "zx ./scripts/js/lint.mjs clients/js-legacy",
+    "clients:js-legacy:test": "zx ./scripts/js/test.mjs clients/js-legacy"
+  },
+  "devDependencies": {
+    "@iarna/toml": "^2.2.5",
+    "typescript": "^5.7.3",
+    "zx": "^8.3.0"
+  },
+  "engines": {
+    "node": ">=v20.0.0"
+  },
+  "packageManager": "pnpm@9.1.0"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,76 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@iarna/toml':
+        specifier: ^2.2.5
+        version: 2.2.5
+      typescript:
+        specifier: ^5.7.3
+        version: 5.7.3
+      zx:
+        specifier: ^8.3.0
+        version: 8.3.0
+
+packages:
+
+  '@iarna/toml@2.2.5':
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
+
+  '@types/fs-extra@11.0.4':
+    resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
+
+  '@types/jsonfile@6.1.4':
+    resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
+
+  '@types/node@22.12.0':
+    resolution: {integrity: sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==}
+
+  typescript@5.7.3:
+    resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.20.0:
+    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+
+  zx@8.3.0:
+    resolution: {integrity: sha512-L8mY3yfJwo3a8ZDD6f9jZzAcRWJZYcV8GauZmBxLB/aSTwaMzMIEVpPp2Kyx+7yF0gdvuxKnMxAZRft9UCawiw==}
+    engines: {node: '>= 12.17.0'}
+    hasBin: true
+
+snapshots:
+
+  '@iarna/toml@2.2.5': {}
+
+  '@types/fs-extra@11.0.4':
+    dependencies:
+      '@types/jsonfile': 6.1.4
+      '@types/node': 22.12.0
+    optional: true
+
+  '@types/jsonfile@6.1.4':
+    dependencies:
+      '@types/node': 22.12.0
+    optional: true
+
+  '@types/node@22.12.0':
+    dependencies:
+      undici-types: 6.20.0
+    optional: true
+
+  typescript@5.7.3: {}
+
+  undici-types@6.20.0:
+    optional: true
+
+  zx@8.3.0:
+    optionalDependencies:
+      '@types/fs-extra': 11.0.4
+      '@types/node': 22.12.0

--- a/scripts/check-solana-version.mjs
+++ b/scripts/check-solana-version.mjs
@@ -1,0 +1,24 @@
+#!/usr/bin/env zx
+import 'zx/globals';
+import { getInstalledSolanaVersion, getSolanaVersion } from './utils.mjs';
+
+const expectedVersion = getSolanaVersion();
+const installedVersion = await getInstalledSolanaVersion();
+
+if (!installedVersion) {
+  echo(
+    chalk.red('[ ERROR ]'),
+    `No Solana installation found. Please install Solana ${expectedVersion} before proceeding.`
+  );
+  process.exit(1);
+} else if (installedVersion !== expectedVersion) {
+  echo(
+    chalk.yellow('[ WARNING ]'),
+    `The installed Solana version ${installedVersion} does not match the expected version ${expectedVersion}.`
+  );
+} else {
+  echo(
+    chalk.green('[ SUCCESS ]'),
+    `The expected Solana version ${expectedVersion} is installed.`
+  );
+}

--- a/scripts/ci/set-env.mjs
+++ b/scripts/ci/set-env.mjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env zx
+import { getSolanaVersion, getToolchain } from '../utils.mjs';
+
+await $`echo "SOLANA_VERSION=${getSolanaVersion()}" >> $GITHUB_ENV`;
+await $`echo "TOOLCHAIN_FORMAT=${getToolchain('format')}" >> $GITHUB_ENV`;
+await $`echo "TOOLCHAIN_LINT=${getToolchain('lint')}" >> $GITHUB_ENV`;

--- a/scripts/js/format.mjs
+++ b/scripts/js/format.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env zx
+import 'zx/globals';
+import { cliArguments, workingDirectory } from '../utils.mjs';
+
+const [folder, ...args] = cliArguments();
+
+// Format the client using Prettier.
+cd(path.join(workingDirectory, folder));
+await $`pnpm install`;
+await $`pnpm format ${args}`;

--- a/scripts/js/lint.mjs
+++ b/scripts/js/lint.mjs
@@ -1,0 +1,10 @@
+#!/usr/bin/env zx
+import 'zx/globals';
+import { cliArguments, workingDirectory } from '../utils.mjs';
+
+const [folder, ...args] = cliArguments();
+
+// Check the client using ESLint.
+cd(path.join(workingDirectory, folder));
+await $`pnpm install`;
+await $`pnpm lint ${args}`;

--- a/scripts/js/test.mjs
+++ b/scripts/js/test.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env zx
+import 'zx/globals';
+import { cliArguments, workingDirectory } from '../utils.mjs';
+
+const [folder, ...args] = cliArguments();
+
+// Start the local validator, or restart it if it is already running.
+await $`pnpm validator:restart`;
+
+// Build the client and run the tests.
+cd(path.join(workingDirectory, folder));
+await $`pnpm install`;
+await $`pnpm build`;
+await $`pnpm test ${args}`;

--- a/scripts/start-validator.mjs
+++ b/scripts/start-validator.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env zx
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import 'zx/globals';
+import {
+    getCargo,
+    getExternalAccountAddresses,
+    getExternalProgramAddresses,
+    getExternalProgramOutputDir,
+    getProgramFolders,
+} from './utils.mjs';
+
+// Check Solana version.
+await $`pnpm solana:check`;
+
+// Options and arguments.
+const restart = argv['restart'];
+
+// Keep the validator running when not using the restart flag.
+const isValidatorRunning = (await $`lsof -t -i:8899`.quiet().exitCode) === 0;
+if (!restart && isValidatorRunning) {
+    echo(chalk.yellow('Local validator is already running.'));
+    process.exit();
+}
+
+// Initial message.
+const verb = isValidatorRunning ? 'Restarting' : 'Starting';
+
+// Get programs and accounts.
+const programs = [];
+const programPluralized = programs.length === 1 ? 'program' : 'programs';
+const accounts = [];
+const accountsPluralized = accounts.length === 1 ? 'account' : 'accounts';
+
+echo(
+    `${verb} local validator with ${programs.length} custom ${programPluralized}` +
+    (accounts.length > 0
+        ? ` and ${accounts.length} external ${accountsPluralized}...`
+        : `...`)
+);
+
+// Kill the validator if it's already running.
+if (isValidatorRunning) {
+    await $`pkill -f solana-test-validator`.quiet();
+    await sleep(1000);
+}
+
+// Global validator arguments.
+const args = [/* Reset ledger */ '-r'];
+
+// Load programs.
+programs.forEach(({ programId, deployPath }) => {
+    args.push(/* Load BPF program */ '--bpf-program', programId, deployPath);
+});
+
+// Load accounts.
+accounts.forEach(({ account, deployPath }) => {
+    args.push(/* Load account */ '--account', account, deployPath);
+});
+
+// Start the validator in detached mode.
+const cliLogs = path.join(os.tmpdir(), 'validator-cli.log');
+fs.writeFileSync(cliLogs, '', () => { });
+const out = fs.openSync(cliLogs, 'a');
+const err = fs.openSync(cliLogs, 'a');
+const validator = spawn('solana-test-validator', args, {
+    detached: true,
+    stdio: ['ignore', out, err],
+});
+validator.unref();
+
+// Wait for the validator to stabilize.
+const waitForValidator = spinner(
+    'Waiting for local validator to stabilize...',
+    () =>
+        new Promise((resolve, reject) => {
+            setInterval(() => {
+                const logs = fs.readFileSync(cliLogs, 'utf8');
+                if (validator.exitCode !== null) {
+                    reject(logs);
+                } else if (logs.includes('Confirmed Slot: 1')) {
+                    resolve();
+                }
+            }, 1000);
+        })
+);
+
+try {
+    await waitForValidator;
+    echo(chalk.green('Local validator is up and running!'));
+} catch (error) {
+    echo(error);
+    echo(chalk.red('Could not start local validator.'));
+} finally {
+    fs.rmSync(cliLogs);
+    process.exit();
+}

--- a/scripts/stop-validator.mjs
+++ b/scripts/stop-validator.mjs
@@ -1,0 +1,13 @@
+#!/usr/bin/env zx
+import 'zx/globals';
+
+const isValidatorRunning = (await $`lsof -t -i:8899`.quiet().exitCode) === 0;
+
+if (isValidatorRunning) {
+    // Kill the validator if it's already running.
+    await $`pkill -f solana-test-validator`.quiet();
+    await sleep(1000);
+    echo(chalk.green('Local validator terminated!'));
+} else {
+    echo(chalk.yellow('Local validator is not running.'));
+}

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1,0 +1,127 @@
+import 'zx/globals';
+import { parse as parseToml } from '@iarna/toml';
+
+$.verbose = true;
+process.env.FORCE_COLOR = 3;
+process.env.CARGO_TERM_COLOR = 'always';
+
+export const workingDirectory = (await $`pwd`.quiet()).toString().trim();
+
+export function getAllProgramIdls() {
+    return getAllProgramFolders().map((folder) =>
+        path.join(workingDirectory, folder, 'idl.json')
+    );
+}
+
+export function getExternalProgramOutputDir() {
+    const config = getCargoMetadata()?.solana?.['external-programs-output'];
+    return path.join(workingDirectory, config ?? 'target/deploy');
+}
+
+export function getExternalProgramAddresses() {
+    const addresses = getProgramFolders().flatMap(
+        (folder) => getCargoMetadata(folder)?.solana?.['program-dependencies'] ?? []
+    );
+    return Array.from(new Set(addresses));
+}
+
+export function getExternalAccountAddresses() {
+    const addresses = getProgramFolders().flatMap(
+        (folder) => getCargoMetadata(folder)?.solana?.['account-dependencies'] ?? []
+    );
+    return Array.from(new Set(addresses));
+}
+
+let didWarnAboutMissingPrograms = false;
+export function getProgramFolders() {
+    let programs;
+
+    if (process.env.PROGRAMS) {
+        try {
+            programs = JSON.parse(process.env.PROGRAMS);
+        } catch (error) {
+            programs = process.env.PROGRAMS.split(/\s+/);
+        }
+    } else {
+        programs = getAllProgramFolders();
+    }
+
+    const filteredPrograms = programs.filter((program) =>
+        fs.existsSync(path.join(workingDirectory, program))
+    );
+
+    if (
+        filteredPrograms.length !== programs.length &&
+        !didWarnAboutMissingPrograms
+    ) {
+        didWarnAboutMissingPrograms = true;
+        programs
+            .filter((program) => !filteredPrograms.includes(program))
+            .forEach((program) => {
+                echo(chalk.yellow(`Program not found: ${workingDirectory}/${program}`));
+            });
+    }
+
+    return filteredPrograms;
+}
+
+export function getAllProgramFolders() {
+    return getCargo().workspace.members.filter((member) =>
+        (getCargo(member).lib?.['crate-type'] ?? []).includes('cdylib')
+    );
+}
+
+export function getCargo(folder) {
+    return parseToml(
+        fs.readFileSync(
+            path.join(workingDirectory, folder ? folder : '.', 'Cargo.toml'),
+            'utf8'
+        )
+    );
+}
+
+export function getCargoMetadata(folder) {
+    const cargo = getCargo(folder);
+    return folder ? cargo?.package?.metadata : cargo?.workspace?.metadata;
+}
+
+export function getSolanaVersion() {
+    return getCargoMetadata()?.cli?.solana;
+}
+
+export function getToolchain(operation) {
+    return getCargoMetadata()?.toolchains?.[operation];
+}
+
+export function getToolchainArgument(operation) {
+    const channel = getToolchain(operation);
+    return channel ? `+${channel}` : '';
+}
+
+export function cliArguments() {
+    return process.argv.slice(3);
+}
+
+export function popArgument(args, arg) {
+    const index = args.indexOf(arg);
+    if (index >= 0) {
+        args.splice(index, 1);
+    }
+    return index >= 0;
+}
+
+export function partitionArguments(args, delimiter) {
+    const index = args.indexOf(delimiter);
+    return index >= 0
+        ? [args.slice(0, index), args.slice(index + 1)]
+        : [args, []];
+}
+
+export async function getInstalledSolanaVersion() {
+    try {
+        const { stdout } = await $`solana --version`.quiet();
+        return stdout.match(/(\d+\.\d+\.\d+)/)?.[1];
+    } catch (error) {
+        return '';
+    }
+}


### PR DESCRIPTION
#### Problem
The CI is not set up for the repo.

#### Summary of Changes
Added github workflow and necessary scripts to run lint and tests on the js-legacy client. A successful run can be found [here](https://github.com/samkim-crypto/zk-elgamal-proof/actions/runs/13027651202/job/36339782522). There is no rust program in the repo, so I omitted any logic for testing rust programs. We can add these logic in the future when we convert the native ZK ElGamal proof program into a bpf program.