### PR TITLE
[zk-sdk] Zeroize all sensitive variables in sigma proofs

### DIFF
--- a/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_2.rs
@@ -67,7 +67,7 @@ impl BatchedGroupedCiphertext2HandlesValidityProof {
         let t = transcript.challenge_scalar(b"t");
 
         let mut batched_message = amount_lo.into() + amount_hi.into() * t;
-        let mut batched_opening = opening_lo + &(opening_hi * &t);
+        let batched_opening = opening_lo + &(opening_hi * &t);
 
         let proof = BatchedGroupedCiphertext2HandlesValidityProof(
             GroupedCiphertext2HandlesValidityProof::new(
@@ -81,7 +81,6 @@ impl BatchedGroupedCiphertext2HandlesValidityProof {
 
         // zeroize all sensitive owned variables
         batched_message.zeroize();
-        batched_opening.zeroize();
 
         proof
     }

--- a/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_2.rs
@@ -8,13 +8,16 @@
 //! The protocol guarantees computational soundness (by the hardness of discrete log) and perfect
 //! zero-knowledge in the random oracle model.
 
-#[cfg(not(target_os = "solana"))]
-use crate::encryption::{
-    elgamal::{DecryptHandle, ElGamalPubkey},
-    pedersen::{PedersenCommitment, PedersenOpening},
-};
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
+#[cfg(not(target_os = "solana"))]
+use {
+    crate::encryption::{
+        elgamal::{DecryptHandle, ElGamalPubkey},
+        pedersen::{PedersenCommitment, PedersenOpening},
+    },
+    zeroize::Zeroize,
+};
 use {
     crate::{
         sigma_proofs::{
@@ -63,16 +66,24 @@ impl BatchedGroupedCiphertext2HandlesValidityProof {
 
         let t = transcript.challenge_scalar(b"t");
 
-        let batched_message = amount_lo.into() + amount_hi.into() * t;
-        let batched_opening = opening_lo + &(opening_hi * &t);
+        let mut batched_message = amount_lo.into() + amount_hi.into() * t;
+        let mut batched_opening = opening_lo + &(opening_hi * &t);
 
-        BatchedGroupedCiphertext2HandlesValidityProof(GroupedCiphertext2HandlesValidityProof::new(
-            first_pubkey,
-            second_pubkey,
-            batched_message,
-            &batched_opening,
-            transcript,
-        ))
+        let proof = BatchedGroupedCiphertext2HandlesValidityProof(
+            GroupedCiphertext2HandlesValidityProof::new(
+                first_pubkey,
+                second_pubkey,
+                batched_message,
+                &batched_opening,
+                transcript,
+            ),
+        );
+
+        // zeroize all sensitive owned variables
+        batched_message.zeroize();
+        batched_opening.zeroize();
+
+        proof
     }
 
     /// Verifies a batched grouped ciphertext validity proof.

--- a/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_3.rs
@@ -12,13 +12,16 @@
 //! The protocol guarantees computational soundness (by the hardness of discrete log) and perfect
 //! zero-knowledge in the random oracle model.
 
-#[cfg(not(target_os = "solana"))]
-use crate::encryption::{
-    elgamal::{DecryptHandle, ElGamalPubkey},
-    pedersen::{PedersenCommitment, PedersenOpening},
-};
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
+#[cfg(not(target_os = "solana"))]
+use {
+    crate::encryption::{
+        elgamal::{DecryptHandle, ElGamalPubkey},
+        pedersen::{PedersenCommitment, PedersenOpening},
+    },
+    zeroize::Zeroize,
+};
 use {
     crate::{
         sigma_proofs::{
@@ -65,17 +68,25 @@ impl BatchedGroupedCiphertext3HandlesValidityProof {
 
         let t = transcript.challenge_scalar(b"t");
 
-        let batched_message = amount_lo.into() + amount_hi.into() * t;
-        let batched_opening = opening_lo + &(opening_hi * &t);
+        let mut batched_message = amount_lo.into() + amount_hi.into() * t;
+        let mut batched_opening = opening_lo + &(opening_hi * &t);
 
-        BatchedGroupedCiphertext3HandlesValidityProof(GroupedCiphertext3HandlesValidityProof::new(
-            first_pubkey,
-            second_pubkey,
-            third_pubkey,
-            batched_message,
-            &batched_opening,
-            transcript,
-        ))
+        let proof = BatchedGroupedCiphertext3HandlesValidityProof(
+            GroupedCiphertext3HandlesValidityProof::new(
+                first_pubkey,
+                second_pubkey,
+                third_pubkey,
+                batched_message,
+                &batched_opening,
+                transcript,
+            ),
+        );
+
+        // zeroize all sensitive owned variables
+        batched_message.zeroize();
+        batched_opening.zeroize();
+
+        proof
     }
 
     /// Verifies a batched grouped ciphertext validity proof.

--- a/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_3.rs
@@ -69,7 +69,7 @@ impl BatchedGroupedCiphertext3HandlesValidityProof {
         let t = transcript.challenge_scalar(b"t");
 
         let mut batched_message = amount_lo.into() + amount_hi.into() * t;
-        let mut batched_opening = opening_lo + &(opening_hi * &t);
+        let batched_opening = opening_lo + &(opening_hi * &t);
 
         let proof = BatchedGroupedCiphertext3HandlesValidityProof(
             GroupedCiphertext3HandlesValidityProof::new(
@@ -84,7 +84,6 @@ impl BatchedGroupedCiphertext3HandlesValidityProof {
 
         // zeroize all sensitive owned variables
         batched_message.zeroize();
-        batched_opening.zeroize();
 
         proof
     }

--- a/zk-sdk/src/sigma_proofs/ciphertext_ciphertext_equality.rs
+++ b/zk-sdk/src/sigma_proofs/ciphertext_ciphertext_equality.rs
@@ -85,7 +85,7 @@ impl CiphertextCiphertextEqualityProof {
         let P_second = second_pubkey.get_point();
 
         let s = first_keypair.secret().get_scalar();
-        let x = Scalar::from(amount);
+        let mut x = Scalar::from(amount);
         let r = second_opening.get_scalar();
 
         // generate random masking factors that also serves as nonces
@@ -112,7 +112,8 @@ impl CiphertextCiphertextEqualityProof {
         let z_x = &(&c * &x) + &y_x;
         let z_r = &(&c * r) + &y_r;
 
-        // zeroize random scalars
+        // zeroize all sensitive non-reference variables
+        x.zeroize();
         y_s.zeroize();
         y_x.zeroize();
         y_r.zeroize();

--- a/zk-sdk/src/sigma_proofs/ciphertext_commitment_equality.rs
+++ b/zk-sdk/src/sigma_proofs/ciphertext_commitment_equality.rs
@@ -88,7 +88,7 @@ impl CiphertextCommitmentEqualityProof {
         let D = ciphertext.handle.get_point();
 
         let s = keypair.secret().get_scalar();
-        let x = Scalar::from(amount);
+        let mut x = Scalar::from(amount);
         let r = opening.get_scalar();
 
         // generate random masking factors that also serves as nonces
@@ -114,6 +114,7 @@ impl CiphertextCommitmentEqualityProof {
         let z_r = &(&c * r) + &y_r;
 
         // zeroize random scalars
+        x.zeroize();
         y_s.zeroize();
         y_x.zeroize();
         y_r.zeroize();

--- a/zk-sdk/src/sigma_proofs/grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk/src/sigma_proofs/grouped_ciphertext_validity/handles_2.rs
@@ -86,7 +86,7 @@ impl GroupedCiphertext2HandlesValidityProof {
         let P_first = first_pubkey.get_point();
         let P_second = second_pubkey.get_point();
 
-        let x = amount.into();
+        let mut x = amount.into();
         let r = opening.get_scalar();
 
         // generate random masking factors that also serves as nonces
@@ -109,6 +109,8 @@ impl GroupedCiphertext2HandlesValidityProof {
         let z_r = &(&c * r) + &y_r;
         let z_x = &(&c * &x) + &y_x;
 
+        // zeroize all sensitive owned variables
+        x.zeroize();
         y_r.zeroize();
         y_x.zeroize();
 

--- a/zk-sdk/src/sigma_proofs/grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk/src/sigma_proofs/grouped_ciphertext_validity/handles_3.rs
@@ -90,7 +90,7 @@ impl GroupedCiphertext3HandlesValidityProof {
         let P_second = second_pubkey.get_point();
         let P_third = third_pubkey.get_point();
 
-        let x = amount.into();
+        let mut x = amount.into();
         let r = opening.get_scalar();
 
         // generate random masking factors that also serves as nonces
@@ -115,6 +115,8 @@ impl GroupedCiphertext3HandlesValidityProof {
         let z_r = &(&c * r) + &y_r;
         let z_x = &(&c * &x) + &y_x;
 
+        // zeroize all sensitive owned variables
+        x.zeroize();
         y_r.zeroize();
         y_x.zeroize();
 

--- a/zk-sdk/src/sigma_proofs/pubkey_validity.rs
+++ b/zk-sdk/src/sigma_proofs/pubkey_validity.rs
@@ -69,7 +69,7 @@ impl PubkeyValidityProof {
         let s = elgamal_keypair.secret().get_scalar();
 
         assert!(s != &Scalar::ZERO);
-        let s_inv = s.invert();
+        let mut s_inv = s.invert();
 
         // generate a random masking factor that also serves as a nonce
         let mut y = Scalar::random(&mut OsRng);
@@ -82,6 +82,8 @@ impl PubkeyValidityProof {
         // compute masked secret key
         let z = &(&c * s_inv) + &y;
 
+        // zeroize all sensitive non-reference variables
+        s_inv.zeroize();
         y.zeroize();
 
         Self { Y, z }


### PR DESCRIPTION
#### Problem
There is some inconsistency in the way some variables are zeroized in sigma proofs. In some proofs, the sensitive variables are manually zeroized while in others, they are not. This is most likely not an issue in most production environments, but does leave a possibility for sensitive information to be exposed through memory dumps or debugging tools.

#### Summary of Changes
Consistently zeroize all sensitive variables in the sigma proof module.

Basically, I should zeroize all owned `Scalar` variables in the proof generation logic for the sigma proofs. These variables are generally denoted with lower-case letters. The exceptions to this are the challenge variables.
- Generally, variables that are the result of `transferscript.challenge_scalar(...)` are public values and do not need to be zeroed out
- But in the percentage with cap proof, I did zeroize out `c_equality` variables, which is technically a challenge, but I zeroized it out for safety just in case there are some subtleties.

Note: Currently the variables are not manually zeroized in the range proof implementation. This is because the range proof implementation is based on the dalek range proof implementation https://github.com/dalek-cryptography/bulletproofs, which does not zeroize variables. For safety, I will zeroize the range proof variables in the zk-sdk, but I will do it in a follow-up.