### PR TITLE
[zk-sdk] Add additional tests, improve docs, and fix transcript update in the proof generation logic

### DIFF
--- a/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_2.rs
@@ -61,6 +61,10 @@ impl BatchedGroupedCiphertext2HandlesValidityProof {
     /// The function simply batches the input openings and invokes the standard grouped ciphertext
     /// validity proof constructor.
     ///
+    /// The function does *not* hash the public keys, commitment, or decryption handles into the
+    /// transcript. For security, the caller (the main protocol) should hash these public
+    /// components prior to invoking this constructor.
+    ///
     /// This function is randomized. It uses `OsRng` internally to generate random scalars.
     pub fn new<T: Into<Scalar>>(
         first_pubkey: &ElGamalPubkey,

--- a/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_2.rs
@@ -5,6 +5,15 @@
 //! ElGamal private keys that are associated with each of the two decryption handles. To generate
 //! the proof, a prover must provide the Pedersen opening associated with the commitment.
 //!
+//! This protocol reduces two `GroupedCiphertext2HandlesValidityProof` instances into a single
+//! proof. The batching is achieved by compressing the two separate statements into one using a
+//! random linear combination.
+//!
+//! The verifier provides a random challenge scalar `t` sampled from the transcript. The prover and
+//! verifier then use this scalar to compute a linear combination of their respective inputs. A
+//! single `GroupedCiphertext3HandlesValidityProof` is then generated and verified for this new
+//! batched statement and witness.
+//!
 //! The protocol guarantees computational soundness (by the hardness of discrete log) and perfect
 //! zero-knowledge in the random oracle model.
 

--- a/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_2.rs
@@ -205,6 +205,11 @@ mod test {
                 &mut verifier_transcript,
             )
             .unwrap();
+
+        assert_eq!(
+            prover_transcript.challenge_scalar(b"test"),
+            verifier_transcript.challenge_scalar(b"test"),
+        )
     }
 
     #[test]

--- a/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_2.rs
@@ -11,7 +11,7 @@
 //!
 //! The verifier provides a random challenge scalar `t` sampled from the transcript. The prover and
 //! verifier then use this scalar to compute a linear combination of their respective inputs. A
-//! single `GroupedCiphertext3HandlesValidityProof` is then generated and verified for this new
+//! single `GroupedCiphertext2HandlesValidityProof` is then generated and verified for this new
 //! batched statement and witness.
 //!
 //! The protocol guarantees computational soundness (by the hardness of discrete log) and perfect

--- a/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_3.rs
@@ -9,6 +9,15 @@
 //! second_handle_1, third_handle_1)`. The proof certifies the anagolous decryptable
 //! properties for each one of these pairs of commitment and decryption handles.
 //!
+//! This protocol reduces two `GroupedCiphertext3HandlesValidityProof` instances into a single
+//! proof. The batching is achieved by compressing the two separate statements into one using a
+//! random linear combination.
+//!
+//! The verifier provides a random challenge scalar `t` sampled from the transcript. The prover and
+//! verifier then use this scalar to compute a linear combination of their respective inputs. A
+//! single `GroupedCiphertext3HandlesValidityProof` is then generated and verified for this new
+//! batched statement and witness.
+//!
 //! The protocol guarantees computational soundness (by the hardness of discrete log) and perfect
 //! zero-knowledge in the random oracle model.
 

--- a/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_3.rs
@@ -60,6 +60,10 @@ pub struct BatchedGroupedCiphertext3HandlesValidityProof(GroupedCiphertext3Handl
 impl BatchedGroupedCiphertext3HandlesValidityProof {
     /// Creates a batched grouped ciphertext validity proof.
     ///
+    /// The function does *not* hash the public keys, commitment, or decryption handles into the
+    /// transcript. For security, the caller (the main protocol) should hash these public
+    /// components prior to invoking this constructor.
+    ///
     /// The function simply batches the input openings and invokes the standard grouped ciphertext
     /// validity proof constructor.
     #[allow(clippy::too_many_arguments)]

--- a/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk/src/sigma_proofs/batched_grouped_ciphertext_validity/handles_3.rs
@@ -226,6 +226,11 @@ mod test {
                 &mut verifier_transcript,
             )
             .unwrap();
+
+        assert_eq!(
+            prover_transcript.challenge_scalar(b"test"),
+            verifier_transcript.challenge_scalar(b"test"),
+        )
     }
 
     #[test]

--- a/zk-sdk/src/sigma_proofs/ciphertext_ciphertext_equality.rs
+++ b/zk-sdk/src/sigma_proofs/ciphertext_ciphertext_equality.rs
@@ -105,12 +105,17 @@ impl CiphertextCiphertextEqualityProof {
         transcript.append_point(b"Y_3", &Y_3);
 
         let c = transcript.challenge_scalar(b"c");
-        transcript.challenge_scalar(b"w");
 
         // compute the masked values
         let z_s = &(&c * s) + &y_s;
         let z_x = &(&c * &x) + &y_x;
         let z_r = &(&c * r) + &y_r;
+
+        // compute challenge `w` for consistency with verification
+        transcript.append_scalar(b"z_s", &z_s);
+        transcript.append_scalar(b"z_x", &z_x);
+        transcript.append_scalar(b"z_r", &z_r);
+        let _w = transcript.challenge_scalar(b"w");
 
         // zeroize all sensitive non-reference variables
         x.zeroize();
@@ -351,6 +356,11 @@ mod test {
                 &mut verifier_transcript
             )
             .is_err());
+
+        assert_eq!(
+            prover_transcript.challenge_scalar(b"test"),
+            verifier_transcript.challenge_scalar(b"test"),
+        )
     }
 
     #[test]

--- a/zk-sdk/src/sigma_proofs/ciphertext_commitment_equality.rs
+++ b/zk-sdk/src/sigma_proofs/ciphertext_commitment_equality.rs
@@ -106,12 +106,17 @@ impl CiphertextCommitmentEqualityProof {
         transcript.append_point(b"Y_2", &Y_2);
 
         let c = transcript.challenge_scalar(b"c");
-        transcript.challenge_scalar(b"w");
 
         // compute the masked values
         let z_s = &(&c * s) + &y_s;
         let z_x = &(&c * &x) + &y_x;
         let z_r = &(&c * r) + &y_r;
+
+        // compute challenge `w` for consistency with verification
+        transcript.append_scalar(b"z_s", &z_s);
+        transcript.append_scalar(b"z_x", &z_x);
+        transcript.append_scalar(b"z_r", &z_r);
+        let _w = transcript.challenge_scalar(b"w");
 
         // zeroize random scalars
         x.zeroize();
@@ -322,6 +327,11 @@ mod test {
                 &mut verifier_transcript
             )
             .is_err());
+
+        assert_eq!(
+            prover_transcript.challenge_scalar(b"test"),
+            verifier_transcript.challenge_scalar(b"test"),
+        )
     }
 
     #[test]

