### PR TITLE
Make transcript module public

### DIFF
--- a/zk-sdk/src/lib.rs
+++ b/zk-sdk/src/lib.rs
@@ -25,7 +25,7 @@ pub mod pod;
 mod range_proof;
 mod sigma_proofs;
 #[cfg(not(target_os = "solana"))]
-mod transcript;
+pub mod transcript;
 pub mod zk_elgamal_proof_program;
 
 /// Byte length of a compressed Ristretto point or scalar in Curve255519


### PR DESCRIPTION
This would be quite helpful for projects like us / anyone needing to work with the lower level primitives inside this crate. Alternatively, this could also be done with a non-default feature gate like `crypto_primitives` or something like that if we want to keep the default API as simple as possible, happy to adapt this PR to that if so.