### PR TITLE
[zk-sdk] Remove unnecessary generator input to discrete log

### DIFF
--- a/zk-sdk/src/encryption/elgamal.rs
+++ b/zk-sdk/src/encryption/elgamal.rs
@@ -125,8 +125,7 @@ impl ElGamal {
     /// The output of this function is of type `DiscreteLog`. To recover, the originally encrypted
     /// amount, use `DiscreteLog::decode`.
     fn decrypt(secret: &ElGamalSecretKey, ciphertext: &ElGamalCiphertext) -> DiscreteLog {
-        DiscreteLog::new(
-            G,
+        DiscreteLog::new_for_g(
             ciphertext.commitment.get_point() - &(&secret.0 * &ciphertext.handle.0),
         )
     }
@@ -873,7 +872,7 @@ mod tests {
         let amount: u32 = 57;
         let ciphertext = ElGamal::encrypt(public, amount);
 
-        let expected_instance = DiscreteLog::new(G, Scalar::from(amount) * &G);
+        let expected_instance = DiscreteLog::new_for_g(Scalar::from(amount) * &G);
 
         assert_eq!(expected_instance, ElGamal::decrypt(secret, &ciphertext));
         assert_eq!(57_u64, secret.decrypt_u32(&ciphertext).unwrap());
@@ -917,7 +916,7 @@ mod tests {
             handle: handle_1,
         };
 
-        let expected_instance = DiscreteLog::new(G, Scalar::from(amount) * &G);
+        let expected_instance = DiscreteLog::new_for_g(Scalar::from(amount) * &G);
 
         assert_eq!(expected_instance, secret_0.decrypt(&ciphertext_0));
         assert_eq!(expected_instance, secret_1.decrypt(&ciphertext_1));


### PR DESCRIPTION
#### Summary

This behavior is intentional: the DiscreteLog helper is engineered to work only with the Ristretto basepoint G (for performance and to reuse a single precomputation table). However, the current API accepts a generator parameter, which suggests arbitrary-generator support. That mismatch is a product-quality issue (foot-gun), not a cryptographic vulnerability. If callers pass a non-G generator, decode_u32() will still solve for x in x · G = target, likely yielding an incorrect result under the caller’s assumptions.
Technical Details

By design, the implementation is optimized for the basepoint G:
        Precomputation blob is for G only (DECODE_PRECOMPUTATION_FOR_G).
        Constructor sets step_point using G.
        Thread partitioning steps by G and adjusts starting_point by G.
        The generator field is currently unused in search logic.

Net effect: DiscreteLog::new(H, x·H) will decode as if relative to G, returning an x that is unrelated to the discrete log under H. The issue is the API implies generality while the implementation is deliberately specialized to G.
Impact

Classification: API misuse risk (not a security flaw by itself).
If a caller assumes arbitrary-generator support and supplies H (or another generator), the result will be incorrect but may look plausible, leading to downstream logical errors.
Within this codebase’s intended use (twisted ElGamal decode under G), behavior is consistent and performant.

#### Recommendation

Lean into the intended G-only design and remove the foot-gun:
Introduce a G-specific constructor, e.g. DiscreteLog::new_for_g(target) (or DiscreteLogG::new(target)), and deprecate new(generator, target).