### PR TITLE
[ci] Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "08:00"
+      timezone: UTC
+    open-pull-requests-limit: 6
+  - package-ecosystem: npm
+    directories:
+      - "/"
+      - "/clients/js-legacy"
+    schedule:
+      interval: daily
+      time: "09:00"
+      timezone: UTC
+    open-pull-requests-limit: 6


### PR DESCRIPTION
#### Problem
Dependabot is not yet set for the repository.

#### Summary of Changes
I read the dependabot docs and ended up just copying the dependabot config from the token22 repo.