### PR TITLE
[zk-sdk] Fix overly permissive account mutability in proof account in instruction generation

### DIFF
--- a/zk-sdk/src/zk_elgamal_proof_program/instruction.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/instruction.rs
@@ -526,12 +526,12 @@ impl ProofInstruction {
     ) -> Instruction {
         let accounts = if let Some(context_state_info) = context_state_info {
             vec![
-                AccountMeta::new(*proof_account, false),
+                AccountMeta::new_readonly(*proof_account, false),
                 AccountMeta::new(*context_state_info.context_state_account, false),
                 AccountMeta::new_readonly(*context_state_info.context_state_authority, false),
             ]
         } else {
-            vec![AccountMeta::new(*proof_account, false)]
+            vec![AccountMeta::new_readonly(*proof_account, false)]
         };
 
         let mut data = vec![ToPrimitive::to_u8(self).unwrap()];


### PR DESCRIPTION
#### Problem
In the zk-elgamal-proof program, when a proof is read from a proof account, it expects the proof account to be read-only. However, the proof instruction constructor function makes the proof account a writable account.

#### Summary of Changes

Make the proof account read-only.