### PR TITLE
[CI / js-client] Add publish CI and update js-client tsconfig for cjs and esm

### DIFF
--- a/.github/workflows/publish-js-client.yml
+++ b/.github/workflows/publish-js-client.yml
@@ -1,0 +1,139 @@
+name: Publish JS Client
+
+on:
+  workflow_dispatch:
+    inputs:
+      package_path:
+        description: Path to directory with package to release
+        required: true
+        default: "clients/js"
+        type: choice
+        options:
+          - clients/js
+          - clients/js-legacy
+      level:
+        description: Version level
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+          - prerelease
+          - prepatch
+          - preminor
+          - premajor
+      tag:
+        description: NPM Tag (and preid for pre-releases)
+        required: true
+        type: string
+        default: latest
+      create_release:
+        description: Create a GitHub release
+        required: true
+        type: boolean
+        default: true
+
+jobs:
+  test:
+    name: Test JS package
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+        with:
+          solana: true
+          cargo-cache-key: cargo-js-test-publish-${{ inputs.package_path }}
+          cargo-cache-fallback-key: cargo-js-test-publish
+
+      - name: Format
+        run: pnpm zx ./scripts/js/format.mjs "${{ inputs.package_path }}"
+
+      - name: Lint
+        run: pnpm zx ./scripts/js/lint.mjs "${{ inputs.package_path }}"
+
+      - name: Test
+        run: pnpm zx ./scripts/js/test.mjs "${{ inputs.package_path }}"
+
+  publish:
+    name: Publish JS package
+    runs-on: ubuntu-latest
+    needs: test
+    permissions:
+      contents: write
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ANZA_TEAM_PAT }}
+          fetch-depth: 0 # get the whole history for git-cliff
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup
+
+      - name: Ensure SOLANA_NPM_TOKEN variable is set
+        env:
+          token: ${{ secrets.SOLANA_NPM_TOKEN }}
+        if: ${{ env.token == '' }}
+        run: |
+          echo "The SOLANA_NPM_TOKEN secret variable is not set"
+          echo "Go to \"Settings\" -> \"Secrets and variables\" -> \"Actions\" -> \"New repository secret\"."
+          exit 1
+      - name: Ensure SOLANA_PROGRAM_NPM_TOKEN variable is set
+        env:
+          token: ${{ secrets.SOLANA_PROGRAM_NPM_TOKEN }}
+        if: ${{ env.token == '' }}
+        run: |
+          echo "The SOLANA_PROGRAM_NPM_TOKEN secret variable is not set"
+          echo "Go to \"Settings\" -> \"Secrets and variables\" -> \"Actions\" -> \"New repository secret\"."
+          exit 1
+      - name: NPM Authentication
+        env:
+          SOLANA_NPM_TOKEN: ${{ secrets.SOLANA_NPM_TOKEN }}
+          SOLANA_PROGRAM_NPM_TOKEN: ${{ secrets.SOLANA_PROGRAM_NPM_TOKEN }}
+        shell: bash
+        run: |
+          cd "${{ inputs.package_path }}"
+          org="$(jq '.name|split("/")|.[0]' package.json)"
+          if [[ $org == "\"@solana-program\"" ]] then
+            pnpm config set '//registry.npmjs.org/:_authToken' "${SOLANA_PROGRAM_NPM_TOKEN}"
+          elif [[ $org == "\"@solana\"" ]] then
+            pnpm config set '//registry.npmjs.org/:_authToken' "${SOLANA_NPM_TOKEN}"
+          else
+            echo "Unknown organization: $org"
+            exit 1
+          fi
+      - name: Set Git Author
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+      - name: Publish JS Client
+        id: publish
+        run: pnpm js:publish "${{ inputs.package_path }}" ${{ inputs.level }} ${{ inputs.tag }}
+
+      - name: Push Commit and Tag
+        run: git push origin --follow-tags
+
+      - name: Generate a changelog
+        if: github.event.inputs.create_release == 'true'
+        uses: orhun/git-cliff-action@v3
+        with:
+          config: "scripts/cliff.toml"
+          args: |
+            "${{ steps.publish.outputs.old_git_tag }}"..main
+            --include-path "${{ inputs.package_path }}/**"
+            --github-repo "${{ github.repository }}"
+        env:
+          OUTPUT: TEMP_CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Create GitHub release
+        if: github.event.inputs.create_release == 'true'
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.publish.outputs.new_git_tag }}
+          bodyFile: TEMP_CHANGELOG.md

--- a/clients/js-legacy/README.md
+++ b/clients/js-legacy/README.md
@@ -1,0 +1,3 @@
+# @solana/zk-elgamal-proof
+
+A TypeScript library for interacting with the Solana ZK ElGamal proof program.

--- a/clients/js-legacy/package.json
+++ b/clients/js-legacy/package.json
@@ -10,15 +10,32 @@
         "node": ">=16"
     },
     "files": [
-        "src"
+        "lib",
+        "src",
+        "LICENSE",
+        "README.md"
     ],