--- a/zk-sdk/src/sigma_proofs/ciphertext_commitment_equality.rs
+++ b/zk-sdk/src/sigma_proofs/ciphertext_commitment_equality.rs
@@ -1,9 +1,9 @@
 //! The ciphertext-commitment equality sigma proof system.
 //!
 //! A ciphertext-commitment equality proof is defined with respect to a twisted ElGamal ciphertext
-//! and a Pedersen commitment. The proof certifies that a given ciphertext and a commitment pair
-//! encrypts/encodes the same message. To generate the proof, a prover must provide the decryption
-//! key for the first ciphertext and the Pedersen opening for the commitment.
+//! and a Pedersen commitment. The proof certifies that a given ElGamal ciphertext and Pedersen
+//! commitment pair encrypt and encode the same message. To generate the proof, a prover must provide
+//! the decryption key for the first ciphertext and the Pedersen opening for the commitment.
 //!
 //! The protocol guarantees computational soundness (by the hardness of discrete log) and perfect
 //! zero-knowledge in the random oracle model.

--- a/zk-sdk/src/sigma_proofs/grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk/src/sigma_proofs/grouped_ciphertext_validity/handles_2.rs
@@ -103,11 +103,15 @@ impl GroupedCiphertext2HandlesValidityProof {
         transcript.append_point(b"Y_2", &Y_2);
 
         let c = transcript.challenge_scalar(b"c");
-        transcript.challenge_scalar(b"w");
 
         // compute masked message and opening
         let z_r = &(&c * r) + &y_r;
         let z_x = &(&c * &x) + &y_x;
+
+        // compute challenge `w` for consistency with verification
+        transcript.append_scalar(b"z_r", &z_r);
+        transcript.append_scalar(b"z_x", &z_x);
+        let _w = transcript.challenge_scalar(b"w");
 
         // zeroize all sensitive owned variables
         x.zeroize();
@@ -403,6 +407,11 @@ mod test {
                 &mut verifier_transcript,
             )
             .unwrap();
+
+        assert_eq!(
+            prover_transcript.challenge_scalar(b"test"),
+            verifier_transcript.challenge_scalar(b"test"),
+        )
     }
 
     #[test]

