### PR TITLE
[zk-sdk-wasm-js] Create wasm wrappers for the rest of the sigma proof types

### DIFF
--- a/zk-sdk-wasm-js/src/lib.rs
+++ b/zk-sdk-wasm-js/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg(target_arch = "wasm32")]
 
 pub mod encryption;
+pub mod proof_data;
 
 /// Simple macro for implementing conversion functions between wrapper types and
 /// wrapped types.

--- a/zk-sdk-wasm-js/src/proof_data/batched_grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk-wasm-js/src/proof_data/batched_grouped_ciphertext_validity/handles_2.rs
@@ -1,0 +1,264 @@
+use {
+    crate::encryption::{
+        elgamal::WasmElGamalPubkey, grouped_elgamal::WasmGroupedElGamalCiphertext2Handles,
+        pedersen::WasmPedersenOpening,
+    },
+    js_sys::Uint8Array,
+    solana_zk_sdk::zk_elgamal_proof_program::proof_data::{
+        batched_grouped_ciphertext_validity::{
+            BatchedGroupedCiphertext2HandlesValidityProofContext,
+            BatchedGroupedCiphertext2HandlesValidityProofData,
+        },
+        ZkProofData,
+    },
+    wasm_bindgen::prelude::*,
+};
+
+/// A batched grouped ciphertext validity proof with two decryption handles. This proof certifies
+/// the validity of two grouped ElGamal ciphertexts that are encrypted under the same public keys.
+#[wasm_bindgen(js_name = "BatchedGroupedCiphertext2HandlesValidityProof")]
+pub struct WasmBatchedGroupedCiphertext2HandlesValidityProofData {
+    pub(crate) inner: BatchedGroupedCiphertext2HandlesValidityProofData,
+}
+
+crate::conversion::impl_inner_conversion!(
+    WasmBatchedGroupedCiphertext2HandlesValidityProofData,
+    BatchedGroupedCiphertext2HandlesValidityProofData
+);
+
+#[wasm_bindgen]
+impl WasmBatchedGroupedCiphertext2HandlesValidityProofData {
+    /// Creates a new batched grouped ciphertext validity proof with two handles.
+    #[wasm_bindgen(constructor)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        first_pubkey: &WasmElGamalPubkey,
+        second_pubkey: &WasmElGamalPubkey,
+        grouped_ciphertext_lo: &WasmGroupedElGamalCiphertext2Handles,
+        grouped_ciphertext_hi: &WasmGroupedElGamalCiphertext2Handles,
+        amount_lo: u64,
+        amount_hi: u64,
+        opening_lo: &WasmPedersenOpening,
+        opening_hi: &WasmPedersenOpening,
+    ) -> Result<WasmBatchedGroupedCiphertext2HandlesValidityProofData, JsValue> {
+        BatchedGroupedCiphertext2HandlesValidityProofData::new(
+            &first_pubkey.inner,
+            &second_pubkey.inner,
+            &grouped_ciphertext_lo.inner,
+            &grouped_ciphertext_hi.inner,
+            amount_lo,
+            amount_hi,
+            &opening_lo.inner,
+            &opening_hi.inner,
+        )
+        .map(|inner| Self { inner })
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Returns the context data associated with the proof.
+    #[wasm_bindgen]
+    pub fn context(&self) -> WasmBatchedGroupedCiphertext2HandlesValidityProofContext {
+        self.inner.context.into()
+    }
+
+    /// Verifies the batched grouped ciphertext 2-handles validity proof.
+    /// Throws an error if the proof is invalid.
+    #[wasm_bindgen]
+    pub fn verify(&self) -> Result<(), JsValue> {
+        self.inner
+            .verify_proof()
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Deserializes a batched grouped ciphertext validity proof with two handles from a byte slice.
+    /// Throws an error if the bytes are invalid.
+    #[wasm_bindgen(js_name = "fromBytes")]
+    pub fn from_bytes(
+        bytes: &Uint8Array,
+    ) -> Result<WasmBatchedGroupedCiphertext2HandlesValidityProofData, JsValue> {
+        let expected_len = std::mem::size_of::<BatchedGroupedCiphertext2HandlesValidityProofData>();
+        if bytes.length() as usize != expected_len {
+            return Err(JsValue::from_str(&format!(
+                "Invalid byte length for BatchedGroupedCiphertext2HandlesValidityProof: expected {}, got {}",
+                expected_len,
+                bytes.length()
+            )));
+        }
+
+        let mut data = vec![0u8; expected_len];
+        bytes.copy_to(&mut data);
+
+        bytemuck::try_from_bytes(&data)
+            .map(|pod: &BatchedGroupedCiphertext2HandlesValidityProofData| Self { inner: *pod })
+            .map_err(|_| {
+                JsValue::from_str("Invalid bytes for BatchedGroupedCiphertext2HandlesValidityProof")
+            })
+    }
+
+    /// Serializes the batched grouped ciphertext validity proof with two handles to a byte array.
+    #[wasm_bindgen(js_name = "toBytes")]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bytemuck::bytes_of(&self.inner).to_vec()
+    }
+}
+
+/// The context data needed to verify a batched grouped ciphertext 2-handles validity proof.
+#[wasm_bindgen]
+pub struct WasmBatchedGroupedCiphertext2HandlesValidityProofContext {
+    pub(crate) inner: BatchedGroupedCiphertext2HandlesValidityProofContext,
+}
+
+crate::conversion::impl_inner_conversion!(
+    WasmBatchedGroupedCiphertext2HandlesValidityProofContext,
+    BatchedGroupedCiphertext2HandlesValidityProofContext
+);
+
+#[wasm_bindgen]
+impl WasmBatchedGroupedCiphertext2HandlesValidityProofContext {
+    /// Deserializes a batched grouped ciphertext 2-handles validity proof context from a byte slice.
+    /// Throws an error if the bytes are invalid.
+    #[wasm_bindgen(js_name = "fromBytes")]
+    pub fn from_bytes(
+        bytes: &Uint8Array,
+    ) -> Result<WasmBatchedGroupedCiphertext2HandlesValidityProofContext, JsValue> {
+        let expected_len =
+            std::mem::size_of::<BatchedGroupedCiphertext2HandlesValidityProofContext>();
+        if bytes.length() as usize != expected_len {
+            return Err(JsValue::from_str(&format!(
+                "Invalid byte length for BatchedGroupedCiphertext2HandlesValidityProofContext: expected {}, got {}",
+                expected_len,
+                bytes.length()
+            )));
+        }
+        let mut data = vec![0u8; expected_len];
+        bytes.copy_to(&mut data);
+        bytemuck::try_from_bytes(&data)
+            .map(|pod: &BatchedGroupedCiphertext2HandlesValidityProofContext| Self { inner: *pod })
+            .map_err(|_| {
+                JsValue::from_str(
+                    "Invalid bytes for BatchedGroupedCiphertext2HandlesValidityProofContext",
+                )
+            })
+    }
+
+    /// Serializes the batched grouped ciphertext 2-handles validity proof context to a byte array.
+    #[wasm_bindgen(js_name = "toBytes")]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bytemuck::bytes_of(&self.inner).to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*, crate::encryption::elgamal::WasmElGamalKeypair,
+        solana_zk_sdk::encryption::grouped_elgamal::GroupedElGamal, wasm_bindgen_test::*,
+    };
+
+    #[wasm_bindgen_test]
+    fn test_batched_grouped_ciphertext_2_handles_validity_proof_creation_and_verification() {
+        let first_keypair = WasmElGamalKeypair::new_rand();
+        let second_keypair = WasmElGamalKeypair::new_rand();
+        let amount_lo: u64 = 11;
+        let amount_hi: u64 = 22;
+        let opening_lo = WasmPedersenOpening::new_rand();
+        let opening_hi = WasmPedersenOpening::new_rand();
+
+        let grouped_ciphertext_lo = WasmGroupedElGamalCiphertext2Handles {
+            inner: GroupedElGamal::encrypt_with(
+                [
+                    &first_keypair.pubkey().inner,
+                    &second_keypair.pubkey().inner,
+                ],
+                amount_lo,
+                &opening_lo.inner,
+            ),
+        };
+
+        let grouped_ciphertext_hi = WasmGroupedElGamalCiphertext2Handles {
+            inner: GroupedElGamal::encrypt_with(
+                [
+                    &first_keypair.pubkey().inner,
+                    &second_keypair.pubkey().inner,
+                ],
+                amount_hi,
+                &opening_hi.inner,
+            ),
+        };
+
+        let proof = WasmBatchedGroupedCiphertext2HandlesValidityProofData::new(
+            &first_keypair.pubkey(),
+            &second_keypair.pubkey(),
+            &grouped_ciphertext_lo,
+            &grouped_ciphertext_hi,
+            amount_lo,
+            amount_hi,
+            &opening_lo,
+            &opening_hi,
+        )
+        .unwrap();
+
+        assert!(proof.verify().is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_batched_grouped_ciphertext_2_handles_validity_proof_bytes_roundtrip() {
+        let first_keypair = WasmElGamalKeypair::new_rand();
+        let second_keypair = WasmElGamalKeypair::new_rand();
+        let amount_lo: u64 = 11;
+        let amount_hi: u64 = 22;
+        let opening_lo = WasmPedersenOpening::new_rand();
+        let opening_hi = WasmPedersenOpening::new_rand();
+
+        let grouped_ciphertext_lo = WasmGroupedElGamalCiphertext2Handles {
+            inner: GroupedElGamal::encrypt_with(
+                [
+                    &first_keypair.pubkey().inner,
+                    &second_keypair.pubkey().inner,
+                ],
+                amount_lo,
+                &opening_lo.inner,
+            ),
+        };
+
+        let grouped_ciphertext_hi = WasmGroupedElGamalCiphertext2Handles {
+            inner: GroupedElGamal::encrypt_with(
+                [
+                    &first_keypair.pubkey().inner,
+                    &second_keypair.pubkey().inner,
+                ],
+                amount_hi,
+                &opening_hi.inner,
+            ),
+        };
+
+        let proof = WasmBatchedGroupedCiphertext2HandlesValidityProofData::new(
+            &first_keypair.pubkey(),
+            &second_keypair.pubkey(),
+            &grouped_ciphertext_lo,
+            &grouped_ciphertext_hi,
+            amount_lo,
+            amount_hi,
+            &opening_lo,
+            &opening_hi,
+        )
+        .unwrap();
+
+        let bytes = proof.to_bytes();
+        let recovered_proof = WasmBatchedGroupedCiphertext2HandlesValidityProofData::from_bytes(
+            &Uint8Array::from(bytes.as_slice()),
+        )
+        .unwrap();
+
+        assert_eq!(proof.to_bytes(), recovered_proof.to_bytes());
+
+        let context = proof.context();
+        let context_bytes = context.to_bytes();
+        let recovered_context =
+            WasmBatchedGroupedCiphertext2HandlesValidityProofContext::from_bytes(
+                &Uint8Array::from(context_bytes.as_slice()),
+            )
+            .unwrap();
+        assert_eq!(context_bytes, recovered_context.to_bytes());
+    }
+}

--- a/zk-sdk-wasm-js/src/proof_data/batched_grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk-wasm-js/src/proof_data/batched_grouped_ciphertext_validity/handles_3.rs
@@ -1,0 +1,274 @@
+use {
+    crate::encryption::{
+        elgamal::WasmElGamalPubkey, grouped_elgamal::WasmGroupedElGamalCiphertext3Handles,
+        pedersen::WasmPedersenOpening,
+    },
+    js_sys::Uint8Array,
+    solana_zk_sdk::zk_elgamal_proof_program::proof_data::{
+        batched_grouped_ciphertext_validity::{
+            BatchedGroupedCiphertext3HandlesValidityProofContext,
+            BatchedGroupedCiphertext3HandlesValidityProofData,
+        },
+        ZkProofData,
+    },
+    wasm_bindgen::prelude::*,
+};
+
+/// A batched grouped ciphertext validity proof with three decryption handles. This proof certifies
+/// the validity of two grouped ElGamal ciphertexts that are encrypted under the same public keys.
+#[wasm_bindgen(js_name = "BatchedGroupedCiphertext3HandlesValidityProof")]
+pub struct WasmBatchedGroupedCiphertext3HandlesValidityProofData {
+    pub(crate) inner: BatchedGroupedCiphertext3HandlesValidityProofData,
+}
+
+crate::conversion::impl_inner_conversion!(
+    WasmBatchedGroupedCiphertext3HandlesValidityProofData,
+    BatchedGroupedCiphertext3HandlesValidityProofData
+);
+
+#[wasm_bindgen]
+impl WasmBatchedGroupedCiphertext3HandlesValidityProofData {
+    /// Creates a new batched grouped ciphertext validity proof with three handles.
+    #[wasm_bindgen(constructor)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        first_pubkey: &WasmElGamalPubkey,
+        second_pubkey: &WasmElGamalPubkey,
+        third_pubkey: &WasmElGamalPubkey,
+        grouped_ciphertext_lo: &WasmGroupedElGamalCiphertext3Handles,
+        grouped_ciphertext_hi: &WasmGroupedElGamalCiphertext3Handles,
+        amount_lo: u64,
+        amount_hi: u64,
+        opening_lo: &WasmPedersenOpening,
+        opening_hi: &WasmPedersenOpening,
+    ) -> Result<WasmBatchedGroupedCiphertext3HandlesValidityProofData, JsValue> {
+        BatchedGroupedCiphertext3HandlesValidityProofData::new(
+            &first_pubkey.inner,
+            &second_pubkey.inner,
+            &third_pubkey.inner,
+            &grouped_ciphertext_lo.inner,
+            &grouped_ciphertext_hi.inner,
+            amount_lo,
+            amount_hi,
+            &opening_lo.inner,
+            &opening_hi.inner,
+        )
+        .map(|inner| Self { inner })
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Returns the context data associated with the proof.
+    #[wasm_bindgen]
+    pub fn context(&self) -> WasmBatchedGroupedCiphertext3HandlesValidityProofContext {
+        self.inner.context.into()
+    }
+
+    /// Verifies the batched grouped ciphertext 3-handles validity proof.
+    /// Throws an error if the proof is invalid.
+    #[wasm_bindgen]
+    pub fn verify(&self) -> Result<(), JsValue> {
+        self.inner
+            .verify_proof()
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Deserializes a batched grouped ciphertext validity proof with three handles from a byte slice.
+    /// Throws an error if the bytes are invalid.
+    #[wasm_bindgen(js_name = "fromBytes")]
+    pub fn from_bytes(
+        bytes: &Uint8Array,
+    ) -> Result<WasmBatchedGroupedCiphertext3HandlesValidityProofData, JsValue> {
+        let expected_len = std::mem::size_of::<BatchedGroupedCiphertext3HandlesValidityProofData>();
+        if bytes.length() as usize != expected_len {
+            return Err(JsValue::from_str(&format!(
+                "Invalid byte length for BatchedGroupedCiphertext3HandlesValidityProof: expected {}, got {}",
+                expected_len,
+                bytes.length()
+            )));
+        }
+
+        let mut data = vec![0u8; expected_len];
+        bytes.copy_to(&mut data);
+
+        bytemuck::try_from_bytes(&data)
+            .map(|pod: &BatchedGroupedCiphertext3HandlesValidityProofData| Self { inner: *pod })
+            .map_err(|_| {
+                JsValue::from_str("Invalid bytes for BatchedGroupedCiphertext3HandlesValidityProof")
+            })
+    }
+
+    /// Serializes the batched grouped ciphertext validity proof with three handles to a byte array.
+    #[wasm_bindgen(js_name = "toBytes")]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bytemuck::bytes_of(&self.inner).to_vec()
+    }
+}
+
+/// The context data needed to verify a batched grouped ciphertext 3-handles validity proof.
+#[wasm_bindgen]
+pub struct WasmBatchedGroupedCiphertext3HandlesValidityProofContext {
+    pub(crate) inner: BatchedGroupedCiphertext3HandlesValidityProofContext,
+}
+
+crate::conversion::impl_inner_conversion!(
+    WasmBatchedGroupedCiphertext3HandlesValidityProofContext,
+    BatchedGroupedCiphertext3HandlesValidityProofContext
+);
+
+#[wasm_bindgen]
+impl WasmBatchedGroupedCiphertext3HandlesValidityProofContext {
+    /// Deserializes a batched grouped ciphertext 3-handles validity proof context from a byte slice.
+    /// Throws an error if the bytes are invalid.
+    #[wasm_bindgen(js_name = "fromBytes")]
+    pub fn from_bytes(
+        bytes: &Uint8Array,
+    ) -> Result<WasmBatchedGroupedCiphertext3HandlesValidityProofContext, JsValue> {
+        let expected_len =
+            std::mem::size_of::<BatchedGroupedCiphertext3HandlesValidityProofContext>();
+        if bytes.length() as usize != expected_len {
+            return Err(JsValue::from_str(&format!(
+                "Invalid byte length for BatchedGroupedCiphertext3HandlesValidityProofContext: expected {}, got {}",
+                expected_len,
+                bytes.length()
+            )));
+        }
+        let mut data = vec![0u8; expected_len];
+        bytes.copy_to(&mut data);
+        bytemuck::try_from_bytes(&data)
+            .map(|pod: &BatchedGroupedCiphertext3HandlesValidityProofContext| Self { inner: *pod })
+            .map_err(|_| {
+                JsValue::from_str(
+                    "Invalid bytes for BatchedGroupedCiphertext3HandlesValidityProofContext",
+                )
+            })
+    }
+
+    /// Serializes the batched grouped ciphertext 3-handles validity proof context to a byte array.
+    #[wasm_bindgen(js_name = "toBytes")]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bytemuck::bytes_of(&self.inner).to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*, crate::encryption::elgamal::WasmElGamalKeypair,
+        solana_zk_sdk::encryption::grouped_elgamal::GroupedElGamal, wasm_bindgen_test::*,
+    };
+
+    #[wasm_bindgen_test]
+    fn test_batched_grouped_ciphertext_3_handles_validity_proof_creation_and_verification() {
+        let first_keypair = WasmElGamalKeypair::new_rand();
+        let second_keypair = WasmElGamalKeypair::new_rand();
+        let third_keypair = WasmElGamalKeypair::new_rand();
+        let amount_lo: u64 = 11;
+        let amount_hi: u64 = 22;
+        let opening_lo = WasmPedersenOpening::new_rand();
+        let opening_hi = WasmPedersenOpening::new_rand();
+
+        let grouped_ciphertext_lo = WasmGroupedElGamalCiphertext3Handles {
+            inner: GroupedElGamal::encrypt_with(
+                [
+                    &first_keypair.pubkey().inner,
+                    &second_keypair.pubkey().inner,
+                    &third_keypair.pubkey().inner,
+                ],
+                amount_lo,
+                &opening_lo.inner,
+            ),
+        };
+
+        let grouped_ciphertext_hi = WasmGroupedElGamalCiphertext3Handles {
+            inner: GroupedElGamal::encrypt_with(
+                [
+                    &first_keypair.pubkey().inner,
+                    &second_keypair.pubkey().inner,
+                    &third_keypair.pubkey().inner,
+                ],
+                amount_hi,
+                &opening_hi.inner,
+            ),
+        };
+
+        let proof = WasmBatchedGroupedCiphertext3HandlesValidityProofData::new(
+            &first_keypair.pubkey(),
+            &second_keypair.pubkey(),
+            &third_keypair.pubkey(),
+            &grouped_ciphertext_lo,
+            &grouped_ciphertext_hi,
+            amount_lo,
+            amount_hi,
+            &opening_lo,
+            &opening_hi,
+        )
+        .unwrap();
+
+        assert!(proof.verify().is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_batched_grouped_ciphertext_3_handles_validity_proof_bytes_roundtrip() {
+        let first_keypair = WasmElGamalKeypair::new_rand();
+        let second_keypair = WasmElGamalKeypair::new_rand();
+        let third_keypair = WasmElGamalKeypair::new_rand();
+        let amount_lo: u64 = 11;
+        let amount_hi: u64 = 22;
+        let opening_lo = WasmPedersenOpening::new_rand();
+        let opening_hi = WasmPedersenOpening::new_rand();
+
+        let grouped_ciphertext_lo = WasmGroupedElGamalCiphertext3Handles {
+            inner: GroupedElGamal::encrypt_with(
+                [
+                    &first_keypair.pubkey().inner,
+                    &second_keypair.pubkey().inner,
+                    &third_keypair.pubkey().inner,
+                ],
+                amount_lo,
+                &opening_lo.inner,
+            ),
+        };
+
+        let grouped_ciphertext_hi = WasmGroupedElGamalCiphertext3Handles {
+            inner: GroupedElGamal::encrypt_with(
+                [
+                    &first_keypair.pubkey().inner,
+                    &second_keypair.pubkey().inner,
+                    &third_keypair.pubkey().inner,
+                ],
+                amount_hi,
+                &opening_hi.inner,
+            ),
+        };
+
+        let proof = WasmBatchedGroupedCiphertext3HandlesValidityProofData::new(
+            &first_keypair.pubkey(),
+            &second_keypair.pubkey(),
+            &third_keypair.pubkey(),
+            &grouped_ciphertext_lo,
+            &grouped_ciphertext_hi,
+            amount_lo,
+            amount_hi,
+            &opening_lo,
+            &opening_hi,
+        )
+        .unwrap();
+
+        let bytes = proof.to_bytes();
+        let recovered_proof = WasmBatchedGroupedCiphertext3HandlesValidityProofData::from_bytes(
+            &Uint8Array::from(bytes.as_slice()),
+        )
+        .unwrap();
+
+        assert_eq!(proof.to_bytes(), recovered_proof.to_bytes());
+
+        let context = proof.context();
+        let context_bytes = context.to_bytes();
+        let recovered_context =
+            WasmBatchedGroupedCiphertext3HandlesValidityProofContext::from_bytes(
+                &Uint8Array::from(context_bytes.as_slice()),
+            )
+            .unwrap();
+        assert_eq!(context_bytes, recovered_context.to_bytes());
+    }
+}

--- a/zk-sdk-wasm-js/src/proof_data/batched_grouped_ciphertext_validity/mod.rs
+++ b/zk-sdk-wasm-js/src/proof_data/batched_grouped_ciphertext_validity/mod.rs
@@ -1,0 +1,13 @@
+mod handles_2;
+mod handles_3;
+
+pub use {
+    handles_2::{
+        WasmBatchedGroupedCiphertext2HandlesValidityProofContext,
+        WasmBatchedGroupedCiphertext2HandlesValidityProofData,
+    },
+    handles_3::{
+        WasmBatchedGroupedCiphertext3HandlesValidityProofContext,
+        WasmBatchedGroupedCiphertext3HandlesValidityProofData,
+    },
+};

--- a/zk-sdk-wasm-js/src/proof_data/ciphertext_ciphertext_equality.rs
+++ b/zk-sdk-wasm-js/src/proof_data/ciphertext_ciphertext_equality.rs
@@ -1,0 +1,214 @@
+use {
+    crate::encryption::{
+        elgamal::{WasmElGamalCiphertext, WasmElGamalKeypair, WasmElGamalPubkey},
+        pedersen::WasmPedersenOpening,
+    },
+    js_sys::Uint8Array,
+    solana_zk_sdk::zk_elgamal_proof_program::proof_data::{
+        ciphertext_ciphertext_equality::{
+            CiphertextCiphertextEqualityProofContext, CiphertextCiphertextEqualityProofData,
+        },
+        ZkProofData,
+    },
+    wasm_bindgen::prelude::*,
+};
+
+/// A ciphertext-ciphertext equality proof. This proof certifies that two ElGamal
+/// ciphertexts encrypt the same message.
+#[wasm_bindgen(js_name = "CiphertextCiphertextEqualityProof")]
+pub struct WasmCiphertextCiphertextEqualityProofData {
+    pub(crate) inner: CiphertextCiphertextEqualityProofData,
+}
+
+crate::conversion::impl_inner_conversion!(
+    WasmCiphertextCiphertextEqualityProofData,
+    CiphertextCiphertextEqualityProofData
+);
+
+#[wasm_bindgen]
+impl WasmCiphertextCiphertextEqualityProofData {
+    /// Creates a new ciphertext-ciphertext equality proof.
+    #[wasm_bindgen(constructor)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        first_keypair: &WasmElGamalKeypair,
+        second_pubkey: &WasmElGamalPubkey,
+        first_ciphertext: &WasmElGamalCiphertext,
+        second_ciphertext: &WasmElGamalCiphertext,
+        second_opening: &WasmPedersenOpening,
+        amount: u64,
+    ) -> Result<WasmCiphertextCiphertextEqualityProofData, JsValue> {
+        CiphertextCiphertextEqualityProofData::new(
+            &first_keypair.inner,
+            &second_pubkey.inner,
+            &first_ciphertext.inner,
+            &second_ciphertext.inner,
+            &second_opening.inner,
+            amount,
+        )
+        .map(|inner| Self { inner })
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Returns the context data associated with the proof.
+    #[wasm_bindgen]
+    pub fn context(&self) -> WasmCiphertextCiphertextEqualityProofContext {
+        self.inner.context.into()
+    }
+
+    /// Verifies the ciphertext-ciphertext equality proof.
+    /// Throws an error if the proof is invalid.
+    #[wasm_bindgen]
+    pub fn verify(&self) -> Result<(), JsValue> {
+        self.inner
+            .verify_proof()
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Deserializes a ciphertext-ciphertext equality proof from a byte slice.
+    /// Throws an error if the bytes are invalid.
+    #[wasm_bindgen(js_name = "fromBytes")]
+    pub fn from_bytes(
+        bytes: &Uint8Array,
+    ) -> Result<WasmCiphertextCiphertextEqualityProofData, JsValue> {
+        let expected_len = std::mem::size_of::<CiphertextCiphertextEqualityProofData>();
+        if bytes.length() as usize != expected_len {
+            return Err(JsValue::from_str(&format!(
+                "Invalid byte length for CiphertextCiphertextEqualityProof: expected {}, got {}",
+                expected_len,
+                bytes.length()
+            )));
+        }
+
+        let mut data = vec![0u8; expected_len];
+        bytes.copy_to(&mut data);
+
+        bytemuck::try_from_bytes(&data)
+            .map(|pod: &CiphertextCiphertextEqualityProofData| Self { inner: *pod })
+            .map_err(|_| JsValue::from_str("Invalid bytes for CiphertextCiphertextEqualityProof"))
+    }
+
+    /// Serializes the ciphertext-ciphertext equality proof to a byte array.
+    #[wasm_bindgen(js_name = "toBytes")]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bytemuck::bytes_of(&self.inner).to_vec()
+    }
+}
+
+/// The context data needed to verify a ciphertext-ciphertext equality proof.
+#[wasm_bindgen]
+pub struct WasmCiphertextCiphertextEqualityProofContext {
+    pub(crate) inner: CiphertextCiphertextEqualityProofContext,
+}
+
+crate::conversion::impl_inner_conversion!(
+    WasmCiphertextCiphertextEqualityProofContext,
+    CiphertextCiphertextEqualityProofContext
+);
+
+#[wasm_bindgen]
+impl WasmCiphertextCiphertextEqualityProofContext {
+    /// Deserializes a ciphertext-ciphertext equality proof context from a byte slice.
+    /// Throws an error if the bytes are invalid.
+    #[wasm_bindgen(js_name = "fromBytes")]
+    pub fn from_bytes(
+        bytes: &Uint8Array,
+    ) -> Result<WasmCiphertextCiphertextEqualityProofContext, JsValue> {
+        let expected_len = std::mem::size_of::<CiphertextCiphertextEqualityProofContext>();
+        if bytes.length() as usize != expected_len {
+            return Err(JsValue::from_str(&format!(
+                "Invalid byte length for CiphertextCiphertextEqualityProofContext: expected {}, got {}",
+                expected_len,
+                bytes.length()
+            )));
+        }
+        let mut data = vec![0u8; expected_len];
+        bytes.copy_to(&mut data);
+        bytemuck::try_from_bytes(&data)
+            .map(|pod: &CiphertextCiphertextEqualityProofContext| Self { inner: *pod })
+            .map_err(|_| {
+                JsValue::from_str("Invalid bytes for CiphertextCiphertextEqualityProofContext")
+            })
+    }
+
+    /// Serializes the ciphertext-ciphertext equality proof context to a byte array.
+    #[wasm_bindgen(js_name = "toBytes")]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bytemuck::bytes_of(&self.inner).to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, wasm_bindgen_test::*};
+
+    #[wasm_bindgen_test]
+    fn test_ciphertext_ciphertext_equality_proof_creation_and_verification() {
+        let first_keypair = WasmElGamalKeypair::new_rand();
+        let second_keypair = WasmElGamalKeypair::new_rand();
+        let amount: u64 = 55;
+
+        let first_ciphertext = first_keypair.pubkey().encrypt_u64(amount);
+        let second_opening = WasmPedersenOpening::new_rand();
+        let second_ciphertext = WasmElGamalCiphertext {
+            inner: second_keypair
+                .pubkey()
+                .inner
+                .encrypt_with(amount, &second_opening.inner),
+        };
+
+        let proof = WasmCiphertextCiphertextEqualityProofData::new(
+            &first_keypair,
+            &second_keypair.pubkey(),
+            &first_ciphertext,
+            &second_ciphertext,
+            &second_opening,
+            amount,
+        )
+        .unwrap();
+
+        assert!(proof.verify().is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_ciphertext_ciphertext_equality_proof_bytes_roundtrip() {
+        let first_keypair = WasmElGamalKeypair::new_rand();
+        let second_keypair = WasmElGamalKeypair::new_rand();
+        let amount: u64 = 55;
+
+        let first_ciphertext = first_keypair.pubkey().encrypt_u64(amount);
+        let second_opening = WasmPedersenOpening::new_rand();
+        let second_ciphertext = WasmElGamalCiphertext {
+            inner: second_keypair
+                .pubkey()
+                .inner
+                .encrypt_with(amount, &second_opening.inner),
+        };
+
+        let proof = WasmCiphertextCiphertextEqualityProofData::new(
+            &first_keypair,
+            &second_keypair.pubkey(),
+            &first_ciphertext,
+            &second_ciphertext,
+            &second_opening,
+            amount,
+        )
+        .unwrap();
+
+        let bytes = proof.to_bytes();
+        let recovered_proof = WasmCiphertextCiphertextEqualityProofData::from_bytes(
+            &Uint8Array::from(bytes.as_slice()),
+        )
+        .unwrap();
+
+        assert_eq!(proof.to_bytes(), recovered_proof.to_bytes());
+
+        let context = proof.context();
+        let context_bytes = context.to_bytes();
+        let recovered_context = WasmCiphertextCiphertextEqualityProofContext::from_bytes(
+            &Uint8Array::from(context_bytes.as_slice()),
+        )
+        .unwrap();
+        assert_eq!(context_bytes, recovered_context.to_bytes());
+    }
+}

--- a/zk-sdk-wasm-js/src/proof_data/ciphertext_commitment_equality.rs
+++ b/zk-sdk-wasm-js/src/proof_data/ciphertext_commitment_equality.rs
@@ -1,0 +1,198 @@
+use {
+    crate::encryption::{
+        elgamal::{WasmElGamalCiphertext, WasmElGamalKeypair, WasmElGamalPubkey},
+        pedersen::{WasmPedersenCommitment, WasmPedersenOpening},
+    },
+    js_sys::Uint8Array,
+    solana_zk_sdk::zk_elgamal_proof_program::proof_data::{
+        ciphertext_commitment_equality::{
+            CiphertextCommitmentEqualityProofContext, CiphertextCommitmentEqualityProofData,
+        },
+        ZkProofData,
+    },
+    wasm_bindgen::prelude::*,
+};
+
+/// A ciphertext-commitment equality proof. This proof certifies that an ElGamal
+/// ciphertext and a Pedersen commitment encrypt/encode the same message.
+#[wasm_bindgen(js_name = "CiphertextCommitmentEqualityProof")]
+pub struct WasmCiphertextCommitmentEqualityProofData {
+    pub(crate) inner: CiphertextCommitmentEqualityProofData,
+}
+
+crate::conversion::impl_inner_conversion!(
+    WasmCiphertextCommitmentEqualityProofData,
+    CiphertextCommitmentEqualityProofData
+);
+
+#[wasm_bindgen]
+impl WasmCiphertextCommitmentEqualityProofData {
+    /// Creates a new ciphertext-commitment equality proof.
+    #[wasm_bindgen(constructor)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        keypair: &WasmElGamalKeypair,
+        ciphertext: &WasmElGamalCiphertext,
+        commitment: &WasmPedersenCommitment,
+        opening: &WasmPedersenOpening,
+        amount: u64,
+    ) -> Result<WasmCiphertextCommitmentEqualityProofData, JsValue> {
+        CiphertextCommitmentEqualityProofData::new(
+            &keypair.inner,
+            &ciphertext.inner,
+            &commitment.inner,
+            &opening.inner,
+            amount,
+        )
+        .map(|inner| Self { inner })
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Returns the context data associated with the proof.
+    #[wasm_bindgen]
+    pub fn context(&self) -> WasmCiphertextCommitmentEqualityProofContext {
+        self.inner.context.into()
+    }
+
+    /// Verifies the ciphertext-commitment equality proof.
+    /// Throws an error if the proof is invalid.
+    #[wasm_bindgen]
+    pub fn verify(&self) -> Result<(), JsValue> {
+        self.inner
+            .verify_proof()
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Deserializes a ciphertext-commitment equality proof from a byte slice.
+    /// Throws an error if the bytes are invalid.
+    #[wasm_bindgen(js_name = "fromBytes")]
+    pub fn from_bytes(
+        bytes: &Uint8Array,
+    ) -> Result<WasmCiphertextCommitmentEqualityProofData, JsValue> {
+        let expected_len = std::mem::size_of::<CiphertextCommitmentEqualityProofData>();
+        if bytes.length() as usize != expected_len {
+            return Err(JsValue::from_str(&format!(
+                "Invalid byte length for CiphertextCommitmentEqualityProof: expected {}, got {}",
+                expected_len,
+                bytes.length()
+            )));
+        }
+
+        let mut data = vec![0u8; expected_len];
+        bytes.copy_to(&mut data);
+
+        bytemuck::try_from_bytes(&data)
+            .map(|pod: &CiphertextCommitmentEqualityProofData| Self { inner: *pod })
+            .map_err(|_| JsValue::from_str("Invalid bytes for CiphertextCommitmentEqualityProof"))
+    }
+
+    /// Serializes the ciphertext-commitment equality proof to a byte array.
+    #[wasm_bindgen(js_name = "toBytes")]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bytemuck::bytes_of(&self.inner).to_vec()
+    }
+}
+
+/// The context data needed to verify a ciphertext-commitment equality proof.
+#[wasm_bindgen]
+pub struct WasmCiphertextCommitmentEqualityProofContext {
+    pub(crate) inner: CiphertextCommitmentEqualityProofContext,
+}
+
+crate::conversion::impl_inner_conversion!(
+    WasmCiphertextCommitmentEqualityProofContext,
+    CiphertextCommitmentEqualityProofContext
+);
+
+#[wasm_bindgen]
+impl WasmCiphertextCommitmentEqualityProofContext {
+    /// Deserializes a ciphertext-commitment equality proof context from a byte slice.
+    /// Throws an error if the bytes are invalid.
+    #[wasm_bindgen(js_name = "fromBytes")]
+    pub fn from_bytes(
+        bytes: &Uint8Array,
+    ) -> Result<WasmCiphertextCommitmentEqualityProofContext, JsValue> {
+        let expected_len = std::mem::size_of::<CiphertextCommitmentEqualityProofContext>();
+        if bytes.length() as usize != expected_len {
+            return Err(JsValue::from_str(&format!(
+                "Invalid byte length for CiphertextCommitmentEqualityProofContext: expected {}, got {}",
+                expected_len,
+                bytes.length()
+            )));
+        }
+        let mut data = vec![0u8; expected_len];
+        bytes.copy_to(&mut data);
+        bytemuck::try_from_bytes(&data)
+            .map(|pod: &CiphertextCommitmentEqualityProofContext| Self { inner: *pod })
+            .map_err(|_| {
+                JsValue::from_str("Invalid bytes for CiphertextCommitmentEqualityProofContext")
+            })
+    }
+
+    /// Serializes the ciphertext-commitment equality proof context to a byte array.
+    #[wasm_bindgen(js_name = "toBytes")]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bytemuck::bytes_of(&self.inner).to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, wasm_bindgen_test::*};
+
+    #[wasm_bindgen_test]
+    fn test_ciphertext_commitment_equality_proof_creation_and_verification() {
+        let keypair = WasmElGamalKeypair::new_rand();
+        let amount: u64 = 55;
+
+        let ciphertext = keypair.pubkey().encrypt_u64(amount);
+        let opening = WasmPedersenOpening::new_rand();
+        let commitment = WasmPedersenCommitment::with_u64(amount, &opening);
+
+        let proof = WasmCiphertextCommitmentEqualityProofData::new(
+            &keypair,
+            &ciphertext,
+            &commitment,
+            &opening,
+            amount,
+        )
+        .unwrap();
+
+        assert!(proof.verify().is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_ciphertext_commitment_equality_proof_bytes_roundtrip() {
+        let keypair = WasmElGamalKeypair::new_rand();
+        let amount: u64 = 55;
+
+        let ciphertext = keypair.pubkey().encrypt_u64(amount);
+        let opening = WasmPedersenOpening::new_rand();
+        let commitment = WasmPedersenCommitment::with_u64(amount, &opening);
+
+        let proof = WasmCiphertextCommitmentEqualityProofData::new(
+            &keypair,
+            &ciphertext,
+            &commitment,
+            &opening,
+            amount,
+        )
+        .unwrap();
+
+        let bytes = proof.to_bytes();
+        let recovered_proof = WasmCiphertextCommitmentEqualityProofData::from_bytes(
+            &Uint8Array::from(bytes.as_slice()),
+        )
+        .unwrap();
+
+        assert_eq!(proof.to_bytes(), recovered_proof.to_bytes());
+
+        let context = proof.context();
+        let context_bytes = context.to_bytes();
+        let recovered_context = WasmCiphertextCommitmentEqualityProofContext::from_bytes(
+            &Uint8Array::from(context_bytes.as_slice()),
+        )
+        .unwrap();
+        assert_eq!(context_bytes, recovered_context.to_bytes());
+    }
+}

--- a/zk-sdk-wasm-js/src/proof_data/grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk-wasm-js/src/proof_data/grouped_ciphertext_validity/handles_2.rs
@@ -1,0 +1,221 @@
+use {
+    crate::encryption::{
+        elgamal::WasmElGamalPubkey, grouped_elgamal::WasmGroupedElGamalCiphertext2Handles,
+        pedersen::WasmPedersenOpening,
+    },
+    js_sys::Uint8Array,
+    solana_zk_sdk::zk_elgamal_proof_program::proof_data::{
+        grouped_ciphertext_validity::{
+            GroupedCiphertext2HandlesValidityProofContext,
+            GroupedCiphertext2HandlesValidityProofData,
+        },
+        ZkProofData,
+    },
+    wasm_bindgen::prelude::*,
+};
+
+/// A grouped ciphertext validity proof with two decryption handles. This proof certifies
+/// that a given grouped ElGamal ciphertext with two handles is well-formed.
+#[wasm_bindgen(js_name = "GroupedCiphertext2HandlesValidityProof")]
+pub struct WasmGroupedCiphertext2HandlesValidityProofData {
+    pub(crate) inner: GroupedCiphertext2HandlesValidityProofData,
+}
+
+crate::conversion::impl_inner_conversion!(
+    WasmGroupedCiphertext2HandlesValidityProofData,
+    GroupedCiphertext2HandlesValidityProofData
+);
+
+#[wasm_bindgen]
+impl WasmGroupedCiphertext2HandlesValidityProofData {
+    /// Creates a new grouped ciphertext validity proof with two handles.
+    #[wasm_bindgen(constructor)]
+    pub fn new(
+        first_pubkey: &WasmElGamalPubkey,
+        second_pubkey: &WasmElGamalPubkey,
+        grouped_ciphertext: &WasmGroupedElGamalCiphertext2Handles,
+        amount: u64,
+        opening: &WasmPedersenOpening,
+    ) -> Result<WasmGroupedCiphertext2HandlesValidityProofData, JsValue> {
+        GroupedCiphertext2HandlesValidityProofData::new(
+            &first_pubkey.inner,
+            &second_pubkey.inner,
+            &grouped_ciphertext.inner,
+            amount,
+            &opening.inner,
+        )
+        .map(|inner| Self { inner })
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Returns the context data associated with the proof.
+    #[wasm_bindgen]
+    pub fn context(&self) -> WasmGroupedCiphertext2HandlesValidityProofContext {
+        self.inner.context.into()
+    }
+
+    /// Verifies the grouped ciphertext 2-handles validity proof.
+    /// Throws an error if the proof is invalid.
+    #[wasm_bindgen]
+    pub fn verify(&self) -> Result<(), JsValue> {
+        self.inner
+            .verify_proof()
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Deserializes a grouped ciphertext validity proof with two handles from a byte slice.
+    /// Throws an error if the bytes are invalid.
+    #[wasm_bindgen(js_name = "fromBytes")]
+    pub fn from_bytes(
+        bytes: &Uint8Array,
+    ) -> Result<WasmGroupedCiphertext2HandlesValidityProofData, JsValue> {
+        let expected_len = std::mem::size_of::<GroupedCiphertext2HandlesValidityProofData>();
+        if bytes.length() as usize != expected_len {
+            return Err(JsValue::from_str(&format!(
+                "Invalid byte length for GroupedCiphertext2HandlesValidityProof: expected {}, got {}",
+                expected_len,
+                bytes.length()
+            )));
+        }
+
+        let mut data = vec![0u8; expected_len];
+        bytes.copy_to(&mut data);
+
+        bytemuck::try_from_bytes(&data)
+            .map(|pod: &GroupedCiphertext2HandlesValidityProofData| Self { inner: *pod })
+            .map_err(|_| {
+                JsValue::from_str("Invalid bytes for GroupedCiphertext2HandlesValidityProof")
+            })
+    }
+
+    /// Serializes the grouped ciphertext validity proof with two handles to a byte array.
+    #[wasm_bindgen(js_name = "toBytes")]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bytemuck::bytes_of(&self.inner).to_vec()
+    }
+}
+
+/// The context data needed to verify a grouped ciphertext 2-handles validity proof.
+#[wasm_bindgen]
+pub struct WasmGroupedCiphertext2HandlesValidityProofContext {
+    pub(crate) inner: GroupedCiphertext2HandlesValidityProofContext,
+}
+
+crate::conversion::impl_inner_conversion!(
+    WasmGroupedCiphertext2HandlesValidityProofContext,
+    GroupedCiphertext2HandlesValidityProofContext
+);
+
+#[wasm_bindgen]
+impl WasmGroupedCiphertext2HandlesValidityProofContext {
+    /// Deserializes a grouped ciphertext 2-handles validity proof context from a byte slice.
+    /// Throws an error if the bytes are invalid.
+    #[wasm_bindgen(js_name = "fromBytes")]
+    pub fn from_bytes(
+        bytes: &Uint8Array,
+    ) -> Result<WasmGroupedCiphertext2HandlesValidityProofContext, JsValue> {
+        let expected_len = std::mem::size_of::<GroupedCiphertext2HandlesValidityProofContext>();
+        if bytes.length() as usize != expected_len {
+            return Err(JsValue::from_str(&format!(
+                "Invalid byte length for GroupedCiphertext2HandlesValidityProofContext: expected {}, got {}",
+                expected_len,
+                bytes.length()
+            )));
+        }
+        let mut data = vec![0u8; expected_len];
+        bytes.copy_to(&mut data);
+        bytemuck::try_from_bytes(&data)
+            .map(|pod: &GroupedCiphertext2HandlesValidityProofContext| Self { inner: *pod })
+            .map_err(|_| {
+                JsValue::from_str("Invalid bytes for GroupedCiphertext2HandlesValidityProofContext")
+            })
+    }
+
+    /// Serializes the grouped ciphertext 2-handles validity proof context to a byte array.
+    #[wasm_bindgen(js_name = "toBytes")]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bytemuck::bytes_of(&self.inner).to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*, crate::encryption::elgamal::WasmElGamalKeypair,
+        solana_zk_sdk::encryption::grouped_elgamal::GroupedElGamal, wasm_bindgen_test::*,
+    };
+
+    #[wasm_bindgen_test]
+    fn test_grouped_ciphertext_2_handles_validity_proof_creation_and_verification() {
+        let first_keypair = WasmElGamalKeypair::new_rand();
+        let second_keypair = WasmElGamalKeypair::new_rand();
+        let amount: u64 = 55;
+        let opening = WasmPedersenOpening::new_rand();
+
+        let grouped_ciphertext = WasmGroupedElGamalCiphertext2Handles {
+            inner: GroupedElGamal::encrypt_with(
+                [
+                    &first_keypair.pubkey().inner,
+                    &second_keypair.pubkey().inner,
+                ],
+                amount,
+                &opening.inner,
+            ),
+        };
+
+        let proof = WasmGroupedCiphertext2HandlesValidityProofData::new(
+            &first_keypair.pubkey(),
+            &second_keypair.pubkey(),
+            &grouped_ciphertext,
+            amount,
+            &opening,
+        )
+        .unwrap();
+
+        assert!(proof.verify().is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_grouped_ciphertext_2_handles_validity_proof_bytes_roundtrip() {
+        let first_keypair = WasmElGamalKeypair::new_rand();
+        let second_keypair = WasmElGamalKeypair::new_rand();
+        let amount: u64 = 55;
+        let opening = WasmPedersenOpening::new_rand();
+
+        let grouped_ciphertext = WasmGroupedElGamalCiphertext2Handles {
+            inner: GroupedElGamal::encrypt_with(
+                [
+                    &first_keypair.pubkey().inner,
+                    &second_keypair.pubkey().inner,
+                ],
+                amount,
+                &opening.inner,
+            ),
+        };
+
+        let proof = WasmGroupedCiphertext2HandlesValidityProofData::new(
+            &first_keypair.pubkey(),
+            &second_keypair.pubkey(),
+            &grouped_ciphertext,
+            amount,
+            &opening,
+        )
+        .unwrap();
+
+        let bytes = proof.to_bytes();
+        let recovered_proof = WasmGroupedCiphertext2HandlesValidityProofData::from_bytes(
+            &Uint8Array::from(bytes.as_slice()),
+        )
+        .unwrap();
+
+        assert_eq!(proof.to_bytes(), recovered_proof.to_bytes());
+
+        let context = proof.context();
+        let context_bytes = context.to_bytes();
+        let recovered_context = WasmGroupedCiphertext2HandlesValidityProofContext::from_bytes(
+            &Uint8Array::from(context_bytes.as_slice()),
+        )
+        .unwrap();
+        assert_eq!(context_bytes, recovered_context.to_bytes());
+    }
+}

--- a/zk-sdk-wasm-js/src/proof_data/grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk-wasm-js/src/proof_data/grouped_ciphertext_validity/handles_3.rs
@@ -1,0 +1,230 @@
+use {
+    crate::encryption::{
+        elgamal::WasmElGamalPubkey, grouped_elgamal::WasmGroupedElGamalCiphertext3Handles,
+        pedersen::WasmPedersenOpening,
+    },
+    js_sys::Uint8Array,
+    solana_zk_sdk::zk_elgamal_proof_program::proof_data::{
+        grouped_ciphertext_validity::{
+            GroupedCiphertext3HandlesValidityProofContext,
+            GroupedCiphertext3HandlesValidityProofData,
+        },
+        ZkProofData,
+    },
+    wasm_bindgen::prelude::*,
+};
+
+/// A grouped ciphertext validity proof with three decryption handles. This proof certifies
+/// that a given grouped ElGamal ciphertext with three handles is well-formed.
+#[wasm_bindgen(js_name = "GroupedCiphertext3HandlesValidityProof")]
+pub struct WasmGroupedCiphertext3HandlesValidityProofData {
+    pub(crate) inner: GroupedCiphertext3HandlesValidityProofData,
+}
+
+crate::conversion::impl_inner_conversion!(
+    WasmGroupedCiphertext3HandlesValidityProofData,
+    GroupedCiphertext3HandlesValidityProofData
+);
+
+#[wasm_bindgen]
+impl WasmGroupedCiphertext3HandlesValidityProofData {
+    /// Creates a new grouped ciphertext validity proof with three handles.
+    #[wasm_bindgen(constructor)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        first_pubkey: &WasmElGamalPubkey,
+        second_pubkey: &WasmElGamalPubkey,
+        third_pubkey: &WasmElGamalPubkey,
+        grouped_ciphertext: &WasmGroupedElGamalCiphertext3Handles,
+        amount: u64,
+        opening: &WasmPedersenOpening,
+    ) -> Result<WasmGroupedCiphertext3HandlesValidityProofData, JsValue> {
+        GroupedCiphertext3HandlesValidityProofData::new(
+            &first_pubkey.inner,
+            &second_pubkey.inner,
+            &third_pubkey.inner,
+            &grouped_ciphertext.inner,
+            amount,
+            &opening.inner,
+        )
+        .map(|inner| Self { inner })
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Returns the context data associated with the proof.
+    #[wasm_bindgen]
+    pub fn context(&self) -> WasmGroupedCiphertext3HandlesValidityProofContext {
+        self.inner.context.into()
+    }
+
+    /// Verifies the grouped ciphertext 3-handles validity proof.
+    /// Throws an error if the proof is invalid.
+    #[wasm_bindgen]
+    pub fn verify(&self) -> Result<(), JsValue> {
+        self.inner
+            .verify_proof()
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Deserializes a grouped ciphertext validity proof with three handles from a byte slice.
+    /// Throws an error if the bytes are invalid.
+    #[wasm_bindgen(js_name = "fromBytes")]
+    pub fn from_bytes(
+        bytes: &Uint8Array,
+    ) -> Result<WasmGroupedCiphertext3HandlesValidityProofData, JsValue> {
+        let expected_len = std::mem::size_of::<GroupedCiphertext3HandlesValidityProofData>();
+        if bytes.length() as usize != expected_len {
+            return Err(JsValue::from_str(&format!(
+                "Invalid byte length for GroupedCiphertext3HandlesValidityProof: expected {}, got {}",
+                expected_len,
+                bytes.length()
+            )));
+        }
+
+        let mut data = vec![0u8; expected_len];
+        bytes.copy_to(&mut data);
+
+        bytemuck::try_from_bytes(&data)
+            .map(|pod: &GroupedCiphertext3HandlesValidityProofData| Self { inner: *pod })
+            .map_err(|_| {
+                JsValue::from_str("Invalid bytes for GroupedCiphertext3HandlesValidityProof")
+            })
+    }
+
+    /// Serializes the grouped ciphertext validity proof with three handles to a byte array.
+    #[wasm_bindgen(js_name = "toBytes")]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bytemuck::bytes_of(&self.inner).to_vec()
+    }
+}
+
+/// The context data needed to verify a grouped ciphertext 3-handles validity proof.
+#[wasm_bindgen]
+pub struct WasmGroupedCiphertext3HandlesValidityProofContext {
+    pub(crate) inner: GroupedCiphertext3HandlesValidityProofContext,
+}
+
+crate::conversion::impl_inner_conversion!(
+    WasmGroupedCiphertext3HandlesValidityProofContext,
+    GroupedCiphertext3HandlesValidityProofContext
+);
+
+#[wasm_bindgen]
+impl WasmGroupedCiphertext3HandlesValidityProofContext {
+    /// Deserializes a grouped ciphertext 3-handles validity proof context from a byte slice.
+    /// Throws an error if the bytes are invalid.
+    #[wasm_bindgen(js_name = "fromBytes")]
+    pub fn from_bytes(
+        bytes: &Uint8Array,
+    ) -> Result<WasmGroupedCiphertext3HandlesValidityProofContext, JsValue> {
+        let expected_len = std::mem::size_of::<GroupedCiphertext3HandlesValidityProofContext>();
+        if bytes.length() as usize != expected_len {
+            return Err(JsValue::from_str(&format!(
+                "Invalid byte length for GroupedCiphertext3HandlesValidityProofContext: expected {}, got {}",
+                expected_len,
+                bytes.length()
+            )));
+        }
+        let mut data = vec![0u8; expected_len];
+        bytes.copy_to(&mut data);
+        bytemuck::try_from_bytes(&data)
+            .map(|pod: &GroupedCiphertext3HandlesValidityProofContext| Self { inner: *pod })
+            .map_err(|_| {
+                JsValue::from_str("Invalid bytes for GroupedCiphertext3HandlesValidityProofContext")
+            })
+    }
+
+    /// Serializes the grouped ciphertext 3-handles validity proof context to a byte array.
+    #[wasm_bindgen(js_name = "toBytes")]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bytemuck::bytes_of(&self.inner).to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*, crate::encryption::elgamal::WasmElGamalKeypair,
+        solana_zk_sdk::encryption::grouped_elgamal::GroupedElGamal, wasm_bindgen_test::*,
+    };
+
+    #[wasm_bindgen_test]
+    fn test_grouped_ciphertext_3_handles_validity_proof_creation_and_verification() {
+        let first_keypair = WasmElGamalKeypair::new_rand();
+        let second_keypair = WasmElGamalKeypair::new_rand();
+        let third_keypair = WasmElGamalKeypair::new_rand();
+        let amount: u64 = 55;
+        let opening = WasmPedersenOpening::new_rand();
+
+        let grouped_ciphertext = WasmGroupedElGamalCiphertext3Handles {
+            inner: GroupedElGamal::encrypt_with(
+                [
+                    &first_keypair.pubkey().inner,
+                    &second_keypair.pubkey().inner,
+                    &third_keypair.pubkey().inner,
+                ],
+                amount,
+                &opening.inner,
+            ),
+        };
+
+        let proof = WasmGroupedCiphertext3HandlesValidityProofData::new(
+            &first_keypair.pubkey(),
+            &second_keypair.pubkey(),
+            &third_keypair.pubkey(),
+            &grouped_ciphertext,
+            amount,
+            &opening,
+        )
+        .unwrap();
+
+        assert!(proof.verify().is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_grouped_ciphertext_3_handles_validity_proof_bytes_roundtrip() {
+        let first_keypair = WasmElGamalKeypair::new_rand();
+        let second_keypair = WasmElGamalKeypair::new_rand();
+        let third_keypair = WasmElGamalKeypair::new_rand();
+        let amount: u64 = 55;
+        let opening = WasmPedersenOpening::new_rand();
+
+        let grouped_ciphertext = WasmGroupedElGamalCiphertext3Handles {
+            inner: GroupedElGamal::encrypt_with(
+                [
+                    &first_keypair.pubkey().inner,
+                    &second_keypair.pubkey().inner,
+                    &third_keypair.pubkey().inner,
+                ],
+                amount,
+                &opening.inner,
+            ),
+        };
+
+        let proof = WasmGroupedCiphertext3HandlesValidityProofData::new(
+            &first_keypair.pubkey(),
+            &second_keypair.pubkey(),
+            &third_keypair.pubkey(),
+            &grouped_ciphertext,
+            amount,
+            &opening,
+        )
+        .unwrap();
+
+        let bytes = proof.to_bytes();
+        let recovered_proof = WasmGroupedCiphertext3HandlesValidityProofData::from_bytes(
+            &Uint8Array::from(bytes.as_slice()),
+        )
+        .unwrap();
+
+        assert_eq!(proof.to_bytes(), recovered_proof.to_bytes());
+
+        let context = proof.context();
+        let context_bytes = context.to_bytes();
+        let recovered_context = WasmGroupedCiphertext3HandlesValidityProofContext::from_bytes(
+            &Uint8Array::from(context_bytes.as_slice()),
+        )
+        .unwrap();
+        assert_eq!(context_bytes, recovered_context.to_bytes());
+    }
+}

--- a/zk-sdk-wasm-js/src/proof_data/grouped_ciphertext_validity/mod.rs
+++ b/zk-sdk-wasm-js/src/proof_data/grouped_ciphertext_validity/mod.rs
@@ -1,0 +1,13 @@
+mod handles_2;
+mod handles_3;
+
+pub use {
+    handles_2::{
+        WasmGroupedCiphertext2HandlesValidityProofContext,
+        WasmGroupedCiphertext2HandlesValidityProofData,
+    },
+    handles_3::{
+        WasmGroupedCiphertext3HandlesValidityProofContext,
+        WasmGroupedCiphertext3HandlesValidityProofData,
+    },
+};

--- a/zk-sdk-wasm-js/src/proof_data/mod.rs
+++ b/zk-sdk-wasm-js/src/proof_data/mod.rs
@@ -1,0 +1,7 @@
+pub mod batched_grouped_ciphertext_validity;
+pub mod ciphertext_ciphertext_equality;
+pub mod ciphertext_commitment_equality;
+pub mod grouped_ciphertext_validity;
+pub mod percentage_with_cap;
+pub mod pubkey_validity;
+pub mod zero_ciphertext;

--- a/zk-sdk-wasm-js/src/proof_data/percentage_with_cap.rs
+++ b/zk-sdk-wasm-js/src/proof_data/percentage_with_cap.rs
@@ -1,0 +1,216 @@
+use {
+    crate::encryption::pedersen::{WasmPedersenCommitment, WasmPedersenOpening},
+    js_sys::Uint8Array,
+    solana_zk_sdk::zk_elgamal_proof_program::proof_data::{
+        percentage_with_cap::{PercentageWithCapProofContext, PercentageWithCapProofData},
+        ZkProofData,
+    },
+    wasm_bindgen::prelude::*,
+};
+
+/// A percentage-with-cap proof. This proof is used to certify that a transfer
+/// amount is within a certain percentage of a base amount, with a cap.
+#[wasm_bindgen(js_name = "PercentageWithCapProof")]
+pub struct WasmPercentageWithCapProofData {
+    pub(crate) inner: PercentageWithCapProofData,
+}
+
+crate::conversion::impl_inner_conversion!(
+    WasmPercentageWithCapProofData,
+    PercentageWithCapProofData
+);
+
+#[wasm_bindgen]
+impl WasmPercentageWithCapProofData {
+    /// Creates a new percentage-with-cap proof.
+    #[wasm_bindgen(constructor)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        percentage_commitment: &WasmPedersenCommitment,
+        percentage_opening: &WasmPedersenOpening,
+        percentage_amount: u64,
+        delta_commitment: &WasmPedersenCommitment,
+        delta_opening: &WasmPedersenOpening,
+        delta_amount: u64,
+        claimed_commitment: &WasmPedersenCommitment,
+        claimed_opening: &WasmPedersenOpening,
+        max_value: u64,
+    ) -> Result<WasmPercentageWithCapProofData, JsValue> {
+        PercentageWithCapProofData::new(
+            &percentage_commitment.inner,
+            &percentage_opening.inner,
+            percentage_amount,
+            &delta_commitment.inner,
+            &delta_opening.inner,
+            delta_amount,
+            &claimed_commitment.inner,
+            &claimed_opening.inner,
+            max_value,
+        )
+        .map(|inner| Self { inner })
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Returns the context data associated with the proof.
+    #[wasm_bindgen]
+    pub fn context(&self) -> WasmPercentageWithCapProofContext {
+        self.inner.context.into()
+    }
+
+    /// Verifies the percentage-with-cap proof.
+    /// Throws an error if the proof is invalid.
+    #[wasm_bindgen]
+    pub fn verify(&self) -> Result<(), JsValue> {
+        self.inner
+            .verify_proof()
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Deserializes a percentage-with-cap proof from a byte slice.
+    /// Throws an error if the bytes are invalid.
+    #[wasm_bindgen(js_name = "fromBytes")]
+    pub fn from_bytes(bytes: &Uint8Array) -> Result<WasmPercentageWithCapProofData, JsValue> {
+        let expected_len = std::mem::size_of::<PercentageWithCapProofData>();
+        if bytes.length() as usize != expected_len {
+            return Err(JsValue::from_str(&format!(
+                "Invalid byte length for PercentageWithCapProof: expected {}, got {}",
+                expected_len,
+                bytes.length()
+            )));
+        }
+
+        let mut data = vec![0u8; expected_len];
+        bytes.copy_to(&mut data);
+
+        bytemuck::try_from_bytes(&data)
+            .map(|pod: &PercentageWithCapProofData| Self { inner: *pod })
+            .map_err(|_| JsValue::from_str("Invalid bytes for PercentageWithCapProof"))
+    }
+
+    /// Serializes the percentage-with-cap proof to a byte array.
+    #[wasm_bindgen(js_name = "toBytes")]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bytemuck::bytes_of(&self.inner).to_vec()
+    }
+}
+
+/// The context data needed to verify a percentage-with-cap proof.
+#[wasm_bindgen]
+pub struct WasmPercentageWithCapProofContext {
+    pub(crate) inner: PercentageWithCapProofContext,
+}
+
+crate::conversion::impl_inner_conversion!(
+    WasmPercentageWithCapProofContext,
+    PercentageWithCapProofContext
+);
+
+#[wasm_bindgen]
+impl WasmPercentageWithCapProofContext {
+    /// Deserializes a percentage-with-cap proof context from a byte slice.
+    /// Throws an error if the bytes are invalid.
+    #[wasm_bindgen(js_name = "fromBytes")]
+    pub fn from_bytes(bytes: &Uint8Array) -> Result<WasmPercentageWithCapProofContext, JsValue> {
+        let expected_len = std::mem::size_of::<PercentageWithCapProofContext>();
+        if bytes.length() as usize != expected_len {
+            return Err(JsValue::from_str(&format!(
+                "Invalid byte length for PercentageWithCapProofContext: expected {}, got {}",
+                expected_len,
+                bytes.length()
+            )));
+        }
+        let mut data = vec![0u8; expected_len];
+        bytes.copy_to(&mut data);
+        bytemuck::try_from_bytes(&data)
+            .map(|pod: &PercentageWithCapProofContext| Self { inner: *pod })
+            .map_err(|_| JsValue::from_str("Invalid bytes for PercentageWithCapProofContext"))
+    }
+
+    /// Serializes the percentage-with-cap proof context to a byte array.
+    #[wasm_bindgen(js_name = "toBytes")]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bytemuck::bytes_of(&self.inner).to_vec()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, wasm_bindgen_test::*};
+
+    #[wasm_bindgen_test]
+    fn test_percentage_with_cap_proof_creation_and_verification() {
+        let percentage_amount: u64 = 1;
+        let delta_amount: u64 = 9600;
+        let max_value: u64 = 3;
+
+        let percentage_opening = WasmPedersenOpening::new_rand();
+        let percentage_commitment =
+            WasmPedersenCommitment::with_u64(percentage_amount, &percentage_opening);
+
+        let delta_opening = WasmPedersenOpening::new_rand();
+        let delta_commitment = WasmPedersenCommitment::with_u64(delta_amount, &delta_opening);
+
+        let claimed_opening = WasmPedersenOpening::new_rand();
+        let claimed_commitment = WasmPedersenCommitment::with_u64(delta_amount, &claimed_opening);
+
+        let proof = WasmPercentageWithCapProofData::new(
+            &percentage_commitment,
+            &percentage_opening,
+            percentage_amount,
+            &delta_commitment,
+            &delta_opening,
+            delta_amount,
+            &claimed_commitment,
+            &claimed_opening,
+            max_value,
+        )
+        .unwrap();
+
+        assert!(proof.verify().is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_percentage_with_cap_proof_bytes_roundtrip() {
+        let percentage_amount: u64 = 1;
+        let delta_amount: u64 = 9600;
+        let max_value: u64 = 3;
+
+        let percentage_opening = WasmPedersenOpening::new_rand();
+        let percentage_commitment =
+            WasmPedersenCommitment::with_u64(percentage_amount, &percentage_opening);
+
+        let delta_opening = WasmPedersenOpening::new_rand();
+        let delta_commitment = WasmPedersenCommitment::with_u64(delta_amount, &delta_opening);
+
+        let claimed_opening = WasmPedersenOpening::new_rand();
+        let claimed_commitment = WasmPedersenCommitment::with_u64(delta_amount, &claimed_opening);
+
+        let proof = WasmPercentageWithCapProofData::new(
+            &percentage_commitment,
+            &percentage_opening,
+            percentage_amount,
+            &delta_commitment,
+            &delta_opening,
+            delta_amount,
+            &claimed_commitment,
+            &claimed_opening,
+            max_value,
+        )
+        .unwrap();
+
+        let bytes = proof.to_bytes();
+        let recovered_proof =
+            WasmPercentageWithCapProofData::from_bytes(&Uint8Array::from(bytes.as_slice()))
+                .unwrap();
+
+        assert_eq!(proof.to_bytes(), recovered_proof.to_bytes());
+
+        let context = proof.context();
+        let context_bytes = context.to_bytes();
+        let recovered_context = WasmPercentageWithCapProofContext::from_bytes(&Uint8Array::from(
+            context_bytes.as_slice(),
+        ))
+        .unwrap();
+        assert_eq!(context_bytes, recovered_context.to_bytes());
+    }
+}

--- a/zk-sdk-wasm-js/src/proof_data/pubkey_validity.rs
+++ b/zk-sdk-wasm-js/src/proof_data/pubkey_validity.rs
@@ -1,6 +1,10 @@
 use {
-    crate::elgamal_wasm::WasmElGamalKeypair, js_sys::Uint8Array,
-    solana_zk_sdk::zk_elgamal_proof_program::proof_data::pubkey_validity::PubkeyValidityProofData,
+    crate::encryption::elgamal::{WasmElGamalKeypair, WasmElGamalPubkey},
+    js_sys::Uint8Array,
+    solana_zk_sdk::zk_elgamal_proof_program::proof_data::{
+        pubkey_validity::{PubkeyValidityProofContext, PubkeyValidityProofData},
+        ZkProofData,
+    },
     wasm_bindgen::prelude::*,
 };
 
@@ -20,6 +24,21 @@ impl WasmPubkeyValidityProofData {
     pub fn new(keypair: &WasmElGamalKeypair) -> Result<WasmPubkeyValidityProofData, JsValue> {
         PubkeyValidityProofData::new(&keypair.inner)
             .map(|inner| Self { inner })
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Returns the context data associated with the proof.
+    #[wasm_bindgen]
+    pub fn context(&self) -> WasmPubkeyValidityProofContext {
+        self.inner.context.into()
+    }
+
+    /// Verifies the public-key validity proof.
+    /// Throws an error if the proof is invalid.
+    #[wasm_bindgen]
+    pub fn verify(&self) -> Result<(), JsValue> {
+        self.inner
+            .verify_proof()
             .map_err(|e| JsValue::from_str(&e.to_string()))
     }
 
@@ -51,15 +70,54 @@ impl WasmPubkeyValidityProofData {
     }
 }
 
+/// The context data needed to verify a public-key validity proof.
+#[wasm_bindgen]
+pub struct WasmPubkeyValidityProofContext {
+    pub(crate) inner: PubkeyValidityProofContext,
+}
+
+crate::conversion::impl_inner_conversion!(
+    WasmPubkeyValidityProofContext,
+    PubkeyValidityProofContext
+);
+
+#[wasm_bindgen]
+impl WasmPubkeyValidityProofContext {
+    /// Deserializes a public-key validity proof context from a byte slice.
+    /// Throws an error if the bytes are invalid.
+    #[wasm_bindgen(js_name = "fromBytes")]
+    pub fn from_bytes(bytes: &Uint8Array) -> Result<WasmPubkeyValidityProofContext, JsValue> {
+        let expected_len = std::mem::size_of::<PubkeyValidityProofContext>();
+        if bytes.length() as usize != expected_len {
+            return Err(JsValue::from_str(&format!(
+                "Invalid byte length for PubkeyValidityProofContext: expected {}, got {}",
+                expected_len,
+                bytes.length()
+            )));
+        }
+        let mut data = vec![0u8; expected_len];
+        bytes.copy_to(&mut data);
+        bytemuck::try_from_bytes(&data)
+            .map(|pod: &PubkeyValidityProofContext| Self { inner: *pod })
+            .map_err(|_| JsValue::from_str("Invalid bytes for PubkeyValidityProofContext"))
+    }
+
+    /// Serializes the public-key validity proof context to a byte array.
+    #[wasm_bindgen(js_name = "toBytes")]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bytemuck::bytes_of(&self.inner).to_vec()
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::elgamal_wasm::WasmElGamalKeypair, wasm_bindgen_test::*};
+    use {super::*, wasm_bindgen_test::*};
 
     #[wasm_bindgen_test]
-    fn test_pubkey_validity_proof_creation() {
+    fn test_pubkey_validity_proof_creation_and_verification() {
         let keypair = WasmElGamalKeypair::new_rand();
-        let proof = WasmPubkeyValidityProofData::new(&keypair);
-        assert!(proof.is_ok());
+        let proof = WasmPubkeyValidityProofData::new(&keypair).unwrap();
+        assert!(proof.verify().is_ok());
     }
 
     #[wasm_bindgen_test]
@@ -72,5 +130,12 @@ mod tests {
             WasmPubkeyValidityProofData::from_bytes(&Uint8Array::from(bytes.as_slice())).unwrap();
 
         assert_eq!(proof.to_bytes(), recovered_proof.to_bytes());
+
+        let context = proof.context();
+        let context_bytes = context.to_bytes();
+        let recovered_context =
+            WasmPubkeyValidityProofContext::from_bytes(&Uint8Array::from(context_bytes.as_slice()))
+                .unwrap();
+        assert_eq!(context_bytes, recovered_context.to_bytes());
     }
 }

--- a/zk-sdk-wasm-js/src/proof_data/zero_ciphertext.rs
+++ b/zk-sdk-wasm-js/src/proof_data/zero_ciphertext.rs
@@ -1,7 +1,10 @@
 use {
-    crate::elgamal_wasm::{WasmElGamalCiphertext, WasmElGamalKeypair},
+    crate::encryption::elgamal::{WasmElGamalCiphertext, WasmElGamalKeypair, WasmElGamalPubkey},
     js_sys::Uint8Array,
-    solana_zk_sdk::zk_elgamal_proof_program::proof_data::zero_ciphertext::ZeroCiphertextProofData,
+    solana_zk_sdk::zk_elgamal_proof_program::proof_data::{
+        zero_ciphertext::{ZeroCiphertextProofContext, ZeroCiphertextProofData},
+        ZkProofData,
+    },
     wasm_bindgen::prelude::*,
 };
 
@@ -24,6 +27,21 @@ impl WasmZeroCiphertextProofData {
     ) -> Result<WasmZeroCiphertextProofData, JsValue> {
         ZeroCiphertextProofData::new(&keypair.inner, &ciphertext.inner)
             .map(|inner| Self { inner })
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Returns the context data associated with the proof.
+    #[wasm_bindgen]
+    pub fn context(&self) -> WasmZeroCiphertextProofContext {
+        self.inner.context.into()
+    }
+
+    /// Verifies the zero-ciphertext proof.
+    /// Throws an error if the proof is invalid.
+    #[wasm_bindgen]
+    pub fn verify(&self) -> Result<(), JsValue> {
+        self.inner
+            .verify_proof()
             .map_err(|e| JsValue::from_str(&e.to_string()))
     }
 
@@ -55,28 +73,62 @@ impl WasmZeroCiphertextProofData {
     }
 }
 
+/// The context data needed to verify a zero-ciphertext proof.
+#[wasm_bindgen]
+pub struct WasmZeroCiphertextProofContext {
+    pub(crate) inner: ZeroCiphertextProofContext,
+}
+
+crate::conversion::impl_inner_conversion!(
+    WasmZeroCiphertextProofContext,
+    ZeroCiphertextProofContext
+);
+
+#[wasm_bindgen]
+impl WasmZeroCiphertextProofContext {
+    /// Deserializes a zero-ciphertext proof context from a byte slice.
+    /// Throws an error if the bytes are invalid.
+    #[wasm_bindgen(js_name = "fromBytes")]
+    pub fn from_bytes(bytes: &Uint8Array) -> Result<WasmZeroCiphertextProofContext, JsValue> {
+        let expected_len = std::mem::size_of::<ZeroCiphertextProofContext>();
+        if bytes.length() as usize != expected_len {
+            return Err(JsValue::from_str(&format!(
+                "Invalid byte length for ZeroCiphertextProofContext: expected {}, got {}",
+                expected_len,
+                bytes.length()
+            )));
+        }
+        let mut data = vec![0u8; expected_len];
+        bytes.copy_to(&mut data);
+        bytemuck::try_from_bytes(&data)
+            .map(|pod: &ZeroCiphertextProofContext| Self { inner: *pod })
+            .map_err(|_| JsValue::from_str("Invalid bytes for ZeroCiphertextProofContext"))
+    }
+
+    /// Serializes the zero-ciphertext proof context to a byte array.
+    #[wasm_bindgen(js_name = "toBytes")]
+    pub fn to_bytes(&self) -> Vec<u8> {
+        bytemuck::bytes_of(&self.inner).to_vec()
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use {
-        super::*,
-        crate::elgamal_wasm::{WasmElGamalCiphertext, WasmElGamalKeypair},
-        wasm_bindgen_test::*,
-    };
+    use {super::*, wasm_bindgen_test::*};
 
     #[wasm_bindgen_test]
-    fn test_zero_ciphertext_proof_creation() {
+    fn test_zero_ciphertext_proof_creation_and_verification() {
         let keypair = WasmElGamalKeypair::new_rand();
 
         // Proof for a valid encryption of 0
         let zero_ciphertext = keypair.pubkey().encrypt_u64(0);
-        let proof_valid = WasmZeroCiphertextProofData::new(&keypair, &zero_ciphertext);
-        assert!(proof_valid.is_ok());
+        let proof_valid = WasmZeroCiphertextProofData::new(&keypair, &zero_ciphertext).unwrap();
+        assert!(proof_valid.verify().is_ok());
 
         // Proof for an invalid encryption of 1
         let one_ciphertext = keypair.pubkey().encrypt_u64(1);
-        let proof_invalid = WasmZeroCiphertextProofData::new(&keypair, &one_ciphertext);
-        // The proof generation itself is valid, but verification would fail on-chain.
-        assert!(proof_invalid.is_ok());
+        let proof_invalid = WasmZeroCiphertextProofData::new(&keypair, &one_ciphertext).unwrap();
+        assert!(proof_invalid.verify().is_err());
     }
 
     #[wasm_bindgen_test]
@@ -90,5 +142,12 @@ mod tests {
             WasmZeroCiphertextProofData::from_bytes(&Uint8Array::from(bytes.as_slice())).unwrap();
 
         assert_eq!(proof.to_bytes(), recovered_proof.to_bytes());
+
+        let context = proof.context();
+        let context_bytes = context.to_bytes();
+        let recovered_context =
+            WasmZeroCiphertextProofContext::from_bytes(&Uint8Array::from(context_bytes.as_slice()))
+                .unwrap();
+        assert_eq!(context_bytes, recovered_context.to_bytes());
     }
 }


### PR DESCRIPTION
#### Summary of Changes

This is a follow-up to https://github.com/solana-program/zk-elgamal-proof/pull/128. All the encryption types that we want to export out to wasm was added in https://github.com/solana-program/zk-elgamal-proof/pull/78 and https://github.com/solana-program/zk-elgamal-proof/pull/128. What remains are sigma proof types and range proof types.

I was thinking of adding wrapper types for both sigma proof types and range proof types in this PR. It seemed like there are some non-trivial design choices for creating wrapper types for range proof, so I decided to focus on sigma proofs in this PR for now.

I apologize for committing in a lot of code, but most of the code is quite repetitive and mechanical.
- I created wrapper types for the proof data type and the proof context type.
- Added proof generation and verification functions for the proof data
- Added basic functions for serializing and deserializing for the context type