+    "publishConfig": {
+        "access": "public"
+    },
+    "main": "./lib/cjs/index.js",
+    "module": "./lib/esm/index.js",
+    "types": "./lib/types/index.d.ts",
+    "exports": {
+        "types": "./lib/types/index.d.ts",
+        "require": "./lib/cjs/index.js",
+        "import": "./lib/esm/index.js"
+    },
     "scripts": {
-        "build": "tsc --build --verbose",
+        "prepublishOnly": "pnpm build",
+        "build": "tsc --build --verbose tsconfig.all.json",
+        "postbuild": "shx echo '{ \"type\": \"commonjs\" }' > lib/cjs/package.json",
         "lint": "eslint --max-warnings 0 .",
         "lint:fix": "eslint --fix .",
         "format": "prettier --check src test",
         "format:fix": "prettier --write src test",
-        "test": "mocha test/*"
+        "test": "mocha test/* && pnpm test:exports",
+        "test:exports": "node ./test/exports/module.mjs && node ./test/exports/commonjs.cjs"
     },
     "dependencies": {
         "@solana/web3.js": "^1.95.5",
@@ -39,6 +56,7 @@
         "globals": "^15.14.0",
         "mocha": "^11.0.1",
         "prettier": "^3.4.2",
+        "shx": "^0.3.4",
         "start-server-and-test": "^2.0.8",
         "ts-node": "^10.9.2",
         "typescript": "^5.7.2",

--- a/clients/js-legacy/pnpm-lock.yaml
+++ b/clients/js-legacy/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
+      shx:
+        specifier: ^0.3.4
+        version: 0.3.4
       start-server-and-test:
         specifier: ^2.0.8
         version: 2.0.10
@@ -679,6 +682,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -718,6 +724,10 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
@@ -751,9 +761,17 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  interpret@1.4.0:
+    resolution: {integrity: sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==}
+    engines: {node: '>= 0.10'}
+
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
+
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -974,6 +992,9 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
@@ -1024,6 +1045,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  rechoir@0.6.2:
+    resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
+    engines: {node: '>= 0.10'}
+
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
@@ -1034,6 +1059,11 @@ packages:
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  resolve@1.22.10:
+    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
 
   reusify@1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
@@ -1071,6 +1101,16 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shelljs@0.8.5:
+    resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  shx@0.3.4:
+    resolution: {integrity: sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -1125,6 +1165,10 @@ packages:
   supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   synckit@0.9.2:
     resolution: {integrity: sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==}
@@ -1949,6 +1993,8 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   get-caller-file@2.0.5: {}
 
   get-stream@6.0.1: {}
@@ -1989,6 +2035,10 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
   he@1.2.0: {}
 
   human-signals@2.1.0: {}
@@ -2015,9 +2065,15 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  interpret@1.4.0: {}
+
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
+
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.2
 
   is-extglob@2.1.1: {}
 
@@ -2231,6 +2287,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-parse@1.0.7: {}
+
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
@@ -2270,11 +2328,21 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  rechoir@0.6.2:
+    dependencies:
+      resolve: 1.22.10
+
   regenerator-runtime@0.14.1: {}
 
   require-directory@2.1.1: {}
 
   resolve-from@4.0.0: {}
+
+  resolve@1.22.10:
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.0.4: {}
 
@@ -2316,6 +2384,17 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shelljs@0.8.5:
+    dependencies:
+      glob: 7.2.3
+      interpret: 1.4.0
+      rechoir: 0.6.2
+
+  shx@0.3.4:
+    dependencies:
+      minimist: 1.2.8
+      shelljs: 0.8.5
 
   signal-exit@3.0.7: {}
 
@@ -2375,6 +2454,8 @@ snapshots:
   supports-color@8.1.1:
     dependencies:
       has-flag: 4.0.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
 
   synckit@0.9.2:
     dependencies:

--- a/clients/js-legacy/test/exports/commonjs.cjs
+++ b/clients/js-legacy/test/exports/commonjs.cjs
@@ -1,0 +1,8 @@
+const { Keypair } = require('@solana/web3.js');
+const { createCloseContextStateInstruction } = require('../../lib/cjs/index.js');
+
+const contextStateAddress = Keypair.generate().publicKey;
+const destinationAccount = Keypair.generate().publicKey;
+const contextStateAuthority = Keypair.generate().publicKey;
+
+createCloseContextStateInstruction(contextStateAddress, destinationAccount, contextStateAuthority);

--- a/clients/js-legacy/test/exports/module.mjs
+++ b/clients/js-legacy/test/exports/module.mjs
@@ -1,0 +1,11 @@
+// This ensures that we do not rely on `__dirname` in ES modules even when it is polyfilled.
+globalThis.__dirname = 'DO_NOT_USE';
+
+import { Keypair } from '@solana/web3.js';
+import { createCloseContextStateInstruction } from '../../lib/esm/index.js';
+
+const contextStateAddress = Keypair.generate().publicKey;
+const destinationAccount = Keypair.generate().publicKey;
+const contextStateAuthority = Keypair.generate().publicKey;
+
+createCloseContextStateInstruction(contextStateAddress, destinationAccount, contextStateAuthority);

--- a/clients/js-legacy/tsconfig.all.json
+++ b/clients/js-legacy/tsconfig.all.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.root.json",
+    "references": [
+        {
+            "path": "./tsconfig.cjs.json"
+        },
+        {
+            "path": "./tsconfig.esm.json"
+        }
+    ]
+}

--- a/clients/js-legacy/tsconfig.base.json
+++ b/clients/js-legacy/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+    "include": [],
+    "compilerOptions": {
+        "target": "ESNext",
+        "module": "ESNext",
+        "moduleResolution": "Node",
+        "esModuleInterop": true,
+        "isolatedModules": true,
+        "noEmitOnError": true,
+        "resolveJsonModule": true,
+        "strict": true,
+        "stripInternal": true
+    }
+}

