### PR TITLE
[zk-sdk] Deprecate `Pedersen::encode` function

### DIFF
--- a/zk-sdk/src/encryption/elgamal.rs
+++ b/zk-sdk/src/encryption/elgamal.rs
@@ -101,7 +101,21 @@ impl ElGamal {
     /// On input an amount, the function returns a twisted ElGamal ciphertext where the associated
     /// Pedersen opening is always zero. Since the opening is zero, any twisted ElGamal ciphertext
     /// of this form is a valid ciphertext under any ElGamal public key.
+    ///
+    /// # Warning
+    ///
+    /// This function produces a deterministic ciphertext by using a zero-value Pedersen opening.
+    /// This is **not** a confidential encryption. The resulting ciphertext is effectively a public
+    /// commitment to the value and is vulnerable to dictionary attacks for small amounts.
+    ///
+    /// It should only be used in contexts where the amount does not need to be kept secret.
+    /// For standard, confidential encryption, use `ElGamalPubkey::encrypt()`.
+    #[deprecated(
+        since = "4.1.0",
+        note = "This function is intended for internal use and will be removed from the public API in a future version."
+    )]
     pub fn encode<T: Into<Scalar>>(amount: T) -> ElGamalCiphertext {
+        #[allow(deprecated)]
         let commitment = Pedersen::encode(amount);
         let handle = DecryptHandle(RistrettoPoint::identity());
 
@@ -1147,6 +1161,7 @@ mod tests {
         let keypair2 = ElGamalKeypair::new_rand();
         let amount: u64 = 12345;
 
+        #[allow(deprecated)]
         let encoded_ciphertext = ElGamal::encode(amount);
 
         // ANY key should be able to "decrypt" the message

--- a/zk-sdk/src/encryption/pedersen.rs
+++ b/zk-sdk/src/encryption/pedersen.rs
@@ -54,6 +54,15 @@ impl Pedersen {
     /// as the opening.
     ///
     /// This function is deterministic.
+    ///
+    /// # Warning
+    ///
+    /// This function produces a deterministic commitment by using a fixed, zero-value opening.
+    /// This is **not** a hiding commitment. If the committed value is small, it may be
+    /// vulnerable to a dictionary attack (pre-computation of common values).
+    ///
+    /// This method should only be used in contexts where the committed value does not need to
+    /// be confidential. For a standard hiding commitment, use `Pedersen::new()`.
     pub fn encode<T: Into<Scalar>>(amount: T) -> PedersenCommitment {
         PedersenCommitment(amount.into() * &G)
     }

--- a/zk-sdk/src/encryption/pedersen.rs
+++ b/zk-sdk/src/encryption/pedersen.rs
@@ -381,6 +381,7 @@ mod tests {
         let commitment_with_zero = Pedersen::with(amount, &zero_opening);
 
         // Compare with the encode function
+        #[allow(deprecated)]
         let encoded_commitment = Pedersen::encode(amount);
 
         assert_eq!(encoded_commitment, commitment_with_zero);

--- a/zk-sdk/src/encryption/pedersen.rs
+++ b/zk-sdk/src/encryption/pedersen.rs
@@ -63,6 +63,10 @@ impl Pedersen {
     ///
     /// This method should only be used in contexts where the committed value does not need to
     /// be confidential. For a standard hiding commitment, use `Pedersen::new()`.
+    #[deprecated(
+        since = "4.1.0",
+        note = "This function is intended for internal use and will be removed from the public API in a future version."
+    )]
     pub fn encode<T: Into<Scalar>>(amount: T) -> PedersenCommitment {
         PedersenCommitment(amount.into() * &G)
     }


### PR DESCRIPTION
#### Problem

The `Pedersen::encode` and `ElGamal::encode` functions are convenience functions that generate Pedersen commitments and ElGamal ciphertexts. These functions are only used within the zk-sdk, but they are currently exposed as public functions. Ideally, their visibility should be updated to be `pub(crate)`.

#### Summary of Changes
I doubt any downstream projects are using these functions, but I deprecated these functions for now. In the next major version update (v5), I will convert these functions to `pub(crate)`.