--- a/zk-sdk/src/sigma_proofs/grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk/src/sigma_proofs/grouped_ciphertext_validity/handles_3.rs
@@ -109,11 +109,15 @@ impl GroupedCiphertext3HandlesValidityProof {
         transcript.append_point(b"Y_3", &Y_3);
 
         let c = transcript.challenge_scalar(b"c");
-        transcript.challenge_scalar(b"w");
 
         // compute masked message and opening
         let z_r = &(&c * r) + &y_r;
         let z_x = &(&c * &x) + &y_x;
+
+        // compute challenge `w` for consistency with verification
+        transcript.append_scalar(b"z_r", &z_r);
+        transcript.append_scalar(b"z_x", &z_x);
+        let _w = transcript.challenge_scalar(b"w");
 
         // zeroize all sensitive owned variables
         x.zeroize();
@@ -462,6 +466,11 @@ mod test {
                 &mut verifier_transcript,
             )
             .unwrap();
+
+        assert_eq!(
+            prover_transcript.challenge_scalar(b"test"),
+            verifier_transcript.challenge_scalar(b"test"),
+        )
     }
 
     #[test]

--- a/zk-sdk/src/sigma_proofs/percentage_with_cap.rs
+++ b/zk-sdk/src/sigma_proofs/percentage_with_cap.rs
@@ -143,7 +143,7 @@ impl PercentageWithCapProof {
 
         let below_max = u64::ct_gt(&max_value, &fee_amount);
 
-        // choose one of `proof_above_max` or `proof_below_max` dependeing on whether the computed
+        // choose one of `proof_above_max` or `proof_below_max` depending on whether the computed
         // fee is less than the max value
         let percentage_max_proof = PercentageMaxProof::conditional_select(
             &proof_above_max.percentage_max_proof,

--- a/zk-sdk/src/sigma_proofs/pubkey_validity.rs
+++ b/zk-sdk/src/sigma_proofs/pubkey_validity.rs
@@ -184,6 +184,11 @@ mod test {
         proof
             .verify(keypair.pubkey(), &mut verifier_transcript)
             .unwrap();
+
+        assert_eq!(
+            prover_transcript.challenge_scalar(b"test"),
+            verifier_transcript.challenge_scalar(b"test"),
+        )
     }
 
     #[test]

--- a/zk-sdk/src/sigma_proofs/zero_ciphertext.rs
+++ b/zk-sdk/src/sigma_proofs/zero_ciphertext.rs
@@ -86,10 +86,12 @@ impl ZeroCiphertextProof {
         transcript.append_point(b"Y_D", &Y_D);
 
         let c = transcript.challenge_scalar(b"c");
-        transcript.challenge_scalar(b"w");
 
         // compute the masked secret key
         let z = &(&c * s) + &y;
+
+        transcript.append_scalar(b"z", &z);
+        let _w = transcript.challenge_scalar(b"w");
 
         // zeroize random scalar
         y.zeroize();
@@ -224,6 +226,11 @@ mod test {
                 &mut verifier_transcript
             )
             .is_err());
+
+        assert_eq!(
+            prover_transcript.challenge_scalar(b"test"),
+            verifier_transcript.challenge_scalar(b"test"),
+        )
     }
 
     #[test]

--- a/zk-sdk/src/sigma_proofs/zero_ciphertext.rs
+++ b/zk-sdk/src/sigma_proofs/zero_ciphertext.rs
@@ -58,9 +58,6 @@ impl ZeroCiphertextProof {
     ///
     /// This function is randomized. It uses `OsRng` internally to generate random scalars.
     ///
-    /// Note that the proof constructor does not take the actual ElGamal ciphertext as input; it
-    /// uses the ElGamal private key instead to generate the proof.
-    ///
     /// * `elgamal_keypair` - The ElGamal keypair associated with the ciphertext to be proved
     /// * `ciphertext` - The main ElGamal ciphertext to be proved
     /// * `transcript` - The transcript that does the bookkeeping for the Fiat-Shamir heuristic

--- a/zk-sdk/src/zk_elgamal_proof_program/instruction.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/instruction.rs
@@ -10,12 +10,19 @@
 //!      dedicated [`context-state`] account.
 //!
 //! In step 1, the zero-knowledge proof can either be included directly as the instruction data or
-//! pre-written to an account. The program determines whether the proof is provided as instruction
-//! data or pre-written to an account by inspecting the length of the data. If the instruction data
-//! is exactly 5 bytes (instruction discriminator + unsigned 32-bit integer), then the program
-//! assumes that the first account provided with the instruction contains the zero-knowledge proof
-//! and verifies the account data at the offset specified in the instruction data. Otherwise, the
-//! program assumes that the zero-knowledge proof is provided as part of the instruction data.
+//! pre-written to an account. The program determines the mode by inspecting the length of the
+//! instruction data.
+//!
+//! **Case A: Proof in a separate account**
+//! If the instruction data is exactly 5 bytes (1-byte instruction discriminator + 4-byte unsigned
+//! integer for offset), the program assumes that the first account provided with the instruction
+//! contains the zero-knowledge proof. It then verifies the account data at the offset specified in
+//! the instruction.
+//!
+//! **Case B: Proof in instruction data**
+//! If two additional accounts are provided (for the context state and its owner), the program
+//! interprets this as a request to store the proof's context data and writes it to the specified
+//! context-state account.
 //!
 //! In step 2, the program determines whether to create a context-state account by inspecting the
 //! number of accounts provided with the instruction. If two additional accounts are provided with
@@ -62,9 +69,24 @@ pub enum ProofInstruction {
     ///
     /// Accounts expected by this instruction:
     ///
-    ///   0. `[]` (Optional) Account to read the proof from
-    ///   1. `[writable]` (Optional) The proof context account
-    ///   2. `[]` (Optional) The proof context account owner
+    ///   There are four ways to structure the accounts, depending on whether the
+    ///   proof is provided as instruction data or in a separate account, and whether
+    ///   a proof context is created.
+    ///
+    ///   1. **Proof in instruction data, no context state:**
+    ///      - No accounts are required.
+    ///
+    ///   2. **Proof in instruction data, with context state:**
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
+    ///
+    ///   3. **Proof in account, no context state:**
+    ///      - `[]` Account to read the proof from.
+    ///
+    ///   4. **Proof in account, with context state:**
+    ///      - `[]` Account to read the proof from.
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
     ///
     /// The instruction expects either:
     ///   i. `ZeroCiphertextProofData` if proof is provided as instruction data
@@ -79,9 +101,24 @@ pub enum ProofInstruction {
     ///
     /// Accounts expected by this instruction:
     ///
-    ///   0. `[]` (Optional) Account to read the proof from
-    ///   1. `[writable]` (Optional) The proof context account
-    ///   2. `[]` (Optional) The proof context account owner
+    ///   There are four ways to structure the accounts, depending on whether the
+    ///   proof is provided as instruction data or in a separate account, and whether
+    ///   a proof context is created.
+    ///
+    ///   1. **Proof in instruction data, no context state:**
+    ///      - No accounts are required.
+    ///
+    ///   2. **Proof in instruction data, with context state:**
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
+    ///
+    ///   3. **Proof in account, no context state:**
+    ///      - `[]` Account to read the proof from.
+    ///
+    ///   4. **Proof in account, with context state:**
+    ///      - `[]` Account to read the proof from.
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
     ///
     /// The instruction expects either:
     ///   i. `CiphertextCiphertextEqualityProofData` if proof is provided as instruction data
@@ -96,9 +133,24 @@ pub enum ProofInstruction {
     ///
     /// Accounts expected by this instruction:
     ///
-    ///   0. `[]` (Optional) Account to read the proof from
-    ///   1. `[writable]` (Optional) The proof context account
-    ///   2. `[]` (Optional) The proof context account owner
+    ///   There are four ways to structure the accounts, depending on whether the
+    ///   proof is provided as instruction data or in a separate account, and whether
+    ///   a proof context is created.
+    ///
+    ///   1. **Proof in instruction data, no context state:**
+    ///      - No accounts are required.
+    ///
+    ///   2. **Proof in instruction data, with context state:**
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
+    ///
+    ///   3. **Proof in account, no context state:**
+    ///      - `[]` Account to read the proof from.
+    ///
+    ///   4. **Proof in account, with context state:**
+    ///      - `[]` Account to read the proof from.
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
     ///
     /// The instruction expects either:
     ///   i. `CiphertextCommitmentEqualityProofData` if proof is provided as instruction data
@@ -113,9 +165,24 @@ pub enum ProofInstruction {
     ///
     /// Accounts expected by this instruction:
     ///
-    ///   0. `[]` (Optional) Account to read the proof from
-    ///   1. `[writable]` (Optional) The proof context account
-    ///   2. `[]` (Optional) The proof context account owner
+    ///   There are four ways to structure the accounts, depending on whether the
+    ///   proof is provided as instruction data or in a separate account, and whether
+    ///   a proof context is created.
+    ///
+    ///   1. **Proof in instruction data, no context state:**
+    ///      - No accounts are required.
+    ///
+    ///   2. **Proof in instruction data, with context state:**
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
+    ///
+    ///   3. **Proof in account, no context state:**
+    ///      - `[]` Account to read the proof from.
+    ///
+    ///   4. **Proof in account, with context state:**
+    ///      - `[]` Account to read the proof from.
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
     ///
     /// The instruction expects either:
     ///   i. `PubkeyValidityData` if proof is provided as instruction data
@@ -130,9 +197,24 @@ pub enum ProofInstruction {
     ///
     /// Accounts expected by this instruction:
     ///
-    ///   0. `[]` (Optional) Account to read the proof from
-    ///   1. `[writable]` (Optional) The proof context account
-    ///   2. `[]` (Optional) The proof context account owner
+    ///   There are four ways to structure the accounts, depending on whether the
+    ///   proof is provided as instruction data or in a separate account, and whether
+    ///   a proof context is created.
+    ///
+    ///   1. **Proof in instruction data, no context state:**
+    ///      - No accounts are required.
+    ///
+    ///   2. **Proof in instruction data, with context state:**
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
+    ///
+    ///   3. **Proof in account, no context state:**
+    ///      - `[]` Account to read the proof from.
+    ///
+    ///   4. **Proof in account, with context state:**
+    ///      - `[]` Account to read the proof from.
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
     ///
     /// The instruction expects either:
     ///   i. `PercentageWithCapProofData` if proof is provided as instruction data
@@ -154,9 +236,24 @@ pub enum ProofInstruction {
     ///
     /// Accounts expected by this instruction:
     ///
-    ///   0. `[]` (Optional) Account to read the proof from
-    ///   1. `[writable]` (Optional) The proof context account
-    ///   2. `[]` (Optional) The proof context account owner
+    ///   There are four ways to structure the accounts, depending on whether the
+    ///   proof is provided as instruction data or in a separate account, and whether
+    ///   a proof context is created.
+    ///
+    ///   1. **Proof in instruction data, no context state:**
+    ///      - No accounts are required.
+    ///
+    ///   2. **Proof in instruction data, with context state:**
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
+    ///
+    ///   3. **Proof in account, no context state:**
+    ///      - `[]` Account to read the proof from.
+    ///
+    ///   4. **Proof in account, with context state:**
+    ///      - `[]` Account to read the proof from.
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
     ///
     /// The instruction expects either:
     ///   i. `BatchedRangeProofU64Data` if proof is provided as instruction data
@@ -172,9 +269,24 @@ pub enum ProofInstruction {
     ///
     /// Accounts expected by this instruction:
     ///
-    ///   0. `[]` (Optional) Account to read the proof from
-    ///   1. `[writable]` (Optional) The proof context account
-    ///   2. `[]` (Optional) The proof context account owner
+    ///   There are four ways to structure the accounts, depending on whether the
+    ///   proof is provided as instruction data or in a separate account, and whether
+    ///   a proof context is created.
+    ///
+    ///   1. **Proof in instruction data, no context state:**
+    ///      - No accounts are required.
+    ///
+    ///   2. **Proof in instruction data, with context state:**
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
+    ///
+    ///   3. **Proof in account, no context state:**
+    ///      - `[]` Account to read the proof from.
+    ///
+    ///   4. **Proof in account, with context state:**
+    ///      - `[]` Account to read the proof from.
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
     ///
     /// The instruction expects either:
     ///   i. `BatchedRangeProofU128Data` if proof is provided as instruction data
@@ -190,9 +302,24 @@ pub enum ProofInstruction {
     ///
     /// Accounts expected by this instruction:
     ///
-    ///   0. `[]` (Optional) Account to read the proof from
-    ///   1. `[writable]` (Optional) The proof context account
-    ///   2. `[]` (Optional) The proof context account owner
+    ///   There are four ways to structure the accounts, depending on whether the
+    ///   proof is provided as instruction data or in a separate account, and whether
+    ///   a proof context is created.
+    ///
+    ///   1. **Proof in instruction data, no context state:**
+    ///      - No accounts are required.
+    ///
+    ///   2. **Proof in instruction data, with context state:**
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
+    ///
+    ///   3. **Proof in account, no context state:**
+    ///      - `[]` Account to read the proof from.
+    ///
+    ///   4. **Proof in account, with context state:**
+    ///      - `[]` Account to read the proof from.
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
     ///
     /// The instruction expects either:
     ///   i. `BatchedRangeProofU256Data` if proof is provided as instruction data
@@ -208,9 +335,24 @@ pub enum ProofInstruction {
     ///
     /// Accounts expected by this instruction:
     ///
-    ///   0. `[]` (Optional) Account to read the proof from
-    ///   1. `[writable]` (Optional) The proof context account
-    ///   2. `[]` (Optional) The proof context account owner
+    ///   There are four ways to structure the accounts, depending on whether the
+    ///   proof is provided as instruction data or in a separate account, and whether
+    ///   a proof context is created.
+    ///
+    ///   1. **Proof in instruction data, no context state:**
+    ///      - No accounts are required.
+    ///
+    ///   2. **Proof in instruction data, with context state:**
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
+    ///
+    ///   3. **Proof in account, no context state:**
+    ///      - `[]` Account to read the proof from.
+    ///
+    ///   4. **Proof in account, with context state:**
+    ///      - `[]` Account to read the proof from.
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
     ///
     /// The instruction expects either:
     ///   i. `GroupedCiphertext2HandlesValidityProofData` if proof is provided as instruction data
@@ -227,9 +369,24 @@ pub enum ProofInstruction {
     ///
     /// Accounts expected by this instruction:
     ///
-    ///   0. `[]` (Optional) Account to read the proof from
-    ///   1. `[writable]` (Optional) The proof context account
-    ///   2. `[]` (Optional) The proof context account owner
+    ///   There are four ways to structure the accounts, depending on whether the
+    ///   proof is provided as instruction data or in a separate account, and whether
+    ///   a proof context is created.
+    ///
+    ///   1. **Proof in instruction data, no context state:**
+    ///      - No accounts are required.
+    ///
+    ///   2. **Proof in instruction data, with context state:**
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
+    ///
+    ///   3. **Proof in account, no context state:**
+    ///      - `[]` Account to read the proof from.
+    ///
+    ///   4. **Proof in account, with context state:**
+    ///      - `[]` Account to read the proof from.
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
     ///
     /// The instruction expects either:
     ///   i. `BatchedGroupedCiphertext2HandlesValidityProofData` if proof is provided as instruction data
@@ -245,13 +402,24 @@ pub enum ProofInstruction {
     ///
     /// Accounts expected by this instruction:
     ///
-    ///   * Creating a proof context account
-    ///   0. `[]` (Optional) Account to read the proof from
-    ///   1. `[writable]` The proof context account
-    ///   2. `[]` The proof context account owner
+    ///   There are four ways to structure the accounts, depending on whether the
+    ///   proof is provided as instruction data or in a separate account, and whether
+    ///   a proof context is created.
     ///
-    ///   * Otherwise
-    ///     None
+    ///   1. **Proof in instruction data, no context state:**
+    ///      - No accounts are required.
+    ///
+    ///   2. **Proof in instruction data, with context state:**
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
+    ///
+    ///   3. **Proof in account, no context state:**
+    ///      - `[]` Account to read the proof from.
+    ///
+    ///   4. **Proof in account, with context state:**
+    ///      - `[]` Account to read the proof from.
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
     ///
     /// The instruction expects either:
     ///   i. `GroupedCiphertext3HandlesValidityProofData` if proof is provided as instruction data
@@ -268,13 +436,24 @@ pub enum ProofInstruction {
     ///
     /// Accounts expected by this instruction:
     ///
-    ///   * Creating a proof context account
-    ///   0. `[]` (Optional) Account to read the proof from
-    ///   1. `[writable]` The proof context account
-    ///   2. `[]` The proof context account owner
+    ///   There are four ways to structure the accounts, depending on whether the
+    ///   proof is provided as instruction data or in a separate account, and whether
+    ///   a proof context is created.
     ///
-    ///   * Otherwise
-    ///     None
+    ///   1. **Proof in instruction data, no context state:**
+    ///      - No accounts are required.
+    ///
+    ///   2. **Proof in instruction data, with context state:**
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
+    ///
+    ///   3. **Proof in account, no context state:**
+    ///      - `[]` Account to read the proof from.
+    ///
+    ///   4. **Proof in account, with context state:**
+    ///      - `[]` Account to read the proof from.
+    ///      - `[writable]` The proof context account to create.
+    ///      - `[]` The proof context account owner.
     ///
     /// The instruction expects either:
     ///   i. `BatchedGroupedCiphertext3HandlesValidityProofData` if proof is provided as instruction data

--- a/zk-sdk/src/zk_elgamal_proof_program/mod.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/mod.rs
@@ -5,7 +5,12 @@
 //! the program as well as the technical details of some of the proof instructions can be found in
 //! the [`ZK ElGamal proof`] documentation.
 //!
+//! This module contains the instruction types, the proof context state, and the proof instruction
+//! data types. For the precise processor logic, see the ZK ElGamal Proof [`program`].
+//! implementation.
+//!
 //! [`ZK ElGamal proof`]: https://docs.solanalabs.com/runtime/zk-token-proof
+//! [`program`]: https://github.com/anza-xyz/agave/blob/master/programs/zk-elgamal-proof/src/lib.rs
 
 pub mod errors;
 pub mod instruction;

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/zero_ciphertext.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/zero_ciphertext.rs
@@ -29,7 +29,7 @@ use {
     bytemuck_derive::{Pod, Zeroable},
 };
 
-/// The instruction data that is needed for the `ProofInstruction::ZeroCiphertext` instruction.
+/// The instruction data that is needed for the `ProofInstruction::VerifyZeroCiphertext` instruction.
 ///
 /// It includes the cryptographic proof as well as the context data information needed to verify
 /// the proof.

--- a/zk-sdk/src/zk_elgamal_proof_program/state.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/state.rs
@@ -7,7 +7,22 @@ use {
     std::mem::size_of,
 };
 
-/// The proof context account state
+/// The on-chain state for a verified zero-knowledge proof statement.
+///
+/// In a zero-knowledge proof system, there is a distinction between a **proof** and a
+/// **statement**.
+/// - The **statement** consists of the public values that a proof is certifying. For example, in a
+///   `VerifyZeroCiphertext` instruction, the statement is the ElGamal ciphertext itself.
+/// - The **proof** is the cryptographic data that demonstrates the statement's validity without
+///   revealing any secret information.
+///
+/// A proof is ephemeral and is discarded after it is successfully verified by a proof
+/// instruction. However, the instruction can optionally store the verified public statement
+/// on-chain in a dedicated account. The `ProofContextState` struct defines the layout of this
+/// account.
+///
+/// Storing the statement on-chain acts as a verifiable receipt or certificate that a specific
+/// proof was successfully processed. This state can then be referenced by other on-chain programs.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(C)]
 pub struct ProofContextState<T: Pod> {
@@ -21,7 +36,7 @@ pub struct ProofContextState<T: Pod> {
 
 // `bytemuck::Pod` cannot be derived for generic structs unless the struct is marked
 // `repr(packed)`, which may cause unnecessary complications when referencing its fields. Directly
-// mark `ProofContextState` as `Zeroable` and `Pod` since since none of its fields has an alignment
+// mark `ProofContextState` as `Zeroable` and `Pod` since none of its fields has an alignment
 // requirement greater than 1 and therefore, guaranteed to be `packed`.
 unsafe impl<T: Pod> Zeroable for ProofContextState<T> {}
 unsafe impl<T: Pod> Pod for ProofContextState<T> {}


### PR DESCRIPTION
#### Summary of Changes
Added some improvements in the docs, add some additional tests, and fixed a transcript update during proof generation.
- [4fd007b](https://github.com/solana-program/zk-elgamal-proof/pull/39/commits/4fd007b4f69206cb23c3bb004f4c483fc434076a): Left a note on how the batching is done on the grouped ciphertext validity proof
- [1929528](https://github.com/solana-program/zk-elgamal-proof/pull/39/commits/19295284b6ed2e5a266688ebf81baaa77776fc95) and [9c93e9b](https://github.com/solana-program/zk-elgamal-proof/pull/39/commits/9c93e9b246a0196d322df0d303bba33648095b44): Just added some sanity tests for the private `create_proof_percentage_above_max` and `create_proof_percentage_below_max` functions
- [97f0e19](https://github.com/solana-program/zk-elgamal-proof/pull/39/commits/97f0e19c9d0cffb08fdf654a1fae19d63035af5e): The current doc on the proof generation logic seemed quite verbose, so I condensed it slightly and added a pointer to the more detailed pdf docs. I renamed the variable `percentage_commitment` to `fee_commitment` since it more aptly describes the variable. Added some additional clarifying comments on the important logic.

- [4f0230f](https://github.com/solana-program/zk-elgamal-proof/pull/39/commits/4f0230f0aa56503c352ae0b3917113dcfc5b73bb): The vulnerability of not hashing all the components to the transcript was only fixed for the proof verification logic (https://github.com/anza-xyz/agave/pull/5883) and not the proof generation to minimize code changes that will need to be backported. Technically, we don't need to update the proof generation because the challenge scalar value `w` that are derived from  the final the hashed components is only used in the verification logic. However, it is good practice to make the proof and verification transcripts consistent, so I added the logic to update the transcripts properly in the proof generation logic. I added tests at the end of each sigma proofs to make sure that the transcripts in the proof generation and verification logic end up the same.

- [20ef405](https://github.com/solana-program/zk-elgamal-proof/pull/39/commits/20ef40555ff44b09f42d90f3da20152bf4373925): The batched grouped ciphertext validity proof constructors didn't have a note on hashing public values, so I added these.
- [981ea28](https://github.com/solana-program/zk-elgamal-proof/pull/39/commits/981ea281ad6712cf0b4c259d4fd79ad333df1f32): General improvements in the ZK ElGamal proof program docs