--- a/clients/js-legacy/tsconfig.cjs.json
+++ b/clients/js-legacy/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+    "extends": "./tsconfig.base.json",
+    "include": [
+        "src"
+    ],
+    "compilerOptions": {
+        "outDir": "lib/cjs",
+        "target": "ES2016",
+        "module": "CommonJS",
+        "sourceMap": true
+    }
+}

--- a/clients/js-legacy/tsconfig.esm.json
+++ b/clients/js-legacy/tsconfig.esm.json
@@ -1,0 +1,15 @@
+{
+    "extends": "./tsconfig.base.json",
+    "include": [
+        "src"
+    ],
+    "compilerOptions": {
+        "outDir": "lib/esm",
+        "declarationDir": "lib/types",
+        "target": "ES2020",
+        "module": "ES2020",
+        "sourceMap": true,
+        "declaration": true,
+        "declarationMap": true
+    }
+}

--- a/clients/js-legacy/tsconfig.json
+++ b/clients/js-legacy/tsconfig.json
@@ -1,28 +1,11 @@
 {
-    "compilerOptions": {
-        "composite": false,
-        "declaration": true,
-        "declarationMap": true,
-        "esModuleInterop": true,
-        "forceConsistentCasingInFileNames": true,
-        "inlineSources": false,
-        "isolatedModules": true,
-        "module": "ESNext",
-        "moduleResolution": "node",
-        "noFallthroughCasesInSwitch": true,
-        "noUnusedLocals": true,
-        "noUnusedParameters": true,
-        "outDir": "./dist",
-        "preserveWatchOutput": true,
-        "skipLibCheck": true,
-        "strict": true,
-        "target": "ESNext"
-    },
-    "exclude": [
-        "node_modules"
-    ],
+    "extends": "./tsconfig.all.json",
     "include": [
         "src",
         "test"
-    ]
+    ],
+    "compilerOptions": {
+        "noEmit": true,
+        "skipLibCheck": true
+    }
 }

--- a/clients/js-legacy/tsconfig.root.json
+++ b/clients/js-legacy/tsconfig.root.json
@@ -1,0 +1,6 @@
+{
+    "extends": "./tsconfig.base.json",
+    "compilerOptions": {
+        "composite": true
+    }
+}

--- a/scripts/js/publish.mjs
+++ b/scripts/js/publish.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env zx
+import 'zx/globals';
+import { cliArguments, getPackageJson, workingDirectory } from '../utils.mjs';
+
+const [folder, level, tag = 'latest'] = cliArguments();
+if (!folder) {
+    throw new Error('A path to a directory with a JS package — e.g. "clients/js" — must be provided.');
+}
+if (!level) {
+    throw new Error('A version level — e.g. "patch" — must be provided.');
+}
+
+// Go to the client directory and install the dependencies.
+cd(path.join(workingDirectory, folder));
+await $`pnpm install`;
+
+const tagName = path.basename(folder);
+const packageJson = getPackageJson(folder);
+const oldVersion = packageJson.version;
+const oldGitTag = `${tagName}@v${oldVersion}`;
+
+// Update the version.
+const versionArgs = [
+    '--no-git-tag-version',
+    ...(level.startsWith('pre') ? [`--preid ${tag}`] : []),
+];
+let { stdout } = await $`pnpm version ${level} ${versionArgs}`;
+const newVersion = stdout.slice(1).trim();
+const newGitTag = `${tagName}@v${newVersion}`;
+
+// Expose the new version to CI if needed.
+if (process.env.CI) {
+    await $`echo "new_git_tag=${newGitTag}" >> $GITHUB_OUTPUT`;
+    await $`echo "old_git_tag=${oldGitTag}" >> $GITHUB_OUTPUT`;
+}
+
+// Publish the package.
+// This will also build the package before publishing (see prepublishOnly script).
+await $`pnpm publish --no-git-checks --tag ${tag}`;
+
+// Commit the new version.
+await $`git commit -am "Publish ${tagName} v${newVersion}"`;
+
+// Tag the new version.
+await $`git tag -a ${newGitTag} -m "${tagName} v${newVersion}"`;


### PR DESCRIPTION
#### Problem
There is no publish script for the js-legacy client.

#### Summary of Changes
I added the publish script (analogous to https://github.com/solana-program/record/pull/25) and updated tsconfig for cjs and esm (analogous to https://github.com/solana-program/record/pull/33).