### PR TITLE
[ci] Upgrade git-cliff-action to v4

### DIFF
--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -166,7 +166,7 @@ jobs:
 
       - name: Generate a changelog
         if: github.event.inputs.create_release == 'true'
-        uses: orhun/git-cliff-action@v3
+        uses: orhun/git-cliff-action@v4
         with:
           config: "scripts/cliff.toml"
           args: |


### PR DESCRIPTION
The CI script seems to fail downloading git-cliff-action v3 so upgrade to v4.