### PR TITLE
[zk-sdk] Improve docs and fix transcript consistency in the range proof implementation

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,24 @@
+Portions of this software are adapted from the dalek-cryptography/bulletproofs
+library, which is licensed under the MIT license.
+
+MIT License
+
+Copyright (c) 2018 Chain, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/zk-sdk/src/range_proof/inner_product.rs
+++ b/zk-sdk/src/range_proof/inner_product.rs
@@ -1,9 +1,9 @@
 //! The inner-product proof protocol.
 //!
 //! This module implements the inner-product proof protocol described in Section 3 of the
-//! Bulletproofs [`paper`]. The protocol is a recursive argument that allows a prover to
-//! convince a verifier that the inner product of two secret vectors `a` and `b` is a
-//! certain public value `c`.
+//! Bulletproofs [`paper`] (also described in [`notes`]). . The protocol is a recursive
+//! argument that allows a prover to convince a verifier that the inner product of two
+//! secret vectors `a` and `b` is a certain public value `c`.
 //!
 //! [`paper`]: https://eprint.iacr.org/2017/1066
 //! [`notes`]: https://doc-internal.dalek.rs/bulletproofs/notes/inner_product_proof/index.html

--- a/zk-sdk/src/range_proof/inner_product.rs
+++ b/zk-sdk/src/range_proof/inner_product.rs
@@ -1,3 +1,13 @@
+//! The inner-product proof protocol.
+//!
+//! This module implements the inner-product proof protocol described in Section 3 of the
+//! Bulletproofs [`paper`]. The protocol is a recursive argument that allows a prover to
+//! convince a verifier that the inner product of two secret vectors `a` and `b` is a
+//! certain public value `c`.
+//!
+//! [`paper`]: https://eprint.iacr.org/2017/1066
+//! [`notes`]: https://doc-internal.dalek.rs/bulletproofs/notes/inner_product_proof/index.html
+
 use {
     crate::{
         range_proof::{
@@ -16,6 +26,11 @@ use {
     std::borrow::Borrow,
 };
 
+/// An inner-product proof.
+///
+/// The proof consists of `log(n)` pairs of compressed Ristretto points, and two scalars.
+/// This corresponds to the `L_i`, `R_i` values and the final `a`, `b` scalars in Protocol 2
+/// of the Bulletproofs paper.
 #[allow(non_snake_case)]
 #[derive(Clone)]
 pub struct InnerProductProof {
@@ -27,17 +42,11 @@ pub struct InnerProductProof {
 
 #[allow(non_snake_case)]
 impl InnerProductProof {
-    /// Create an inner-product proof.
+    /// Creates an inner-product proof.
     ///
-    /// The proof is created with respect to the bases \\(G\\), \\(H'\\),
-    /// where \\(H'\_i = H\_i \cdot \texttt{Hprime\\_factors}\_i\\).
-    ///
-    /// The `verifier` is passed in as a parameter so that the
-    /// challenges depend on the *entire* transcript (including parent
-    /// protocols).
-    ///
-    /// The lengths of the vectors must all be the same, and must all be
-    /// a power of 2.
+    /// This function implements Protocol 2 from the Bulletproofs paper, a recursive
+    /// argument to prove knowledge of two vectors `a` and `b` such that `<a,b> = c`.
+    /// The length of the vectors must be a power of two.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         Q: &RistrettoPoint,
@@ -81,8 +90,9 @@ impl InnerProductProof {
         let mut L_vec = Vec::with_capacity(lg_n);
         let mut R_vec = Vec::with_capacity(lg_n);
 
-        // If it's the first iteration, unroll the Hprime = H*y_inv scalar mults
-        // into multiscalar muls, for performance.
+        // This is an optimization: the first round of the protocol is unrolled from the
+        // main loop to handle the `G_factors` and `H_factors` more efficiently using
+        // a single multiscalar multiplication. Subsequent rounds use a simplified loop.
         if n != 1 {
             n = n.checked_div(2).unwrap();
             let (a_L, a_R) = a.split_at_mut(n);
@@ -90,11 +100,14 @@ impl InnerProductProof {
             let (G_L, G_R) = G.split_at_mut(n);
             let (H_L, H_R) = H.split_at_mut(n);
 
+            // Compute the cross terms c_L and c_R
             let c_L = util::inner_product(a_L, b_R)
                 .ok_or(RangeProofGenerationError::InnerProductLengthMismatch)?;
             let c_R = util::inner_product(a_R, b_L)
                 .ok_or(RangeProofGenerationError::InnerProductLengthMismatch)?;
 
+            // Compute L and R points for this round
+            // L = <a_L, G_R> + <b_R, H_L> + c_L * Q
             let L = RistrettoPoint::multiscalar_mul(
                 a_L.iter()
                     // `n` was previously divided in half and therefore, it cannot overflow.
@@ -110,6 +123,7 @@ impl InnerProductProof {
             )
             .compress();
 
+            // R = <a_R, G_L> + <b_L, H_R> + c_R * Q
             let R = RistrettoPoint::multiscalar_mul(
                 a_R.iter()
                     .zip(G_factors[0..n].iter())
@@ -158,6 +172,7 @@ impl InnerProductProof {
             H = H_L;
         }
 
+        // Main recursive loop
         while n != 1 {
             n = n.checked_div(2).unwrap();
             let (a_L, a_R) = a.split_at_mut(n);
@@ -165,17 +180,21 @@ impl InnerProductProof {
             let (G_L, G_R) = G.split_at_mut(n);
             let (H_L, H_R) = H.split_at_mut(n);
 
+            // Compute the cross terms c_L and c_R
             let c_L = util::inner_product(a_L, b_R)
                 .ok_or(RangeProofGenerationError::InnerProductLengthMismatch)?;
             let c_R = util::inner_product(a_R, b_L)
                 .ok_or(RangeProofGenerationError::InnerProductLengthMismatch)?;
 
+            // Compute L and R points for this round
+            // L = <a_L, G_R> + <b_R, H_L> + c_L * Q
             let L = RistrettoPoint::multiscalar_mul(
                 a_L.iter().chain(b_R.iter()).chain(iter::once(&c_L)),
                 G_R.iter().chain(H_L.iter()).chain(iter::once(Q)),
             )
             .compress();
 
+            // R = <a_R, G_L> + <b_L, H_R> + c_R * Q
             let R = RistrettoPoint::multiscalar_mul(
                 a_R.iter().chain(b_L.iter()).chain(iter::once(&c_R)),
                 G_L.iter().chain(H_R.iter()).chain(iter::once(Q)),
@@ -212,11 +231,11 @@ impl InnerProductProof {
         })
     }
 
-    /// Computes three vectors of verification scalars \\([u\_{i}^{2}]\\), \\([u\_{i}^{-2}]\\) and
-    /// \\([s\_{i}]\\) for combined multiscalar multiplication in a parent protocol. See [inner
-    /// product protocol notes](index.html#verification-equation) for details. The verifier must
-    /// provide the input length \\(n\\) explicitly to avoid unbounded allocation within the inner
-    /// product proof.
+    /// Computes the verification scalars for a single inner product proof.
+    ///
+    /// This is a helper function for the verifier, implementing the logic from
+    /// Section 3.1 of the paper. It computes the scalars `u_i^2`, `u_i^-2`, and `s_i`
+    /// which are needed for the final, single multiscalar multiplication check.
     #[allow(clippy::type_complexity)]
     pub(crate) fn verification_scalars(
         &self,
@@ -235,8 +254,7 @@ impl InnerProductProof {
 
         transcript.inner_product_proof_domain_separator(n as u64);
 
-        // 1. Recompute x_k,...,x_1 based on the proof transcript
-
+        // 1. Recompute challenges `u_i` from the proof transcript (`x_i` in the paper).
         let mut challenges = Vec::with_capacity(lg_n);
         for (L, R) in self.L_vec.iter().zip(self.R_vec.iter()) {
             transcript.validate_and_append_point(b"L", L)?;
@@ -244,13 +262,12 @@ impl InnerProductProof {
             challenges.push(transcript.challenge_scalar(b"u"));
         }
 
-        // 2. Compute 1/(u_k...u_1) and 1/u_k, ..., 1/u_1
-
+        // 2. Compute `u_i^-1` for all `i`.
         let mut challenges_inv = challenges.clone();
+        // This computes `(u_k * ... * u_1)^-1` and stores `u_i^-1` in `challenges_inv`.
         let allinv = Scalar::batch_invert(&mut challenges_inv);
 
-        // 3. Compute u_i^2 and (1/u_i)^2
-
+        // 3. Compute `u_i^2` and `u_i^-2` for all `i`.
         for i in 0..lg_n {
             challenges[i] = challenges[i] * challenges[i];
             challenges_inv[i] = challenges_inv[i] * challenges_inv[i];
@@ -258,15 +275,14 @@ impl InnerProductProof {
         let challenges_sq = challenges;
         let challenges_inv_sq = challenges_inv;
 
-        // 4. Compute s values inductively.
-
+        // 4. Compute `s_i` values inductively, as described in Section 6.2 of the paper.
         let mut s = Vec::with_capacity(n);
         s.push(allinv);
         for i in 1..n {
             let lg_i = 31_u32.checked_sub((i as u32).leading_zeros()).unwrap() as usize;
             let k = 1_usize.checked_shl(lg_i as u32).unwrap();
-            // The challenges are stored in "creation order" as [u_k,...,u_1],
-            // so u_{lg(i)+1} = is indexed by (lg_n-1) - lg_i
+            // The challenges are stored in "creation order" as [u_lg_n, ..., u_1],
+            // so u_{lg_i+1} is indexed by (lg_n - 1) - lg_i
             let u_lg_i_sq = challenges_sq[lg_n
                 .checked_sub(1)
                 .and_then(|x| x.checked_sub(lg_i))
@@ -277,9 +293,11 @@ impl InnerProductProof {
         Ok((challenges_sq, challenges_inv_sq, s))
     }
 
-    /// This method is for testing that proof generation work, but for efficiency the actual
-    /// protocols would use `verification_scalars` method to combine inner product verification
-    /// with other checks in a single multiscalar multiplication.
+    /// Verifies an inner product proof.
+    ///
+    /// This is a standalone verification function for testing. In a real protocol,
+    /// the `verification_scalars` method would be used to integrate the check into
+    /// a larger, single multiscalar multiplication.
     #[allow(clippy::too_many_arguments)]
     pub fn verify<IG, IH>(
         &self,
@@ -335,6 +353,9 @@ impl InnerProductProof {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
+        // This check implements the verification equation from Section 3.1 of the paper.
+        // P' = P + <L, u^2> + <R, u^-2>
+        // We check that P' = g^(a*s) * h^(b*s^-1) * Q^(a*b)
         let expect_P = RistrettoPoint::vartime_multiscalar_mul(
             iter::once(self.a * self.b)
                 .chain(g_times_a_times_s)
@@ -355,19 +376,19 @@ impl InnerProductProof {
         }
     }
 
-    /// Returns the size in bytes required to serialize the inner
-    /// product proof.
+    /// Returns the size in bytes required to serialize the inner product proof.
     ///
-    /// For vectors of length `n` the proof size is
-    /// \\(32 \cdot (2\lg n+2)\\) bytes.
+    /// For vectors of length `n`, the proof size is `(2*log2(n) + 2) * 32` bytes.
     pub fn serialized_size(&self) -> usize {
         (self.L_vec.len() * 2 + 2) * 32
     }
 
-    /// Serializes the proof into a byte array of \\(2n+2\\) 32-byte elements.
+    /// Serializes the proof into a byte array.
     /// The layout of the inner product proof is:
-    /// * \\(n\\) pairs of compressed Ristretto points \\(L_0, R_0 \dots, L_{n-1}, R_{n-1}\\),
-    /// * two scalars \\(a, b\\).
+    /// - `log(n)` compressed Ristretto points for L_vec
+    /// - `log(n)` compressed Ristretto points for R_vec
+    /// - a scalar `a`
+    /// - a scalar `b`
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(self.serialized_size());
         for (l, r) in self.L_vec.iter().zip(self.R_vec.iter()) {
@@ -380,11 +401,22 @@ impl InnerProductProof {
     }
 
     /// Deserializes the proof from a byte slice.
-    /// Returns an error in the following cases:
-    /// * the slice does not have \\(2n+2\\) 32-byte elements,
-    /// * \\(n\\) is larger or equal to 32 (proof is too big),
-    /// * any of \\(2n\\) points are not valid compressed Ristretto points,
-    /// * any of 2 scalars are not canonical scalars modulo Ristretto group order.
+    ///
+    /// Returns an error if the slice is malformed or does not represent a
+    /// canonical inner product proof. The function checks for the following
+    /// failure conditions:
+    ///
+    /// * The slice's length is not a multiple of 32.
+    /// * The proof contains an invalid number of elements (e.g., no `a` and `b`
+    ///   scalars, or an odd number of point commitments).
+    /// * The number of L/R pairs (`log(n)`) is 32 or greater, which is
+    ///   considered an invalid proof size that could cause overflows.
+    /// * The bytes for the final `a` or `b` scalars are not canonical representations
+    ///   modulo the Ristretto group order.
+    ///
+    /// Note: This function does not check if the `L` and `R` points are valid
+    /// Ristretto points on the curve. The verifier should handle this by attempting
+    /// to decompress them, which will fail for invalid points.
     pub fn from_bytes(slice: &[u8]) -> Result<InnerProductProof, RangeProofVerificationError> {
         let b = slice.len();
         if b % 32 != 0 {

--- a/zk-sdk/src/range_proof/mod.rs
+++ b/zk-sdk/src/range_proof/mod.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2018 Chain, Inc.
+// This code is licensed under the MIT license.
+
 //! The Bulletproofs range-proof implementation over Curve25519 Ristretto points.
 //!
 //! The implementation is based on the dalek-cryptography bulletproofs
@@ -8,7 +11,6 @@
 //!   represented by arithmetic circuits as well as MPC.
 //! - This implementation implements a non-interactive range proof aggregation that is specified in
 //!   the original Bulletproofs [paper](https://eprint.iacr.org/2017/1066) (Section 4.3).
-//!
 
 #![allow(dead_code)]
 

--- a/zk-sdk/src/range_proof/mod.rs
+++ b/zk-sdk/src/range_proof/mod.rs
@@ -286,6 +286,11 @@ impl RangeProof {
             transcript,
         )?;
 
+        // compute challenge `d` for consistency with the verifier
+        transcript.append_scalar(b"ipp_a", &ipp_proof.a);
+        transcript.append_scalar(b"ipp_b", &ipp_proof.b);
+        let _d = transcript.challenge_scalar(b"d");
+
         Ok(RangeProof {
             A,
             S,
@@ -520,6 +525,11 @@ mod tests {
         proof
             .verify(vec![&comm], vec![32], &mut transcript_verify)
             .unwrap();
+
+        assert_eq!(
+            transcript_create.challenge_scalar(b"test"),
+            transcript_verify.challenge_scalar(b"test"),
+        )
     }
 
     #[test]
@@ -546,6 +556,11 @@ mod tests {
                 &mut transcript_verify,
             )
             .unwrap();
+
+        assert_eq!(
+            transcript_create.challenge_scalar(b"test"),
+            transcript_verify.challenge_scalar(b"test"),
+        )
     }
 
     #[test]

--- a/zk-sdk/src/range_proof/mod.rs
+++ b/zk-sdk/src/range_proof/mod.rs
@@ -71,32 +71,43 @@ pub const INNER_PRODUCT_PROOF_U256_LEN: usize = 576;
 pub const RANGE_PROOF_U256_LEN: usize =
     INNER_PRODUCT_PROOF_U256_LEN + RANGE_PROOF_MODULO_INNER_PRODUCT_PROOF_LEN; // 800 bytes
 
+/// A Bulletproofs range proof.
 #[allow(non_snake_case)]
 #[cfg(not(target_os = "solana"))]
 #[derive(Clone)]
 pub struct RangeProof {
-    pub(crate) A: CompressedRistretto,       // 32 bytes
-    pub(crate) S: CompressedRistretto,       // 32 bytes
-    pub(crate) T_1: CompressedRistretto,     // 32 bytes
-    pub(crate) T_2: CompressedRistretto,     // 32 bytes
-    pub(crate) t_x: Scalar,                  // 32 bytes
-    pub(crate) t_x_blinding: Scalar,         // 32 bytes
-    pub(crate) e_blinding: Scalar,           // 32 bytes
+    /// A commitment to the bit-vectors `a_L` and `a_R`.
+    pub(crate) A: CompressedRistretto, // 32 bytes
+    /// A commitment to the blinding vectors `s_L` and `s_R`.
+    pub(crate) S: CompressedRistretto, // 32 bytes
+    /// A commitment to the `t_1` coefficient of the polynomial `t(x)`.
+    pub(crate) T_1: CompressedRistretto, // 32 bytes
+    /// A commitment to the `t_2` coefficient of the polynomial `t(x)`.
+    pub(crate) T_2: CompressedRistretto, // 32 bytes
+    /// The evaluation of the polynomial `t(x)` at the challenge point `x`.
+    pub(crate) t_x: Scalar, // 32 bytes
+    /// The blinding factor for the `t_x` value.
+    pub(crate) t_x_blinding: Scalar, // 32 bytes
+    /// The blinding factor for the synthetic commitment to `l(x)` and `r(x)`.
+    pub(crate) e_blinding: Scalar, // 32 bytes
+    /// The inner product proof.
     pub(crate) ipp_proof: InnerProductProof, // 448 bytes for withdraw; 512 for transfer
 }
 
 #[allow(non_snake_case)]
 #[cfg(not(target_os = "solana"))]
 impl RangeProof {
-    /// Create an aggregated range proof.
+    /// Creates an aggregated range proof for a set of values that are committed to a set of
+    /// Pedersen commitments.
     ///
-    /// The proof is created with respect to a vector of Pedersen commitments C_1, ..., C_m. The
-    /// method itself does not take in these commitments, but the values associated with the commitments:
-    /// - vector of committed amounts v_1, ..., v_m represented as u64
-    /// - bit-lengths of the committed amounts
-    /// - Pedersen openings for each commitments
+    /// This function implements the aggregated proof generation logic from Section 4.3
+    /// of the Bulletproofs paper. It allows proving that multiple values are in their
+    /// respective ranges, creating one proof that is much smaller than the sum of
+    /// individual proofs.
     ///
-    /// The sum of the bit-lengths of the commitments amounts must be a power-of-two
+    /// # Panics
+    /// This function will panic if the `openings` vector does not contain the same number
+    /// of elements as the `amounts` and `bit_lengths` vectors.
     #[allow(clippy::many_single_char_names)]
     #[cfg(not(target_os = "solana"))]
     pub fn new(
@@ -105,7 +116,7 @@ impl RangeProof {
         openings: Vec<&PedersenOpening>,
         transcript: &mut Transcript,
     ) -> Result<Self, RangeProofGenerationError> {
-        // amounts, bit-lengths, openings must be same length vectors
+        // 1. Validate inputs
         let m = amounts.len();
         if bit_lengths.len() != m || openings.len() != m {
             return Err(RangeProofGenerationError::VectorLengthMismatch);
@@ -130,7 +141,8 @@ impl RangeProof {
 
         transcript.range_proof_domain_separator(nm as u64);
 
-        // bit-decompose values and generate their Pedersen vector commitment
+        // 2. Create commitments A and S.
+        // A is a commitment to the bit-vectors a_L and a_R
         let a_blinding = Scalar::random(&mut OsRng);
         let mut A = a_blinding * &(*H);
 
@@ -143,6 +155,7 @@ impl RangeProof {
                 // casting is lossless and right shift can be safely unwrapped
                 let v_ij = Choice::from((amount_i.checked_shr(j as u32).unwrap() & 1) as u8);
                 let mut point = -H_ij;
+                // Add G_ij if bit is 1, else do nothing (since a_R = a_L - 1)
                 point.conditional_assign(G_ij, v_ij);
                 A += point;
             }
@@ -163,18 +176,17 @@ impl RangeProof {
         )
         .compress();
 
-        // add the Pedersen vector commitments to the transcript (send the commitments to the verifier)
+        // 3. Derive challenges y and z.
         transcript.append_point(b"A", &A);
         transcript.append_point(b"S", &S);
 
-        // derive challenge scalars from the transcript (receive challenge from the verifier): `y`
-        // and `z` used for merge multiple inner product relations into one single inner product
         let y = transcript.challenge_scalar(b"y");
         let z = transcript.challenge_scalar(b"z");
 
-        // define blinded vectors:
-        // - l(x) = (a_L - z*1) + s_L*x
-        // - r(x) = (y^n * (a_R + z*1) + [z^2*2^n | z^3*2^n | ... | z^m*2^n]) + y^n * s_R*x
+        // 4. Construct the blinded vector polynomials l(x) and r(x).
+        //    l(x) = (a_L - z*1) + s_L*x
+        //    r(x) = y^nm o (a_R + z*1 + s_R*x) + (z^2*2^n_1 || ... || z^{m+1}*2^n_m)
+        //    where `o` is the Hadamard product and `||` is vector concatenation.
         let mut l_poly = util::VecPoly1::zero(nm);
         let mut r_poly = util::VecPoly1::zero(nm);
 
@@ -205,12 +217,12 @@ impl RangeProof {
             exp_z *= z;
         }
 
-        // define t(x) = <l(x), r(x)> = t_0 + t_1*x + t_2*x
+        // 5. Compute the inner product polynomial t(x) = <l(x), r(x)>.
         let t_poly = l_poly
             .inner_product(&r_poly)
             .ok_or(RangeProofGenerationError::InnerProductLengthMismatch)?;
 
-        // generate Pedersen commitment for the coefficients t_1 and t_2
+        // 6. Commit to the t_1 and t_2 coefficients of t(x).
         let (T_1, t_1_blinding) = Pedersen::new(t_poly.1);
         let (T_2, t_2_blinding) = Pedersen::new(t_poly.2);
 
@@ -220,10 +232,10 @@ impl RangeProof {
         transcript.append_point(b"T_1", &T_1);
         transcript.append_point(b"T_2", &T_2);
 
-        // evaluate t(x) on challenge x and homomorphically compute the openings for
-        // z^2 * V_1 + z^3 * V_2 + ... + z^{m+1} * V_m + delta(y, z)*G + x*T_1 + x^2*T_2
+        // 7. Derive challenge x and compute openings.
         let x = transcript.challenge_scalar(b"x");
 
+        // Compute the aggregated blinding factor for all value commitments.
         let mut agg_opening = Scalar::ZERO;
         let mut exp_z = z;
         for opening in openings {
@@ -245,6 +257,8 @@ impl RangeProof {
 
         // homomorphically compuate the openings for A + x*S
         let e_blinding = a_blinding + s_blinding * x;
+
+        // 8. Finally, create the inner product proof.
         let l_vec = l_poly.eval(x);
         let r_vec = r_poly.eval(x);
 
@@ -258,8 +272,8 @@ impl RangeProof {
         let G_factors: Vec<Scalar> = iter::repeat_n(Scalar::ONE, nm).collect();
         let H_factors: Vec<Scalar> = util::exp_iter(y.invert()).take(nm).collect();
 
-        // generate challenge `c` for consistency with the verifier's transcript
-        transcript.challenge_scalar(b"c");
+        // this variable exists for backwards compatibility
+        let _c = transcript.challenge_scalar(b"c");
 
         let ipp_proof = InnerProductProof::new(
             &Q,
@@ -284,6 +298,11 @@ impl RangeProof {
         })
     }
 
+    /// Verifies an aggregated range proof for a set of commitments.
+    ///
+    /// This function implements the verifier's logic, which is optimized into a
+    /// single large multiscalar multiplication (`mega_check`) for efficiency. This
+    /// check simultaneously verifies all aspects of the proof.
     #[allow(clippy::many_single_char_names)]
     pub fn verify(
         &self,
@@ -291,7 +310,7 @@ impl RangeProof {
         bit_lengths: Vec<usize>,
         transcript: &mut Transcript,
     ) -> Result<(), RangeProofVerificationError> {
-        // commitments and bit-lengths must be same length vectors
+        // 1. Validate inputs and reconstruct challenges from the transcript.
         if comms.len() != bit_lengths.len() {
             return Err(RangeProofVerificationError::VectorLengthMismatch);
         }
@@ -331,7 +350,7 @@ impl RangeProof {
         // this variable exists for backwards compatibility
         let _c = transcript.challenge_scalar(b"c");
 
-        // verify inner product proof
+        // 2. Compute the scalars for the verification equation.
         let (x_sq, x_inv_sq, s) = self.ipp_proof.verification_scalars(nm, transcript)?;
         let s_inv = s.iter().rev();
 
@@ -341,10 +360,14 @@ impl RangeProof {
         transcript.append_scalar(b"ipp_a", &a);
         transcript.append_scalar(b"ipp_b", &b);
 
-        let d = transcript.challenge_scalar(b"d"); // challenge value for batching multiscalar mul
+        // Challenge for batching the main algebraic relation checks
+        let d = transcript.challenge_scalar(b"d");
 
-        // construct concat_z_and_2, an iterator of the values of
-        // z^0 * \vec(2)^n || z^1 * \vec(2)^n || ... || z^(m-1) * \vec(2)^n
+        // 3. Construct the scalars for the single large multiscalar multiplication.
+
+        // This vector is used in the `h` terms of the final check.
+        // It's a concatenation of powers-of-2 vectors, each scaled by a power of z.
+        // Formula: z^0*2^n_0 || z^1*2^n_1 || ... || z^{m-1}*2^n_{m-1}
         let concat_z_and_2: Vec<Scalar> = util::exp_iter(z)
             .zip(bit_lengths.iter())
             .flat_map(|(exp_z, n_i)| {
@@ -364,6 +387,8 @@ impl RangeProof {
             w * (self.t_x - a * b) + d * (delta(&bit_lengths, &y, &z) - self.t_x);
         let value_commitment_scalars = util::exp_iter(z).take(m).map(|z_exp| d * zz * z_exp);
 
+        // 4. Perform the final "mega-check"
+        // This single multiscalar multiplication verifies all relations simultaneously.
         let mega_check = RistrettoPoint::optional_multiscalar_mul(
             iter::once(Scalar::ONE)
                 .chain(iter::once(x))
@@ -452,10 +477,11 @@ impl RangeProof {
     }
 }
 
-/// Compute
-/// \\[
-/// \delta(y,z) = (z - z^{2}) \langle \mathbf{1}, {\mathbf{y}}^{n \cdot m} \rangle - \sum_{j=0}^{m-1} z^{j+3} \cdot \langle \mathbf{1}, {\mathbf{2}}^{n \cdot m} \rangle
-/// \\]
+/// Computes the `delta(y,z)` term for the verification equation.
+///
+/// This term is a function of the challenges `y` and `z` and the proof dimensions.
+/// It is needed to correctly aggregate the polynomial checks.
+/// The formula is: `delta(y,z) = (z - z^2) * <1, y^nm> - sum_{j=0}^{m-1} z^(j+3) * <1, 2^n_j>`
 #[cfg(not(target_os = "solana"))]
 fn delta(bit_lengths: &[usize], y: &Scalar, z: &Scalar) -> Scalar {
     let nm: usize = bit_lengths.iter().sum();


### PR DESCRIPTION
#### Summary of Changes
I went through the range proof implementation component and generally updated the docs with more detail and removed the latex syntax that many of the function docs had.
- [b74361b](https://github.com/solana-program/zk-elgamal-proof/pull/41/commits/b74361bcb26ee06094c269219fb5ab75fd82ec09): I also fixed the transcript consistency issue between the proving and verifying functions as was done for sigma proofs
- https://github.com/solana-program/zk-elgamal-proof/pull/41/commits/2a8fb3f5c57c6765aa57312beb57bcbafcdcc6e8: The dalek-cryptography/bulletproofs library, which the range proof implementation is based derived from is licensed under MIT. After some searching, it seemed that the proper way to credit the original bulletproof library is to add a license statement on top of the range proof module and also a `NOTICE` file to also acknowledge the library. If you want me to pull this commit out into a separate PR, then I can do this as well.