### PR TITLE
Add .gitignore

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -53,10 +53,7 @@ jobs:
           clippy: true
           rustfmt: true
           solana: true
-          cli: true
-          purge: true
-          cargo-cache-key: cargo-test-publish-${{ inputs.package_path }}
-          cargo-cache-fallback-key: cargo-test-publish
+          wasm: true
 
       - name: Format
         run: pnpm zx ./scripts/rust/format.mjs "${{ inputs.package_path }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.anchor
+.cargo
+.DS_Store
+**/.DS_Store
+**/target
+**/*.rs.bk
+node_modules
+test-ledger
+dist
+.idea


### PR DESCRIPTION
#### Problem
The repo doesn't have a `.gitignore` file, so the publish script in the CI is resulting in an error.

#### Summary of Changes
Add `.gitignore` that is a copy of https://github.com/solana-program/token-2022/blob/main/.gitignore.

Also, the initial publish script did not have the wasm installation setting set, so I added that in. Otherwise, the script fails (https://github.com/solana-program/zk-elgamal-proof/actions/runs/16460363413/job/46526277147)