### PR TITLE
[zk-sdk] Clean up dependencies, transcript and auth encryption

### DIFF
--- a/zk-sdk/Cargo.toml
+++ b/zk-sdk/Cargo.toml
@@ -24,9 +24,6 @@ solana-pubkey = { workspace = true, features = ["bytemuck"] }
 solana-sdk-ids = { workspace = true }
 thiserror = { workspace = true }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-solana-pubkey = { workspace = true, features = ["bytemuck"] }
-
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 aes-gcm-siv = { workspace = true }
 bincode = { workspace = true }

--- a/zk-sdk/Cargo.toml
+++ b/zk-sdk/Cargo.toml
@@ -16,7 +16,6 @@ crate-type = ["cdylib", "rlib"]
 base64 = { workspace = true }
 bytemuck = { workspace = true }
 bytemuck_derive = { workspace = true }
-merlin = { workspace = true }
 num-derive = { workspace = true }
 num-traits = { workspace = true }
 solana-instruction = { workspace = true, features = ["std"] }
@@ -29,6 +28,7 @@ aes-gcm-siv = { workspace = true }
 bincode = { workspace = true }
 curve25519-dalek = { workspace = true, features = ["serde"] }
 itertools = { workspace = true }
+merlin = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }

--- a/zk-sdk/src/encryption/auth_encryption.rs
+++ b/zk-sdk/src/encryption/auth_encryption.rs
@@ -1,7 +1,8 @@
 //! Authenticated encryption implementation.
 //!
