### PR TITLE
[zk-sdk] hash `c_max_proof` into the transcript

### DIFF
--- a/zk-sdk/src/sigma_proofs/percentage_with_cap.rs
+++ b/zk-sdk/src/sigma_proofs/percentage_with_cap.rs
@@ -384,6 +384,7 @@ impl PercentageWithCapProof {
         let c_equality = c - c_max_proof;
 
         transcript.append_scalar(b"z_max", &z_max);
+        transcript.append_scalar(b"c_max_proof", &c_max_proof);
         transcript.append_scalar(b"z_x", &z_x);
         transcript.append_scalar(b"z_delta_real", &z_delta_real);
         transcript.append_scalar(b"z_claimed", &z_claimed);


### PR DESCRIPTION
#### Problem
The `c_max_proof` component of the percentage with cap sigma proof is not hashed into the proof transcript.

#### Summary of Changes
Hash `c_max_proof` into the proof transcript. This change was originally done in https://github.com/anza-xyz/agave/pull/6523, but it was reverted in https://github.com/anza-xyz/agave/pull/6544 since it introduced a breaking change. It is safe to add this change now because the proof program is disabled on all clusters.