### PR TITLE
[js-legacy-client] Add support for ciphertext validity proofs

### DIFF
--- a/clients/js-legacy/package.json
+++ b/clients/js-legacy/package.json
@@ -40,7 +40,7 @@
     "dependencies": {
         "@solana/codecs-numbers": "^2.0.0",
         "@solana/web3.js": "^1.95.5",
-        "@solana/zk-sdk": "0.1.1"
+        "@solana/zk-sdk": "0.1.2"
     },
     "devDependencies": {
         "@solana/prettier-config-solana": "0.0.5",

--- a/clients/js-legacy/pnpm-lock.yaml
+++ b/clients/js-legacy/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^1.95.5
         version: 1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       '@solana/zk-sdk':
-        specifier: 0.1.1
-        version: 0.1.1
+        specifier: 0.1.2
+        version: 0.1.2
     devDependencies:
       '@eslint/js':
         specifier: ^9.19.0
@@ -218,8 +218,8 @@ packages:
   '@solana/web3.js@1.98.0':
     resolution: {integrity: sha512-nz3Q5OeyGFpFCR+erX2f6JPt3sKhzhYcSycBCSPkWjzSVDh/Rr1FqTVMRe58FKO16/ivTUcuJjeS5MyBvpkbzA==}
 
-  '@solana/zk-sdk@0.1.1':
-    resolution: {integrity: sha512-udavyWNQLdwriv3fZB6xG1GRghq39WTUmUpoaJaxa9uXZdpYGBwWWmfH3DAHq2jkOsFDwSPE+Vuu+YkeYbiYHg==}
+  '@solana/zk-sdk@0.1.2':
+    resolution: {integrity: sha512-uhuj4d8bk55ArICoe23mxDfYKZYJ7OGyg4fwY+k8mWxroaww/1wHG873086Aanb68tW32EMm9FjRRvztDUVDhA==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -1527,7 +1527,7 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  '@solana/zk-sdk@0.1.1': {}
+  '@solana/zk-sdk@0.1.2': {}
 
   '@swc/helpers@0.5.15':
     dependencies:

--- a/clients/js-legacy/src/actions.ts
+++ b/clients/js-legacy/src/actions.ts
@@ -1,23 +1,35 @@
 import type { ConfirmOptions, Connection, Signer, TransactionSignature } from '@solana/web3.js';
 import { PublicKey, sendAndConfirmTransaction, SystemProgram, Transaction } from '@solana/web3.js';
 import type {
+    BatchedGroupedCiphertext2HandlesValidityProofInput,
+    BatchedGroupedCiphertext3HandlesValidityProofInput,
     ContextStateInfo,
     RecordAccountInfo,
     CiphertextCiphertextEqualityProofInput,
     CiphertextCommitmentEqualityProofInput,
+    GroupedCiphertext2HandlesValidityProofInput,
+    GroupedCiphertext3HandlesValidityProofInput,
     PubkeyValidityProofInput,
     ZeroCiphertextProofInput,
 } from './instructions.js';
 import {
     createCloseContextStateInstruction,
+    createVerifyBatchedGroupedCiphertext2HandlesValidityInstruction,
+    createVerifyBatchedGroupedCiphertext3HandlesValidityInstruction,
     createVerifyCiphertextCiphertextEqualityInstruction,
     createVerifyCiphertextCommitmentEqualityInstruction,
+    createVerifyGroupedCiphertext2HandlesValidityInstruction,
+    createVerifyGroupedCiphertext3HandlesValidityInstruction,
     createVerifyPubkeyValidityInstruction,
     createVerifyZeroCiphertextInstruction,
 } from './instructions.js';
 import {
+    BATCHED_GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_CONTEXT_ACCOUNT_SIZE,
+    BATCHED_GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_CONTEXT_ACCOUNT_SIZE,
     CIPHERTEXT_CIPHERTEXT_EQUALITY_CONTEXT_ACCOUNT_SIZE,
     CIPHERTEXT_COMMITMENT_EQUALITY_CONTEXT_ACCOUNT_SIZE,
+    GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_CONTEXT_ACCOUNT_SIZE,
+    GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_CONTEXT_ACCOUNT_SIZE,
     PUBKEY_VALIDITY_CONTEXT_ACCOUNT_SIZE,
     ZERO_CIPHERTEXT_CONTEXT_ACCOUNT_SIZE,
     ZK_ELGAMAL_PROOF_PROGRAM_ID,
@@ -226,5 +238,125 @@ export async function verifyPubkeyValidity(
     }
 
     transaction.add(createVerifyPubkeyValidityInstruction(proofInput, contextStateInfo));
+    return await sendAndConfirmTransaction(connection, transaction, signers, confirmOptions);
+}
+
+export async function verifyGroupedCiphertext2HandlesValidity(
+    connection: Connection,
+    payer: Signer,
+    proofInput: GroupedCiphertext2HandlesValidityProofInput | RecordAccountInfo,
+    contextStateInfo: ContextStateInfo,
+    confirmOptions?: ConfirmOptions,
+    programId = ZK_ELGAMAL_PROOF_PROGRAM_ID,
+): Promise<TransactionSignature> {
+    const transaction = new Transaction();
+    const signers = [payer];
+    if (contextStateInfo && !(contextStateInfo.account instanceof PublicKey)) {
+        const accountSize = GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_CONTEXT_ACCOUNT_SIZE;
+        const lamports = await connection.getMinimumBalanceForRentExemption(accountSize);
+
+        transaction.add(
+            SystemProgram.createAccount({
+                fromPubkey: payer.publicKey,
+                newAccountPubkey: contextStateInfo.account.publicKey,
+                space: accountSize,
+                lamports,
+                programId,
+            }),
+        );
+        signers.push(contextStateInfo.account);
+    }
+
+    transaction.add(createVerifyGroupedCiphertext2HandlesValidityInstruction(proofInput, contextStateInfo));
+    return await sendAndConfirmTransaction(connection, transaction, signers, confirmOptions);
+}
+
+export async function verifyGroupedCiphertext3HandlesValidity(
+    connection: Connection,
+    payer: Signer,
+    proofInput: GroupedCiphertext3HandlesValidityProofInput | RecordAccountInfo,
+    contextStateInfo: ContextStateInfo,
+    confirmOptions?: ConfirmOptions,
+    programId = ZK_ELGAMAL_PROOF_PROGRAM_ID,
+): Promise<TransactionSignature> {
+    const transaction = new Transaction();
+    const signers = [payer];
+    if (contextStateInfo && !(contextStateInfo.account instanceof PublicKey)) {
+        const accountSize = GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_CONTEXT_ACCOUNT_SIZE;
+        const lamports = await connection.getMinimumBalanceForRentExemption(accountSize);
+
+        transaction.add(
+            SystemProgram.createAccount({
+                fromPubkey: payer.publicKey,
+                newAccountPubkey: contextStateInfo.account.publicKey,
+                space: accountSize,
+                lamports,
+                programId,
+            }),
+        );
+        signers.push(contextStateInfo.account);
+    }
+
+    transaction.add(createVerifyGroupedCiphertext3HandlesValidityInstruction(proofInput, contextStateInfo));
+    return await sendAndConfirmTransaction(connection, transaction, signers, confirmOptions);
+}
+
+export async function verifyBatchedGroupedCiphertext2HandlesValidity(
+    connection: Connection,
+    payer: Signer,
+    proofInput: BatchedGroupedCiphertext2HandlesValidityProofInput | RecordAccountInfo,
+    contextStateInfo: ContextStateInfo,
+    confirmOptions?: ConfirmOptions,
+    programId = ZK_ELGAMAL_PROOF_PROGRAM_ID,
+): Promise<TransactionSignature> {
+    const transaction = new Transaction();
+    const signers = [payer];
+    if (contextStateInfo && !(contextStateInfo.account instanceof PublicKey)) {
+        const accountSize = BATCHED_GROUPED_CIPHERTEXT_2_HANDLES_VALIDITY_CONTEXT_ACCOUNT_SIZE;
+        const lamports = await connection.getMinimumBalanceForRentExemption(accountSize);
+
+        transaction.add(
+            SystemProgram.createAccount({
+                fromPubkey: payer.publicKey,
+                newAccountPubkey: contextStateInfo.account.publicKey,
+                space: accountSize,
+                lamports,
+                programId,
+            }),
+        );
+        signers.push(contextStateInfo.account);
+    }
+
+    transaction.add(createVerifyBatchedGroupedCiphertext2HandlesValidityInstruction(proofInput, contextStateInfo));
+    return await sendAndConfirmTransaction(connection, transaction, signers, confirmOptions);
+}
+
+export async function verifyBatchedGroupedCiphertext3HandlesValidity(
+    connection: Connection,
+    payer: Signer,
+    proofInput: BatchedGroupedCiphertext3HandlesValidityProofInput | RecordAccountInfo,
+    contextStateInfo: ContextStateInfo,
+    confirmOptions?: ConfirmOptions,
+    programId = ZK_ELGAMAL_PROOF_PROGRAM_ID,
+): Promise<TransactionSignature> {
+    const transaction = new Transaction();
+    const signers = [payer];
+    if (contextStateInfo && !(contextStateInfo.account instanceof PublicKey)) {
+        const accountSize = BATCHED_GROUPED_CIPHERTEXT_3_HANDLES_VALIDITY_CONTEXT_ACCOUNT_SIZE;
+        const lamports = await connection.getMinimumBalanceForRentExemption(accountSize);
+
+        transaction.add(
+            SystemProgram.createAccount({
+                fromPubkey: payer.publicKey,
+                newAccountPubkey: contextStateInfo.account.publicKey,
+                space: accountSize,
+                lamports,
+                programId,
+            }),
+        );
+        signers.push(contextStateInfo.account);
+    }
+
+    transaction.add(createVerifyBatchedGroupedCiphertext3HandlesValidityInstruction(proofInput, contextStateInfo));
     return await sendAndConfirmTransaction(connection, transaction, signers, confirmOptions);
 }

--- a/clients/js-legacy/src/instructions.ts
+++ b/clients/js-legacy/src/instructions.ts
@@ -5,12 +5,18 @@ import type {
     ElGamalCiphertext,
     ElGamalKeypair,
     ElGamalPubkey,
+    GroupedElGamalCiphertext2Handles,
+    GroupedElGamalCiphertext3Handles,
     PedersenOpening,
     PedersenCommitment,
 } from '@solana/zk-sdk';
 import {
+    BatchedGroupedCiphertext2HandlesValidityProofData,
+    BatchedGroupedCiphertext3HandlesValidityProofData,
     CiphertextCiphertextEqualityProofData,
     CiphertextCommitmentEqualityProofData,
+    GroupedCiphertext2HandlesValidityProofData,
+    GroupedCiphertext3HandlesValidityProofData,
     PubkeyValidityProofData,
     ZeroCiphertextProofData,
 } from '@solana/zk-sdk';
@@ -280,6 +286,198 @@ export function createVerifyPubkeyValidityInstruction(
         data.push(...getU32Codec().encode(proofInput.offset));
     } else {
         const proofData = PubkeyValidityProofData.new(proofInput.elgamalKeypair);
+        data.push(...proofData.toBytes());
+    }
+
+    return new TransactionInstruction({ keys, programId, data: Buffer.from(data) });
+}
+
+export interface GroupedCiphertext2HandlesValidityProofInput {
+    firstPubkey: ElGamalPubkey;
+    secondPubkey: ElGamalPubkey;
+    groupedCiphertext: GroupedElGamalCiphertext2Handles;
+    amount: bigint;
+    opening: PedersenOpening;
+}
+
+export function createVerifyGroupedCiphertext2HandlesValidityInstruction(
+    proofInput: GroupedCiphertext2HandlesValidityProofInput | RecordAccountInfo,
+    contextStateInfo?: ContextStateInfo,
+    programId = ZK_ELGAMAL_PROOF_PROGRAM_ID,
+): TransactionInstruction {
+    const keys: AccountMeta[] = [];
+    if ('account' in proofInput) {
+        keys.push({ pubkey: proofInput.account, isSigner: false, isWritable: false });
+    }
+    if (contextStateInfo) {
+        const contextStateAccount =
+            contextStateInfo.account instanceof PublicKey
+                ? contextStateInfo.account
+                : contextStateInfo.account.publicKey;
+
+        keys.push({ pubkey: contextStateAccount, isSigner: false, isWritable: true });
+        keys.push({ pubkey: contextStateInfo.authority, isSigner: false, isWritable: false });
+    }
+
+    const data = [ZkElGamalProofInstruction.VerifyGroupedCiphertext2HandlesValidity];
+    if ('offset' in proofInput) {
+        data.push(...getU32Codec().encode(proofInput.offset));
+    } else {
+        const proofData = GroupedCiphertext2HandlesValidityProofData.new(
+            proofInput.firstPubkey,
+            proofInput.secondPubkey,
+            proofInput.groupedCiphertext,
+            proofInput.amount,
+            proofInput.opening,
+        );
+        data.push(...proofData.toBytes());
+    }
+
+    return new TransactionInstruction({ keys, programId, data: Buffer.from(data) });
+}
+
+export interface GroupedCiphertext3HandlesValidityProofInput {
+    firstPubkey: ElGamalPubkey;
+    secondPubkey: ElGamalPubkey;
+    thirdPubkey: ElGamalPubkey;
+    groupedCiphertext: GroupedElGamalCiphertext3Handles;
+    amount: bigint;
+    opening: PedersenOpening;
+}
+
+export function createVerifyGroupedCiphertext3HandlesValidityInstruction(
+    proofInput: GroupedCiphertext3HandlesValidityProofInput | RecordAccountInfo,
+    contextStateInfo?: ContextStateInfo,
+    programId = ZK_ELGAMAL_PROOF_PROGRAM_ID,
+): TransactionInstruction {
+    const keys: AccountMeta[] = [];
+    if ('account' in proofInput) {
+        keys.push({ pubkey: proofInput.account, isSigner: false, isWritable: false });
+    }
+    if (contextStateInfo) {
+        const contextStateAccount =
+            contextStateInfo.account instanceof PublicKey
+                ? contextStateInfo.account
+                : contextStateInfo.account.publicKey;
+
+        keys.push({ pubkey: contextStateAccount, isSigner: false, isWritable: true });
+        keys.push({ pubkey: contextStateInfo.authority, isSigner: false, isWritable: false });
+    }
+
+    const data = [ZkElGamalProofInstruction.VerifyGroupedCiphertext3HandlesValidity];
+    if ('offset' in proofInput) {
+        data.push(...getU32Codec().encode(proofInput.offset));
+    } else {
+        const proofData = GroupedCiphertext3HandlesValidityProofData.new(
+            proofInput.firstPubkey,
+            proofInput.secondPubkey,
+            proofInput.thirdPubkey,
+            proofInput.groupedCiphertext,
+            proofInput.amount,
+            proofInput.opening,
+        );
+        data.push(...proofData.toBytes());
+    }
+
+    return new TransactionInstruction({ keys, programId, data: Buffer.from(data) });
+}
+
+export interface BatchedGroupedCiphertext2HandlesValidityProofInput {
+    firstPubkey: ElGamalPubkey;
+    secondPubkey: ElGamalPubkey;
+    groupedCiphertextLo: GroupedElGamalCiphertext2Handles;
+    groupedCiphertextHi: GroupedElGamalCiphertext2Handles;
+    amountLo: bigint;
+    amountHi: bigint;
+    openingLo: PedersenOpening;
+    openingHi: PedersenOpening;
+}
+
+export function createVerifyBatchedGroupedCiphertext2HandlesValidityInstruction(
+    proofInput: BatchedGroupedCiphertext2HandlesValidityProofInput | RecordAccountInfo,
+    contextStateInfo?: ContextStateInfo,
+    programId = ZK_ELGAMAL_PROOF_PROGRAM_ID,
+): TransactionInstruction {
+    const keys: AccountMeta[] = [];
+    if ('account' in proofInput) {
+        keys.push({ pubkey: proofInput.account, isSigner: false, isWritable: false });
+    }
+    if (contextStateInfo) {
+        const contextStateAccount =
+            contextStateInfo.account instanceof PublicKey
+                ? contextStateInfo.account
+                : contextStateInfo.account.publicKey;
+
+        keys.push({ pubkey: contextStateAccount, isSigner: false, isWritable: true });
+        keys.push({ pubkey: contextStateInfo.authority, isSigner: false, isWritable: false });
+    }
+
+    const data = [ZkElGamalProofInstruction.VerifyBatchedGroupedCiphertext2HandlesValidity];
+    if ('offset' in proofInput) {
+        data.push(...getU32Codec().encode(proofInput.offset));
+    } else {
+        const proofData = BatchedGroupedCiphertext2HandlesValidityProofData.new(
+            proofInput.firstPubkey,
+            proofInput.secondPubkey,
+            proofInput.groupedCiphertextLo,
+            proofInput.groupedCiphertextHi,
+            proofInput.amountLo,
+            proofInput.amountHi,
+            proofInput.openingLo,
+            proofInput.openingHi,
+        );
+        data.push(...proofData.toBytes());
+    }
+
+    return new TransactionInstruction({ keys, programId, data: Buffer.from(data) });
+}
+
+export interface BatchedGroupedCiphertext3HandlesValidityProofInput {
+    firstPubkey: ElGamalPubkey;
+    secondPubkey: ElGamalPubkey;
+    thirdPubkey: ElGamalPubkey;
+    groupedCiphertextLo: GroupedElGamalCiphertext2Handles;
+    groupedCiphertextHi: GroupedElGamalCiphertext2Handles;
+    amountLo: bigint;
+    amountHi: bigint;
+    openingLo: PedersenOpening;
+    openingHi: PedersenOpening;
+}
+
+export function createVerifyBatchedGroupedCiphertext3HandlesValidityInstruction(
+    proofInput: BatchedGroupedCiphertext3HandlesValidityProofInput | RecordAccountInfo,
+    contextStateInfo?: ContextStateInfo,
+    programId = ZK_ELGAMAL_PROOF_PROGRAM_ID,
+): TransactionInstruction {
+    const keys: AccountMeta[] = [];
+    if ('account' in proofInput) {
+        keys.push({ pubkey: proofInput.account, isSigner: false, isWritable: false });
+    }
+    if (contextStateInfo) {
+        const contextStateAccount =
+            contextStateInfo.account instanceof PublicKey
+                ? contextStateInfo.account
+                : contextStateInfo.account.publicKey;
+
+        keys.push({ pubkey: contextStateAccount, isSigner: false, isWritable: true });
+        keys.push({ pubkey: contextStateInfo.authority, isSigner: false, isWritable: false });
+    }
+
+    const data = [ZkElGamalProofInstruction.VerifyBatchedGroupedCiphertext3HandlesValidity];
+    if ('offset' in proofInput) {
+        data.push(...getU32Codec().encode(proofInput.offset));
+    } else {
+        const proofData = BatchedGroupedCiphertext3HandlesValidityProofData.new(
+            proofInput.firstPubkey,
+            proofInput.secondPubkey,
+            proofInput.thirdPubkey,
+            proofInput.groupedCiphertextLo,
+            proofInput.groupedCiphertextHi,
+            proofInput.amountLo,
+            proofInput.amountHi,
+            proofInput.openingLo,
+            proofInput.openingHi,
+        );
         data.push(...proofData.toBytes());
     }
 

--- a/clients/js-legacy/test/batchedGroupedCiphertext2HandlesValidity.ts
+++ b/clients/js-legacy/test/batchedGroupedCiphertext2HandlesValidity.ts
@@ -8,8 +8,8 @@ import {
     createVerifyBatchedGroupedCiphertext2HandlesValidityInstruction,
     verifyBatchedGroupedCiphertext2HandlesValidity,
 } from '../src';
+import type { ElGamalPubkey } from '@solana/zk-sdk';
 import {
-    ElGamalPubkey,
     ElGamalKeypair,
     PedersenOpening,
     BatchedGroupedCiphertext2HandlesValidityProofData,

--- a/clients/js-legacy/test/batchedGroupedCiphertext2HandlesValidity.ts
+++ b/clients/js-legacy/test/batchedGroupedCiphertext2HandlesValidity.ts
@@ -1,0 +1,228 @@
+import { expect } from 'chai';
+import type { Connection, Signer } from '@solana/web3.js';
+import { Keypair, sendAndConfirmTransaction, Transaction } from '@solana/web3.js';
+import { newAccountWithLamports, getConnection } from './common';
+import type { ContextStateInfo, RecordAccountInfo } from '../src';
+import {
+    closeContextStateProof,
+    createVerifyBatchedGroupedCiphertext2HandlesValidityInstruction,
+    verifyBatchedGroupedCiphertext2HandlesValidity,
+} from '../src';
+import {
+    ElGamalPubkey,
+    ElGamalKeypair,
+    PedersenOpening,
+    BatchedGroupedCiphertext2HandlesValidityProofData,
+    GroupedElGamalCiphertext2Handles,
+} from '@solana/zk-sdk';
+import { RECORD_META_DATA_SIZE, createInitializeWriteRecord, closeRecord } from '@solana/spl-record';
+
+describe('batchedGroupedCiphertext2HandlesValidity', () => {
+    let connection: Connection;
+    let payer: Signer;
+
+    let testFirstElGamalPubkey: ElGamalPubkey;
+    let testSecondElGamalPubkey: ElGamalPubkey;
+    let testGroupedCiphertextLo: GroupedElGamalCiphertext2Handles;
+    let testGroupedCiphertextHi: GroupedElGamalCiphertext2Handles;
+    let testAmountLo: bigint;
+    let testAmountHi: bigint;
+    let testOpeningLo: PedersenOpening;
+    let testOpeningHi: PedersenOpening;
+
+    before(async () => {
+        connection = await getConnection();
+        payer = await newAccountWithLamports(connection, 1000000000);
+        testAmountLo = BigInt(10);
+        testAmountHi = BigInt(10);
+
+        const testFirstElGamalKeypair = ElGamalKeypair.newRand();
+        testFirstElGamalPubkey = testFirstElGamalKeypair.pubkeyOwned();
+
+        const testSecondElGamalKeypair = ElGamalKeypair.newRand();
+        testSecondElGamalPubkey = testSecondElGamalKeypair.pubkeyOwned();
+
+        testOpeningLo = PedersenOpening.newRand();
+        testOpeningHi = PedersenOpening.newRand();
+
+        testGroupedCiphertextLo = GroupedElGamalCiphertext2Handles.encryptionWithU64(
+            testFirstElGamalPubkey,
+            testSecondElGamalPubkey,
+            testAmountLo,
+            testOpeningLo,
+        );
+
+        testGroupedCiphertextHi = GroupedElGamalCiphertext2Handles.encryptionWithU64(
+            testFirstElGamalPubkey,
+            testSecondElGamalPubkey,
+            testAmountHi,
+            testOpeningHi,
+        );
+    });
+
+    it('verify proof data', async () => {
+        const transaction = new Transaction().add(
+            createVerifyBatchedGroupedCiphertext2HandlesValidityInstruction({
+                firstPubkey: testFirstElGamalPubkey,
+                secondPubkey: testSecondElGamalPubkey,
+                groupedCiphertextLo: testGroupedCiphertextLo,
+                groupedCiphertextHi: testGroupedCiphertextHi,
+                amountLo: testAmountLo,
+                amountHi: testAmountHi,
+                openingLo: testOpeningLo,
+                openingHi: testOpeningHi,
+            }),
+        );
+        await sendAndConfirmTransaction(connection, transaction, [payer]);
+    });
+
+    it('read proof data record', async () => {
+        const recordAccount = Keypair.generate();
+        const recordAccountAddress = recordAccount.publicKey;
+        const recordAuthority = Keypair.generate();
+
+        const proofData = BatchedGroupedCiphertext2HandlesValidityProofData.new(
+            testFirstElGamalPubkey,
+            testSecondElGamalPubkey,
+            testGroupedCiphertextLo,
+            testGroupedCiphertextHi,
+            testAmountLo,
+            testAmountHi,
+            testOpeningLo,
+            testOpeningHi,
+        );
+
+        await createInitializeWriteRecord(
+            connection,
+            payer,
+            recordAccount,
+            recordAuthority,
+            BigInt(0),
+            proofData.toBytes(),
+        );
+
+        const recordAccountInfo: RecordAccountInfo = {
+            account: recordAccountAddress,
+            offset: RECORD_META_DATA_SIZE,
+        };
+
+        const transaction = new Transaction().add(
+            createVerifyBatchedGroupedCiphertext2HandlesValidityInstruction(recordAccountInfo),
+        );
+        await sendAndConfirmTransaction(connection, transaction, [payer]);
+
+        const destinationAccount = Keypair.generate();
+        const destinationAccountAddress = destinationAccount.publicKey;
+
+        await closeRecord(connection, payer, recordAccountAddress, recordAuthority, destinationAccountAddress);
+
+        const closedRecordAccountInfo = await connection.getAccountInfo(recordAccountAddress);
+        expect(closedRecordAccountInfo).to.equal(null);
+    });
+
+    it('verify, create, and close context', async () => {
+        const contextState = Keypair.generate();
+        const contextStateAddress = contextState.publicKey;
+        const contextStateAuthority = Keypair.generate();
+        const contextStateInfo: ContextStateInfo = {
+            account: contextState,
+            authority: contextStateAuthority.publicKey,
+        };
+
+        const destinationAccount = Keypair.generate();
+        const destinationAccountAddress = destinationAccount.publicKey;
+
+        await verifyBatchedGroupedCiphertext2HandlesValidity(
+            connection,
+            payer,
+            {
+                firstPubkey: testFirstElGamalPubkey,
+                secondPubkey: testSecondElGamalPubkey,
+                groupedCiphertextLo: testGroupedCiphertextLo,
+                groupedCiphertextHi: testGroupedCiphertextHi,
+                amountLo: testAmountLo,
+                amountHi: testAmountHi,
+                openingLo: testOpeningLo,
+                openingHi: testOpeningHi,
+            },
+            contextStateInfo,
+        );
+
+        const createdContextStateInfo = await connection.getAccountInfo(contextStateAddress);
+        expect(createdContextStateInfo).to.not.equal(null);
+
+        await closeContextStateProof(
+            connection,
+            payer,
+            contextStateAddress,
+            destinationAccountAddress,
+            contextStateAuthority,
+        );
+
+        const closedContextStateInfo = await connection.getAccountInfo(contextStateAddress);
+        expect(closedContextStateInfo).to.equal(null);
+    });
+
+    it('read proof data record and create context', async () => {
+        const contextState = Keypair.generate();
+        const contextStateAddress = contextState.publicKey;
+        const contextStateAuthority = Keypair.generate();
+        const contextStateInfo: ContextStateInfo = {
+            account: contextState,
+            authority: contextStateAuthority.publicKey,
+        };
+
+        const recordAccount = Keypair.generate();
+        const recordAccountAddress = recordAccount.publicKey;
+        const recordAuthority = Keypair.generate();
+
+        const destinationAccount = Keypair.generate();
+        const destinationAccountAddress = destinationAccount.publicKey;
+
+        const proofData = BatchedGroupedCiphertext2HandlesValidityProofData.new(
+            testFirstElGamalPubkey,
+            testSecondElGamalPubkey,
+            testGroupedCiphertextLo,
+            testGroupedCiphertextHi,
+            testAmountLo,
+            testAmountHi,
+            testOpeningLo,
+            testOpeningHi,
+        );
+
+        await createInitializeWriteRecord(
+            connection,
+            payer,
+            recordAccount,
+            recordAuthority,
+            BigInt(0),
+            proofData.toBytes(),
+        );
+
+        const recordAccountInfo: RecordAccountInfo = {
+            account: recordAccountAddress,
+            offset: RECORD_META_DATA_SIZE,
+        };
+
+        await verifyBatchedGroupedCiphertext2HandlesValidity(connection, payer, recordAccountInfo, contextStateInfo);
+
+        await closeRecord(connection, payer, recordAccountAddress, recordAuthority, destinationAccountAddress);
+
+        const closedRecordAccountInfo = await connection.getAccountInfo(recordAccountAddress);
+        expect(closedRecordAccountInfo).to.equal(null);
+
+        const createdContextStateInfo = await connection.getAccountInfo(contextStateAddress);
+        expect(createdContextStateInfo).to.not.equal(null);
+
+        await closeContextStateProof(
+            connection,
+            payer,
+            contextStateAddress,
+            destinationAccountAddress,
+            contextStateAuthority,
+        );
+
+        const closedContextStateInfo = await connection.getAccountInfo(contextStateAddress);
+        expect(closedContextStateInfo).to.equal(null);
+    });
+});

--- a/clients/js-legacy/test/batchedGroupedCiphertext3HandlesValidity.ts
+++ b/clients/js-legacy/test/batchedGroupedCiphertext3HandlesValidity.ts
@@ -17,7 +17,7 @@ import {
 } from '@solana/zk-sdk';
 import { RECORD_META_DATA_SIZE, createInitializeWriteRecord, closeRecord } from '@solana/spl-record';
 
-describe('batchedGroupedCiphertext2HandlesValidity', () => {
+describe('batchedGroupedCiphertext3HandlesValidity', () => {
     let connection: Connection;
     let payer: Signer;
 

--- a/clients/js-legacy/test/batchedGroupedCiphertext3HandlesValidity.ts
+++ b/clients/js-legacy/test/batchedGroupedCiphertext3HandlesValidity.ts
@@ -8,8 +8,8 @@ import {
     createVerifyBatchedGroupedCiphertext3HandlesValidityInstruction,
     verifyBatchedGroupedCiphertext3HandlesValidity,
 } from '../src';
+import type { ElGamalPubkey } from '@solana/zk-sdk';
 import {
-    ElGamalPubkey,
     ElGamalKeypair,
     PedersenOpening,
     BatchedGroupedCiphertext3HandlesValidityProofData,

--- a/clients/js-legacy/test/batchedGroupedCiphertext3HandlesValidity.ts
+++ b/clients/js-legacy/test/batchedGroupedCiphertext3HandlesValidity.ts
@@ -1,0 +1,238 @@
+import { expect } from 'chai';
+import type { Connection, Signer } from '@solana/web3.js';
+import { Keypair, sendAndConfirmTransaction, Transaction } from '@solana/web3.js';
+import { newAccountWithLamports, getConnection } from './common';
+import type { ContextStateInfo, RecordAccountInfo } from '../src';
+import {
+    closeContextStateProof,
+    createVerifyBatchedGroupedCiphertext3HandlesValidityInstruction,
+    verifyBatchedGroupedCiphertext3HandlesValidity,
+} from '../src';
+import {
+    ElGamalPubkey,
+    ElGamalKeypair,
+    PedersenOpening,
+    BatchedGroupedCiphertext3HandlesValidityProofData,
+    GroupedElGamalCiphertext3Handles,
+} from '@solana/zk-sdk';
+import { RECORD_META_DATA_SIZE, createInitializeWriteRecord, closeRecord } from '@solana/spl-record';
+
+describe('batchedGroupedCiphertext2HandlesValidity', () => {
+    let connection: Connection;
+    let payer: Signer;
+
+    let testFirstElGamalPubkey: ElGamalPubkey;
+    let testSecondElGamalPubkey: ElGamalPubkey;
+    let testThirdElGamalPubkey: ElGamalPubkey;
+    let testGroupedCiphertextLo: GroupedElGamalCiphertext3Handles;
+    let testGroupedCiphertextHi: GroupedElGamalCiphertext3Handles;
+    let testAmountLo: bigint;
+    let testAmountHi: bigint;
+    let testOpeningLo: PedersenOpening;
+    let testOpeningHi: PedersenOpening;
+
+    before(async () => {
+        connection = await getConnection();
+        payer = await newAccountWithLamports(connection, 1000000000);
+        testAmountLo = BigInt(10);
+        testAmountHi = BigInt(10);
+
+        const testFirstElGamalKeypair = ElGamalKeypair.newRand();
+        testFirstElGamalPubkey = testFirstElGamalKeypair.pubkeyOwned();
+
+        const testSecondElGamalKeypair = ElGamalKeypair.newRand();
+        testSecondElGamalPubkey = testSecondElGamalKeypair.pubkeyOwned();
+
+        const testThirdElGamalKeypair = ElGamalKeypair.newRand();
+        testThirdElGamalPubkey = testThirdElGamalKeypair.pubkeyOwned();
+
+        testOpeningLo = PedersenOpening.newRand();
+        testOpeningHi = PedersenOpening.newRand();
+
+        testGroupedCiphertextLo = GroupedElGamalCiphertext3Handles.encryptionWithU64(
+            testFirstElGamalPubkey,
+            testSecondElGamalPubkey,
+            testThirdElGamalPubkey,
+            testAmountLo,
+            testOpeningLo,
+        );
+
+        testGroupedCiphertextHi = GroupedElGamalCiphertext3Handles.encryptionWithU64(
+            testFirstElGamalPubkey,
+            testSecondElGamalPubkey,
+            testThirdElGamalPubkey,
+            testAmountHi,
+            testOpeningHi,
+        );
+    });
+
+    it('verify proof data', async () => {
+        const transaction = new Transaction().add(
+            createVerifyBatchedGroupedCiphertext3HandlesValidityInstruction({
+                firstPubkey: testFirstElGamalPubkey,
+                secondPubkey: testSecondElGamalPubkey,
+                thirdPubkey: testThirdElGamalPubkey,
+                groupedCiphertextLo: testGroupedCiphertextLo,
+                groupedCiphertextHi: testGroupedCiphertextHi,
+                amountLo: testAmountLo,
+                amountHi: testAmountHi,
+                openingLo: testOpeningLo,
+                openingHi: testOpeningHi,
+            }),
+        );
+        await sendAndConfirmTransaction(connection, transaction, [payer]);
+    });
+
+    it('read proof data record', async () => {
+        const recordAccount = Keypair.generate();
+        const recordAccountAddress = recordAccount.publicKey;
+        const recordAuthority = Keypair.generate();
+
+        const proofData = BatchedGroupedCiphertext3HandlesValidityProofData.new(
+            testFirstElGamalPubkey,
+            testSecondElGamalPubkey,
+            testThirdElGamalPubkey,
+            testGroupedCiphertextLo,
+            testGroupedCiphertextHi,
+            testAmountLo,
+            testAmountHi,
+            testOpeningLo,
+            testOpeningHi,
+        );
+
+        await createInitializeWriteRecord(
+            connection,
+            payer,
+            recordAccount,
+            recordAuthority,
+            BigInt(0),
+            proofData.toBytes(),
+        );
+
+        const recordAccountInfo: RecordAccountInfo = {
+            account: recordAccountAddress,
+            offset: RECORD_META_DATA_SIZE,
+        };
+
+        const transaction = new Transaction().add(
+            createVerifyBatchedGroupedCiphertext3HandlesValidityInstruction(recordAccountInfo),
+        );
+        await sendAndConfirmTransaction(connection, transaction, [payer]);
+
+        const destinationAccount = Keypair.generate();
+        const destinationAccountAddress = destinationAccount.publicKey;
+
+        await closeRecord(connection, payer, recordAccountAddress, recordAuthority, destinationAccountAddress);
+
+        const closedRecordAccountInfo = await connection.getAccountInfo(recordAccountAddress);
+        expect(closedRecordAccountInfo).to.equal(null);
+    });
+
+    it('verify, create, and close context', async () => {
+        const contextState = Keypair.generate();
+        const contextStateAddress = contextState.publicKey;
+        const contextStateAuthority = Keypair.generate();
+        const contextStateInfo: ContextStateInfo = {
+            account: contextState,
+            authority: contextStateAuthority.publicKey,
+        };
+
+        const destinationAccount = Keypair.generate();
+        const destinationAccountAddress = destinationAccount.publicKey;
+
+        await verifyBatchedGroupedCiphertext3HandlesValidity(
+            connection,
+            payer,
+            {
+                firstPubkey: testFirstElGamalPubkey,
+                secondPubkey: testSecondElGamalPubkey,
+                thirdPubkey: testThirdElGamalPubkey,
+                groupedCiphertextLo: testGroupedCiphertextLo,
+                groupedCiphertextHi: testGroupedCiphertextHi,
+                amountLo: testAmountLo,
+                amountHi: testAmountHi,
+                openingLo: testOpeningLo,
+                openingHi: testOpeningHi,
+            },
+            contextStateInfo,
+        );
+
+        const createdContextStateInfo = await connection.getAccountInfo(contextStateAddress);
+        expect(createdContextStateInfo).to.not.equal(null);
+
+        await closeContextStateProof(
+            connection,
+            payer,
+            contextStateAddress,
+            destinationAccountAddress,
+            contextStateAuthority,
+        );
+
+        const closedContextStateInfo = await connection.getAccountInfo(contextStateAddress);
+        expect(closedContextStateInfo).to.equal(null);
+    });
+
+    it('read proof data record and create context', async () => {
+        const contextState = Keypair.generate();
+        const contextStateAddress = contextState.publicKey;
+        const contextStateAuthority = Keypair.generate();
+        const contextStateInfo: ContextStateInfo = {
+            account: contextState,
+            authority: contextStateAuthority.publicKey,
+        };
+
+        const recordAccount = Keypair.generate();
+        const recordAccountAddress = recordAccount.publicKey;
+        const recordAuthority = Keypair.generate();
+
+        const destinationAccount = Keypair.generate();
+        const destinationAccountAddress = destinationAccount.publicKey;
+
+        const proofData = BatchedGroupedCiphertext3HandlesValidityProofData.new(
+            testFirstElGamalPubkey,
+            testSecondElGamalPubkey,
+            testThirdElGamalPubkey,
+            testGroupedCiphertextLo,
+            testGroupedCiphertextHi,
+            testAmountLo,
+            testAmountHi,
+            testOpeningLo,
+            testOpeningHi,
+        );
+
+        await createInitializeWriteRecord(
+            connection,
+            payer,
+            recordAccount,
+            recordAuthority,
+            BigInt(0),
+            proofData.toBytes(),
+        );
+
+        const recordAccountInfo: RecordAccountInfo = {
+            account: recordAccountAddress,
+            offset: RECORD_META_DATA_SIZE,
+        };
+
+        await verifyBatchedGroupedCiphertext3HandlesValidity(connection, payer, recordAccountInfo, contextStateInfo);
+
+        await closeRecord(connection, payer, recordAccountAddress, recordAuthority, destinationAccountAddress);
+
+        const closedRecordAccountInfo = await connection.getAccountInfo(recordAccountAddress);
+        expect(closedRecordAccountInfo).to.equal(null);
+
+        const createdContextStateInfo = await connection.getAccountInfo(contextStateAddress);
+        expect(createdContextStateInfo).to.not.equal(null);
+
+        await closeContextStateProof(
+            connection,
+            payer,
+            contextStateAddress,
+            destinationAccountAddress,
+            contextStateAuthority,
+        );
+
+        const closedContextStateInfo = await connection.getAccountInfo(contextStateAddress);
+        expect(closedContextStateInfo).to.equal(null);
+    });
+});

--- a/clients/js-legacy/test/groupedCiphertext2HandlesValidity.ts
+++ b/clients/js-legacy/test/groupedCiphertext2HandlesValidity.ts
@@ -1,0 +1,204 @@
+import { expect } from 'chai';
+import type { Connection, Signer } from '@solana/web3.js';
+import { Keypair, sendAndConfirmTransaction, Transaction } from '@solana/web3.js';
+import { newAccountWithLamports, getConnection } from './common';
+import type { ContextStateInfo, RecordAccountInfo } from '../src';
+import {
+    closeContextStateProof,
+    createVerifyGroupedCiphertext2HandlesValidityInstruction,
+    verifyGroupedCiphertext2HandlesValidity,
+} from '../src';
+import {
+    ElGamalPubkey,
+    ElGamalKeypair,
+    PedersenOpening,
+    GroupedCiphertext2HandlesValidityProofData,
+    GroupedElGamalCiphertext2Handles,
+} from '@solana/zk-sdk';
+import { RECORD_META_DATA_SIZE, createInitializeWriteRecord, closeRecord } from '@solana/spl-record';
+
+describe('groupedCiphertext2HandlesValidity', () => {
+    let connection: Connection;
+    let payer: Signer;
+
+    let testFirstElGamalPubkey: ElGamalPubkey;
+    let testSecondElGamalPubkey: ElGamalPubkey;
+    let testGroupedCiphertext: GroupedElGamalCiphertext2Handles;
+    let testAmount: bigint;
+    let testOpening: PedersenOpening;
+
+    before(async () => {
+        connection = await getConnection();
+        payer = await newAccountWithLamports(connection, 1000000000);
+        testAmount = BigInt(10);
+
+        const testFirstElGamalKeypair = ElGamalKeypair.newRand();
+        testFirstElGamalPubkey = testFirstElGamalKeypair.pubkeyOwned();
+
+        const testSecondElGamalKeypair = ElGamalKeypair.newRand();
+        testSecondElGamalPubkey = testSecondElGamalKeypair.pubkeyOwned();
+
+        testOpening = PedersenOpening.newRand();
+
+        testGroupedCiphertext = GroupedElGamalCiphertext2Handles.encryptionWithU64(
+            testFirstElGamalPubkey,
+            testSecondElGamalPubkey,
+            testAmount,
+            testOpening,
+        );
+    });
+
+    it('verify proof data', async () => {
+        const transaction = new Transaction().add(
+            createVerifyGroupedCiphertext2HandlesValidityInstruction({
+                firstPubkey: testFirstElGamalPubkey,
+                secondPubkey: testSecondElGamalPubkey,
+                groupedCiphertext: testGroupedCiphertext,
+                amount: testAmount,
+                opening: testOpening,
+            }),
+        );
+        await sendAndConfirmTransaction(connection, transaction, [payer]);
+    });
+
+    it('read proof data record', async () => {
+        const recordAccount = Keypair.generate();
+        const recordAccountAddress = recordAccount.publicKey;
+        const recordAuthority = Keypair.generate();
+
+        const proofData = GroupedCiphertext2HandlesValidityProofData.new(
+            testFirstElGamalPubkey,
+            testSecondElGamalPubkey,
+            testGroupedCiphertext,
+            testAmount,
+            testOpening,
+        );
+
+        await createInitializeWriteRecord(
+            connection,
+            payer,
+            recordAccount,
+            recordAuthority,
+            BigInt(0),
+            proofData.toBytes(),
+        );
+
+        const recordAccountInfo: RecordAccountInfo = {
+            account: recordAccountAddress,
+            offset: RECORD_META_DATA_SIZE,
+        };
+
+        const transaction = new Transaction().add(
+            createVerifyGroupedCiphertext2HandlesValidityInstruction(recordAccountInfo),
+        );
+        await sendAndConfirmTransaction(connection, transaction, [payer]);
+
+        const destinationAccount = Keypair.generate();
+        const destinationAccountAddress = destinationAccount.publicKey;
+
+        await closeRecord(connection, payer, recordAccountAddress, recordAuthority, destinationAccountAddress);
+
+        const closedRecordAccountInfo = await connection.getAccountInfo(recordAccountAddress);
+        expect(closedRecordAccountInfo).to.equal(null);
+    });
+
+    it('verify, create, and close context', async () => {
+        const contextState = Keypair.generate();
+        const contextStateAddress = contextState.publicKey;
+        const contextStateAuthority = Keypair.generate();
+        const contextStateInfo: ContextStateInfo = {
+            account: contextState,
+            authority: contextStateAuthority.publicKey,
+        };
+
+        const destinationAccount = Keypair.generate();
+        const destinationAccountAddress = destinationAccount.publicKey;
+
+        await verifyGroupedCiphertext2HandlesValidity(
+            connection,
+            payer,
+            {
+                firstPubkey: testFirstElGamalPubkey,
+                secondPubkey: testSecondElGamalPubkey,
+                groupedCiphertext: testGroupedCiphertext,
+                amount: testAmount,
+                opening: testOpening,
+            },
+            contextStateInfo,
+        );
+
+        const createdContextStateInfo = await connection.getAccountInfo(contextStateAddress);
+        expect(createdContextStateInfo).to.not.equal(null);
+
+        await closeContextStateProof(
+            connection,
+            payer,
+            contextStateAddress,
+            destinationAccountAddress,
+            contextStateAuthority,
+        );
+
+        const closedContextStateInfo = await connection.getAccountInfo(contextStateAddress);
+        expect(closedContextStateInfo).to.equal(null);
+    });
+
+    it('read proof data record and create context', async () => {
+        const contextState = Keypair.generate();
+        const contextStateAddress = contextState.publicKey;
+        const contextStateAuthority = Keypair.generate();
+        const contextStateInfo: ContextStateInfo = {
+            account: contextState,
+            authority: contextStateAuthority.publicKey,
+        };
+
+        const recordAccount = Keypair.generate();
+        const recordAccountAddress = recordAccount.publicKey;
+        const recordAuthority = Keypair.generate();
+
+        const destinationAccount = Keypair.generate();
+        const destinationAccountAddress = destinationAccount.publicKey;
+
+        const proofData = GroupedCiphertext2HandlesValidityProofData.new(
+            testFirstElGamalPubkey,
+            testSecondElGamalPubkey,
+            testGroupedCiphertext,
+            testAmount,
+            testOpening,
+        );
+
+        await createInitializeWriteRecord(
+            connection,
+            payer,
+            recordAccount,
+            recordAuthority,
+            BigInt(0),
+            proofData.toBytes(),
+        );
+
+        const recordAccountInfo: RecordAccountInfo = {
+            account: recordAccountAddress,
+            offset: RECORD_META_DATA_SIZE,
+        };
+
+        await verifyGroupedCiphertext2HandlesValidity(connection, payer, recordAccountInfo, contextStateInfo);
+
+        await closeRecord(connection, payer, recordAccountAddress, recordAuthority, destinationAccountAddress);
+
+        const closedRecordAccountInfo = await connection.getAccountInfo(recordAccountAddress);
+        expect(closedRecordAccountInfo).to.equal(null);
+
+        const createdContextStateInfo = await connection.getAccountInfo(contextStateAddress);
+        expect(createdContextStateInfo).to.not.equal(null);
+
+        await closeContextStateProof(
+            connection,
+            payer,
+            contextStateAddress,
+            destinationAccountAddress,
+            contextStateAuthority,
+        );
+
+        const closedContextStateInfo = await connection.getAccountInfo(contextStateAddress);
+        expect(closedContextStateInfo).to.equal(null);
+    });
+});

--- a/clients/js-legacy/test/groupedCiphertext2HandlesValidity.ts
+++ b/clients/js-legacy/test/groupedCiphertext2HandlesValidity.ts
@@ -8,8 +8,8 @@ import {
     createVerifyGroupedCiphertext2HandlesValidityInstruction,
     verifyGroupedCiphertext2HandlesValidity,
 } from '../src';
+import type { ElGamalPubkey } from '@solana/zk-sdk';
 import {
-    ElGamalPubkey,
     ElGamalKeypair,
     PedersenOpening,
     GroupedCiphertext2HandlesValidityProofData,

--- a/clients/js-legacy/test/groupedCiphertext3HandlesValidity.ts
+++ b/clients/js-legacy/test/groupedCiphertext3HandlesValidity.ts
@@ -1,0 +1,213 @@
+import { expect } from 'chai';
+import type { Connection, Signer } from '@solana/web3.js';
+import { Keypair, sendAndConfirmTransaction, Transaction } from '@solana/web3.js';
+import { newAccountWithLamports, getConnection } from './common';
+import type { ContextStateInfo, RecordAccountInfo } from '../src';
+import {
+    closeContextStateProof,
+    createVerifyGroupedCiphertext3HandlesValidityInstruction,
+    verifyGroupedCiphertext3HandlesValidity,
+} from '../src';
+import {
+    ElGamalPubkey,
+    ElGamalKeypair,
+    PedersenOpening,
+    GroupedCiphertext3HandlesValidityProofData,
+    GroupedElGamalCiphertext3Handles,
+} from '@solana/zk-sdk';
+import { RECORD_META_DATA_SIZE, createInitializeWriteRecord, closeRecord } from '@solana/spl-record';
+
+describe('groupedCiphertext3HandlesValidity', () => {
+    let connection: Connection;
+    let payer: Signer;
+
+    let testFirstElGamalPubkey: ElGamalPubkey;
+    let testSecondElGamalPubkey: ElGamalPubkey;
+    let testThirdElGamalPubkey: ElGamalPubkey;
+    let testGroupedCiphertext: GroupedElGamalCiphertext3Handles;
+    let testAmount: bigint;
+    let testOpening: PedersenOpening;
+
+    before(async () => {
+        connection = await getConnection();
+        payer = await newAccountWithLamports(connection, 1000000000);
+        testAmount = BigInt(10);
+
+        const testFirstElGamalKeypair = ElGamalKeypair.newRand();
+        testFirstElGamalPubkey = testFirstElGamalKeypair.pubkeyOwned();
+
+        const testSecondElGamalKeypair = ElGamalKeypair.newRand();
+        testSecondElGamalPubkey = testSecondElGamalKeypair.pubkeyOwned();
+
+        const testThirdElGamalKeypair = ElGamalKeypair.newRand();
+        testThirdElGamalPubkey = testThirdElGamalKeypair.pubkeyOwned();
+
+        testOpening = PedersenOpening.newRand();
+
+        testGroupedCiphertext = GroupedElGamalCiphertext3Handles.encryptionWithU64(
+            testFirstElGamalPubkey,
+            testSecondElGamalPubkey,
+            testThirdElGamalPubkey,
+            testAmount,
+            testOpening,
+        );
+    });
+
+    it('verify proof data', async () => {
+        const transaction = new Transaction().add(
+            createVerifyGroupedCiphertext3HandlesValidityInstruction({
+                firstPubkey: testFirstElGamalPubkey,
+                secondPubkey: testSecondElGamalPubkey,
+                thirdPubkey: testThirdElGamalPubkey,
+                groupedCiphertext: testGroupedCiphertext,
+                amount: testAmount,
+                opening: testOpening,
+            }),
+        );
+        await sendAndConfirmTransaction(connection, transaction, [payer]);
+    });
+
+    it('read proof data record', async () => {
+        const recordAccount = Keypair.generate();
+        const recordAccountAddress = recordAccount.publicKey;
+        const recordAuthority = Keypair.generate();
+
+        const proofData = GroupedCiphertext3HandlesValidityProofData.new(
+            testFirstElGamalPubkey,
+            testSecondElGamalPubkey,
+            testThirdElGamalPubkey,
+            testGroupedCiphertext,
+            testAmount,
+            testOpening,
+        );
+
+        await createInitializeWriteRecord(
+            connection,
+            payer,
+            recordAccount,
+            recordAuthority,
+            BigInt(0),
+            proofData.toBytes(),
+        );
+
+        const recordAccountInfo: RecordAccountInfo = {
+            account: recordAccountAddress,
+            offset: RECORD_META_DATA_SIZE,
+        };
+
+        const transaction = new Transaction().add(
+            createVerifyGroupedCiphertext3HandlesValidityInstruction(recordAccountInfo),
+        );
+        await sendAndConfirmTransaction(connection, transaction, [payer]);
+
+        const destinationAccount = Keypair.generate();
+        const destinationAccountAddress = destinationAccount.publicKey;
+
+        await closeRecord(connection, payer, recordAccountAddress, recordAuthority, destinationAccountAddress);
+
+        const closedRecordAccountInfo = await connection.getAccountInfo(recordAccountAddress);
+        expect(closedRecordAccountInfo).to.equal(null);
+    });
+
+    it('verify, create, and close context', async () => {
+        const contextState = Keypair.generate();
+        const contextStateAddress = contextState.publicKey;
+        const contextStateAuthority = Keypair.generate();
+        const contextStateInfo: ContextStateInfo = {
+            account: contextState,
+            authority: contextStateAuthority.publicKey,
+        };
+
+        const destinationAccount = Keypair.generate();
+        const destinationAccountAddress = destinationAccount.publicKey;
+
+        await verifyGroupedCiphertext3HandlesValidity(
+            connection,
+            payer,
+            {
+                firstPubkey: testFirstElGamalPubkey,
+                secondPubkey: testSecondElGamalPubkey,
+                thirdPubkey: testThirdElGamalPubkey,
+                groupedCiphertext: testGroupedCiphertext,
+                amount: testAmount,
+                opening: testOpening,
+            },
+            contextStateInfo,
+        );
+
+        const createdContextStateInfo = await connection.getAccountInfo(contextStateAddress);
+        expect(createdContextStateInfo).to.not.equal(null);
+
+        await closeContextStateProof(
+            connection,
+            payer,
+            contextStateAddress,
+            destinationAccountAddress,
+            contextStateAuthority,
+        );
+
+        const closedContextStateInfo = await connection.getAccountInfo(contextStateAddress);
+        expect(closedContextStateInfo).to.equal(null);
+    });
+
+    it('read proof data record and create context', async () => {
+        const contextState = Keypair.generate();
+        const contextStateAddress = contextState.publicKey;
+        const contextStateAuthority = Keypair.generate();
+        const contextStateInfo: ContextStateInfo = {
+            account: contextState,
+            authority: contextStateAuthority.publicKey,
+        };
+
+        const recordAccount = Keypair.generate();
+        const recordAccountAddress = recordAccount.publicKey;
+        const recordAuthority = Keypair.generate();
+
+        const destinationAccount = Keypair.generate();
+        const destinationAccountAddress = destinationAccount.publicKey;
+
+        const proofData = GroupedCiphertext3HandlesValidityProofData.new(
+            testFirstElGamalPubkey,
+            testSecondElGamalPubkey,
+            testThirdElGamalPubkey,
+            testGroupedCiphertext,
+            testAmount,
+            testOpening,
+        );
+
+        await createInitializeWriteRecord(
+            connection,
+            payer,
+            recordAccount,
+            recordAuthority,
+            BigInt(0),
+            proofData.toBytes(),
+        );
+
+        const recordAccountInfo: RecordAccountInfo = {
+            account: recordAccountAddress,
+            offset: RECORD_META_DATA_SIZE,
+        };
+
+        await verifyGroupedCiphertext3HandlesValidity(connection, payer, recordAccountInfo, contextStateInfo);
+
+        await closeRecord(connection, payer, recordAccountAddress, recordAuthority, destinationAccountAddress);
+
+        const closedRecordAccountInfo = await connection.getAccountInfo(recordAccountAddress);
+        expect(closedRecordAccountInfo).to.equal(null);
+
+        const createdContextStateInfo = await connection.getAccountInfo(contextStateAddress);
+        expect(createdContextStateInfo).to.not.equal(null);
+
+        await closeContextStateProof(
+            connection,
+            payer,
+            contextStateAddress,
+            destinationAccountAddress,
+            contextStateAuthority,
+        );
+
+        const closedContextStateInfo = await connection.getAccountInfo(contextStateAddress);
+        expect(closedContextStateInfo).to.equal(null);
+    });
+});

--- a/clients/js-legacy/test/groupedCiphertext3HandlesValidity.ts
+++ b/clients/js-legacy/test/groupedCiphertext3HandlesValidity.ts
@@ -8,8 +8,8 @@ import {
     createVerifyGroupedCiphertext3HandlesValidityInstruction,
     verifyGroupedCiphertext3HandlesValidity,
 } from '../src';
+import type { ElGamalPubkey } from '@solana/zk-sdk';
 import {
-    ElGamalPubkey,
     ElGamalKeypair,
     PedersenOpening,
     GroupedCiphertext3HandlesValidityProofData,


### PR DESCRIPTION
#### Problem
The ciphertext validity proofs are not yet supported in the js-legacy client.

#### Summary of Changes
Adding support for the ciphertext validity proofs. I think things should be straightforward. Once this lands, we just need range proofs to complete full support for all the instructions.

We are still discussing what the best way is to support both node and browser. For now, I will continue developing this for the node build.