### PR TITLE
test(zk-token-sdk): add RangeProof bytes roundtrip (serialization/deserialization) tes

### DIFF
--- a/zk-sdk/src/range_proof/mod.rs
+++ b/zk-sdk/src/range_proof/mod.rs
@@ -566,6 +566,31 @@ mod tests {
     }
 
     #[test]
+    fn range_proof_bytes_roundtrip() {
+        let (comm, open) = Pedersen::new(42_u64);
+
+        let mut transcript_create = Transcript::new(b"Test");
+        let mut transcript_verify = Transcript::new(b"Test");
+
+        let bits: usize = 8;
+
+        let proof = RangeProof::new(vec![42], vec![bits], vec![&open], &mut transcript_create)
+            .expect("proof create");
+
+        let enc = proof.to_bytes();
+        assert!(!enc.is_empty());
+
+        let dec = RangeProof::from_bytes(&enc).expect("from_bytes");
+
+        assert_eq!(enc, dec.to_bytes());
+
+        assert!(
+            dec.verify(vec![&comm], vec![bits], &mut transcript_verify)
+                .is_ok()
+        );
+    }
+
+    #[test]
     fn test_range_proof_string() {
         let commitment_1_str = "dDaa/MTEDlyI0Nxx+iu1tOteZsTWmPXAfn9QI0W9mSc=";
         let pod_commitment_1 = PodPedersenCommitment::from_str(commitment_1_str).unwrap();

--- a/zk-sdk/src/range_proof/mod.rs
+++ b/zk-sdk/src/range_proof/mod.rs
@@ -584,10 +584,9 @@ mod tests {
 
         assert_eq!(enc, dec.to_bytes());
 
-        assert!(
-            dec.verify(vec![&comm], vec![bits], &mut transcript_verify)
-                .is_ok()
-        );
+        assert!(dec
+            .verify(vec![&comm], vec![bits], &mut transcript_verify)
+            .is_ok());
     }
 
     #[test]


### PR DESCRIPTION
#### Changes
- Add `range_proof_bytes_roundtrip` unit test in `range_proof::tests`.
- Generate a single proof for amount `42` with an `8`-bit range using existing APIs (`Pedersen::new`, `RangeProof::new`).
- Serialize with `to_bytes()`, deserialize with `from_bytes()`.
- Assert byte-level equality and successfully verify the deserialized proof against the original commitment using a consistent transcript label (`b"Test"`).
- Test-only change under `#[cfg(test)]`; no runtime, network, or consensus impact.