### PR TITLE
[zk-sdk] Improve range proof context docs and add some clarifying comments

### DIFF
--- a/zk-sdk/src/sigma_proofs/percentage_with_cap.rs
+++ b/zk-sdk/src/sigma_proofs/percentage_with_cap.rs
@@ -15,7 +15,7 @@
 //! The protocol guarantees computational soundness (by the hardness of discrete log) and perfect
 //! zero-knowledge in the random oracle model.
 //!
-//! [`ZK ElGamal proof program`]: https://edge.docs.solanalabs.com/runtime/zk-token-proof
+//! [`ZK ElGamal proof program`]: https://docs.anza.xyz/runtime/zk-elgamal-proof
 //! [`specification`](https://github.com/anza-xyz/agave/blob/master/docs/src/runtime/zk-docs/percentage_with_cap.pdf).
 
 #[cfg(target_arch = "wasm32")]

--- a/zk-sdk/src/sigma_proofs/percentage_with_cap.rs
+++ b/zk-sdk/src/sigma_proofs/percentage_with_cap.rs
@@ -10,12 +10,12 @@
 //! max cap value.
 //!
 //! A more detailed description of the context and how the proof is computed is provided in the
-//! [`ZK Token proof program`] documentation, specifically the percentage-with-cap [`specification`].
+//! [`ZK ElGamal proof program`] documentation, specifically the percentage-with-cap [`specification`].
 //!
 //! The protocol guarantees computational soundness (by the hardness of discrete log) and perfect
 //! zero-knowledge in the random oracle model.
 //!
-//! [`ZK Token proof program`]: https://docs.solanalabs.com/runtime/zk-token-proof
+//! [`ZK ElGamal proof program`]: https://edge.docs.solanalabs.com/runtime/zk-token-proof
 //! [`specification`](https://github.com/anza-xyz/agave/blob/master/docs/src/runtime/zk-docs/percentage_with_cap.pdf).
 
 #[cfg(target_arch = "wasm32")]

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/batched_range_proof_u256.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/batched_range_proof_u256.rs
@@ -91,6 +91,11 @@ impl ZkProofData<BatchedRangeProofContext> for BatchedRangeProofU256Data {
         let (commitments, bit_lengths) = self.context.try_into()?;
         let num_commitments = commitments.len();
 
+        // This check is unique to the 256-bit proof. For 64-bit and 128-bit proofs,
+        // the total sum constraint already guarantees that no single bit length can
+        // exceed 128. However, for a 256-bit proof, bit lengths can sum to 256
+        // while containing a value greater than 128 (e.g., [160, 96]), so this
+        // must be explicitly checked.
         if bit_lengths
             .iter()
             .any(|length| *length > MAX_SINGLE_BIT_LENGTH)


### PR DESCRIPTION
#### Summary of Changes
No code changes. Just added some comments on potentially confusing part of the range proof context state logic and also fixed a broken link that refers to the ZK Token proof program instead of the ZK ElGamal proof program.