-//! This module is a simple wrapper of the `Aes128GcmSiv` implementation specialized for SPL
-//! token-2022 where the plaintext is always `u64`.
+//! This module is a simple wrapper of the `Aes128GcmSiv` implementation
+//! specialized for SPL Token2022 program where the plaintext is always a `u64`
+//! number.
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 use {
@@ -94,7 +95,7 @@ pub struct AeKey([u8; AE_KEY_LEN]);
 impl AeKey {
     /// Generates a random authenticated encryption key.
     ///
-    /// This function is randomized. It internally samples a scalar element using `OsRng`.
+    /// This function is randomized. It internally samples a 128-bit key using `OsRng`.
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen(js_name = newRand))]
     pub fn new_rand() -> Self {
         AuthenticatedEncryption::keygen()
@@ -347,7 +348,51 @@ mod tests {
 
     #[test]
     fn test_aes_key_try_from_error() {
-        let too_many_bytes = vec![0_u8; 32];
+        let too_short_bytes = vec![0_u8; AE_KEY_LEN - 1];
+        assert!(AeKey::try_from(too_short_bytes.as_slice()).is_err());
+
+        let too_many_bytes = vec![0_u8; AE_KEY_LEN + 1];
         assert!(AeKey::try_from(too_many_bytes.as_slice()).is_err());
+    }
+
+    #[test]
+    fn test_tampered_ciphertext_fails_decryption() {
+        let key = AeKey::new_rand();
+        let amount = 99_u64;
+
+        let ciphertext = key.encrypt(amount);
+        let mut tampered_bytes = ciphertext.to_bytes();
+
+        // Flip the first bit of the actual ciphertext component
+        tampered_bytes[NONCE_LEN] ^= 1;
+
+        let tampered_ciphertext = AeCiphertext::from_bytes(&tampered_bytes).unwrap();
+        assert!(tampered_ciphertext.decrypt(&key).is_none());
+    }
+
+    #[test]
+    fn test_tampered_nonce_fails_decryption() {
+        let key = AeKey::new_rand();
+        let amount = 99_u64;
+
+        let ciphertext = key.encrypt(amount);
+        let mut tampered_bytes = ciphertext.to_bytes();
+
+        // Flip the first bit of the nonce
+        tampered_bytes[0] ^= 1;
+
+        let tampered_ciphertext = AeCiphertext::from_bytes(&tampered_bytes).unwrap();
+        assert!(tampered_ciphertext.decrypt(&key).is_none());
+    }
+
+    #[test]
+    fn test_encryption_is_non_deterministic() {
+        let key = AeKey::new_rand();
+        let amount = 123_u64;
+
+        let ciphertext1 = key.encrypt(amount);
+        let ciphertext2 = key.encrypt(amount);
+
+        assert_ne!(ciphertext1.to_bytes(), ciphertext2.to_bytes());
     }
 }

--- a/zk-sdk/src/encryption/auth_encryption.rs
+++ b/zk-sdk/src/encryption/auth_encryption.rs
@@ -134,6 +134,8 @@ impl AeKey {
         signer: &dyn Signer,
         public_seed: &[u8],
     ) -> Result<Vec<u8>, SignerError> {
+        // TODO: This function uses a non-standard KDF and should be refactored.
+        // See: https://github.com/solana-program/zk-elgamal-proof/issues/35
         let message = [b"AeKey", public_seed].concat();
         let signature = signer.try_sign_message(&message)?;
 

--- a/zk-sdk/src/transcript.rs
+++ b/zk-sdk/src/transcript.rs
@@ -6,16 +6,13 @@ use {
 
 pub trait TranscriptProtocol {
     /// Append a `scalar` with the given `label`.
-    #[cfg(not(target_os = "solana"))]
     fn append_scalar(&mut self, label: &'static [u8], scalar: &Scalar);
 
     /// Append a `point` with the given `label`.
-    #[cfg(not(target_os = "solana"))]
     fn append_point(&mut self, label: &'static [u8], point: &CompressedRistretto);
 
     /// Check that a point is not the identity, then append it to the
     /// transcript.  Otherwise, return an error.
-    #[cfg(not(target_os = "solana"))]
     fn validate_and_append_point(
         &mut self,
         label: &'static [u8],
@@ -50,22 +47,18 @@ pub trait TranscriptProtocol {
     fn pubkey_proof_domain_separator(&mut self);
 
     /// Compute a `label`ed challenge variable.
-    #[cfg(not(target_os = "solana"))]
     fn challenge_scalar(&mut self, label: &'static [u8]) -> Scalar;
 }
 
 impl TranscriptProtocol for Transcript {
-    #[cfg(not(target_os = "solana"))]
     fn append_scalar(&mut self, label: &'static [u8], scalar: &Scalar) {
         self.append_message(label, scalar.as_bytes());
     }
 
-    #[cfg(not(target_os = "solana"))]
     fn append_point(&mut self, label: &'static [u8], point: &CompressedRistretto) {
         self.append_message(label, point.as_bytes());
     }
 
-    #[cfg(not(target_os = "solana"))]
     fn validate_and_append_point(
         &mut self,
         label: &'static [u8],
@@ -119,7 +112,6 @@ impl TranscriptProtocol for Transcript {
         self.append_message(b"dom-sep", b"pubkey-proof")
     }
 
-    #[cfg(not(target_os = "solana"))]
     fn challenge_scalar(&mut self, label: &'static [u8]) -> Scalar {
         let mut buf = [0u8; 64];
         self.challenge_bytes(label, &mut buf);


### PR DESCRIPTION
#### Summary of Changes
Cleaning some parts of the zk-sdk crate as I was doing a pass over the entire repo:
- seems like `solana-pubkey` was set as a dependency twice so I removed it ([9d4344c](https://github.com/solana-program/zk-elgamal-proof/pull/36/commits/9d4344cd4ee025db8bb9791b5d164b0ec26f3818))
- the `merlin` dependency is not used in the solana target, so I removed it ([7bd1b22](https://github.com/solana-program/zk-elgamal-proof/pull/36/commits/7bd1b22d1c5b7118ecbc453ce0f471f657936b17))
- fixed some typo in the `auth_encryption` submodule and added some additional sanity tests ([a475495](https://github.com/solana-program/zk-elgamal-proof/pull/36/commits/a4754952a0ddb12892b48cc62c8a16d0ab9440e8))
- right now, the key derivation function that derives keys from Solana signer uses sha3 to hash a Solana signature to derive the key. I think this can be improved to use a standard KDF function instead of sha3. I created https://github.com/solana-program/zk-elgamal-proof/issues/35 and added a note in the doc ([ecf2ab7](https://github.com/solana-program/zk-elgamal-proof/pull/36/commits/ecf2ab72e6cc2936673c82155e325a0abcbec5ce))