### PR TITLE
[zk-sdk] Remove `Debug` from private key materials

### DIFF
--- a/zk-sdk/src/encryption/auth_encryption.rs
+++ b/zk-sdk/src/encryption/auth_encryption.rs
@@ -78,7 +78,7 @@ impl AuthenticatedEncryption {
     }
 }
 
-#[derive(Clone, Debug, Zeroize, Eq, PartialEq)]
+#[derive(Clone, Zeroize, Eq, PartialEq)]
 pub struct AeKey([u8; AE_KEY_LEN]);
 
 impl AeKey {
@@ -146,6 +146,12 @@ impl AeKey {
 
     pub fn decrypt(&self, ciphertext: &AeCiphertext) -> Option<u64> {
         AuthenticatedEncryption::decrypt(self, ciphertext)
+    }
+}
+
+impl fmt::Debug for AeKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("AeKey").field(&"[REDACTED]").finish()
     }
 }
 

--- a/zk-sdk/src/encryption/elgamal.rs
+++ b/zk-sdk/src/encryption/elgamal.rs
@@ -136,7 +136,7 @@ impl ElGamal {
 /// A (twisted) ElGamal encryption keypair.
 ///
 /// The instances of the secret key are zeroized on drop.
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize, Zeroize)]
+#[derive(Clone, Deserialize, PartialEq, Eq, Serialize, Zeroize)]
 pub struct ElGamalKeypair {
     /// The public half of this keypair.
     public: ElGamalPubkey,
@@ -234,6 +234,15 @@ impl ElGamalKeypair {
         outfile: F,
     ) -> Result<String, Box<dyn std::error::Error>> {
         self.write_to_file(outfile)
+    }
+}
+
+impl fmt::Debug for ElGamalKeypair {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ElGamalKeypair")
+            .field("public", &self.public)
+            .field("secret", &"[REDACTED]")
+            .finish()
     }
 }
 
@@ -425,7 +434,7 @@ impl From<&ElGamalPubkey> for [u8; ELGAMAL_PUBKEY_LEN] {
 /// Secret key for the ElGamal encryption scheme.
 ///
 /// Instances of ElGamal secret key are zeroized on drop.
-#[derive(Clone, Debug, Deserialize, Serialize, Zeroize)]
+#[derive(Clone, Deserialize, Serialize, Zeroize)]
 #[zeroize(drop)]
 pub struct ElGamalSecretKey(Scalar);
 impl ElGamalSecretKey {
@@ -523,6 +532,14 @@ impl ElGamalSecretKey {
         let result = hasher.finalize();
 
         result.to_vec()
+    }
+}
+
+impl fmt::Debug for ElGamalSecretKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("ElGamalSecretKey")
+            .field(&"[REDACTED]")
+            .finish()
     }
 }
 

--- a/zk-sdk/src/encryption/pedersen.rs
+++ b/zk-sdk/src/encryption/pedersen.rs
@@ -12,7 +12,7 @@ use {
     rand::rngs::OsRng,
     serde::{Deserialize, Serialize},
     sha3::Sha3_512,
-    std::convert::TryInto,
+    std::{convert::TryInto, fmt},
     subtle::{Choice, ConstantTimeEq},
     zeroize::Zeroize,
 };
@@ -62,7 +62,7 @@ impl Pedersen {
 /// Pedersen opening type.
 ///
 /// Instances of Pedersen openings are zeroized on drop.
-#[derive(Clone, Debug, Default, Serialize, Deserialize, Zeroize)]
+#[derive(Clone, Default, Serialize, Deserialize, Zeroize)]
 #[zeroize(drop)]
 pub struct PedersenOpening(Scalar);
 
@@ -107,6 +107,14 @@ impl PartialEq for PedersenOpening {
 impl ConstantTimeEq for PedersenOpening {
     fn ct_eq(&self, other: &Self) -> Choice {
         self.0.ct_eq(&other.0)
+    }
+}
+
+impl fmt::Debug for PedersenOpening {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("PedersenOpening")
+            .field(&"[REDACTED]")
+            .finish()
     }
 }
 

--- a/zk-sdk/src/encryption/pedersen.rs
+++ b/zk-sdk/src/encryption/pedersen.rs
@@ -62,7 +62,7 @@ impl Pedersen {
 /// Pedersen opening type.
 ///
 /// Instances of Pedersen openings are zeroized on drop.
-#[derive(Clone, Default, Serialize, Deserialize, Zeroize)]
+#[derive(Clone, Default, Zeroize)]
 #[zeroize(drop)]
 pub struct PedersenOpening(Scalar);
 
@@ -344,16 +344,6 @@ mod tests {
         let decoded: PedersenCommitment = bincode::deserialize(&encoded).unwrap();
 
         assert_eq!(commitment, decoded);
-    }
-
-    #[test]
-    fn test_serde_pedersen_opening() {
-        let opening = PedersenOpening(Scalar::random(&mut OsRng));
-
-        let encoded = bincode::serialize(&opening).unwrap();
-        let decoded: PedersenOpening = bincode::deserialize(&encoded).unwrap();
-
-        assert_eq!(opening, decoded);
     }
 
     #[test]


### PR DESCRIPTION
#### Problem

Currently, private key materials automatically derive `Debug`. Though these key materials implement `#[zeroize(drop)]`, debugging create unprotected heap or string copies (for example, Vec<u8>, String, JSON) that Zeroize will not clear, and these copies can persist in process memory, logs, crash dumps, or files. 

#### Summary of Changes

Removed `Debug` from key materials.

I also removed `Serialize` and `Deserialize` for `PedersenOpening`. Ideally, we want to remove `Serialize` and `Deserialize` from all key types like `ElGamalKeypair`, but we use serialize traits for writing keys to JSON. `PedersenOpening` is a private type that we don't need to write to files, so I removed it.

Closes https://github.com/solana-program/zk-elgamal-proof/issues/84.