### PR TITLE
Add dependabot auto merge script

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,29 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: >
+      github.actor == 'dependabot[bot]' &&
+      github.repository_owner == 'solana-program' &&
+      !contains(github.event.pull_request.title, 'aes-gcm-siv') &&
+      !contains(github.event.pull_request.title, 'curve25519-dalek') &&
+      !contains(github.event.pull_request.title, 'sha3')
+
+    steps:
+      - name: Enable auto-merge for non-critical dependencies
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Summary of Changes

Now that the audit competition code freeze is over, I wanted to add the dependabot auto-merge script. I modeled the script over the one in [token-2022](https://github.com/solana-program/token-2022/blob/main/.github/workflows/dependabot-auto-merge.yml).

The only difference is that I added some exceptions for the auto-merge. For cryptography crates, we have to be careful about subtle breaking changes, so I made an explicit check to prevent auto merge on these crates.