### PR TITLE
[zk-sdk] Expand on backwards compatibility comment

### DIFF
--- a/zk-sdk/src/range_proof/mod.rs
+++ b/zk-sdk/src/range_proof/mod.rs
@@ -274,7 +274,7 @@ impl RangeProof {
         let G_factors: Vec<Scalar> = iter::repeat_n(Scalar::ONE, nm).collect();
         let H_factors: Vec<Scalar> = util::exp_iter(y.invert()).take(nm).collect();
 
-        // this variable exists for backwards compatibility
+        // compute challenge `c` for consistency with the verifier
         let _c = transcript.challenge_scalar(b"c");
 
         let ipp_proof = InnerProductProof::new(
@@ -354,7 +354,8 @@ impl RangeProof {
 
         let w = transcript.challenge_scalar(b"w");
 
-        // this variable exists for backwards compatibility
+        // The challenge `c` is a legacy component from an older implementation.
+        // It is now unused, but is kept here for backward compatibility.
         let _c = transcript.challenge_scalar(b"c");
 
         // 2. Compute the scalars for the verification equation.


### PR DESCRIPTION
#### Summary of Changes

I got a comment regarding the extra hashing of the transcript to get variable `c`. We already leave a comment that this is for backwards compatibility, but I expanded the comment just slightly. 

I considered expanding on why the variable `c` is not used any more, but this would require very lengthy explanation, so I think just a slight expansion suffices.