### PR TITLE
[zk-sdk-wasm-js] Rename `Wasm*` types to just their normal names

### DIFF
--- a/zk-sdk-wasm-js/src/encryption/auth_encryption.rs
+++ b/zk-sdk-wasm-js/src/encryption/auth_encryption.rs
@@ -1,32 +1,29 @@
 use {
     js_sys::Uint8Array,
-    solana_zk_sdk::encryption::{
-        auth_encryption::{AeCiphertext, AeKey},
-        AE_CIPHERTEXT_LEN, AE_KEY_LEN,
-    },
+    solana_zk_sdk::encryption::{auth_encryption, AE_CIPHERTEXT_LEN, AE_KEY_LEN},
     wasm_bindgen::prelude::{wasm_bindgen, JsValue},
 };
 
-#[wasm_bindgen(js_name = "AeKey")]
-pub struct WasmAeKey {
-    pub(crate) inner: AeKey,
+#[wasm_bindgen]
+pub struct AeKey {
+    pub(crate) inner: auth_encryption::AeKey,
 }
 
-crate::conversion::impl_inner_conversion!(WasmAeKey, AeKey);
+crate::conversion::impl_inner_conversion!(AeKey, auth_encryption::AeKey);
 
 #[wasm_bindgen]
-impl WasmAeKey {
+impl AeKey {
     /// Creates a new, random authenticated encryption key.
     #[wasm_bindgen(constructor)]
     pub fn new_rand() -> Self {
         Self {
-            inner: AeKey::new_rand(),
+            inner: auth_encryption::AeKey::new_rand(),
         }
     }
 
     /// Deserializes an AeKey from a byte slice.
     #[wasm_bindgen(js_name = "fromBytes")]
-    pub fn from_bytes(uint8_array: Uint8Array) -> Result<WasmAeKey, JsValue> {
+    pub fn from_bytes(uint8_array: Uint8Array) -> Result<AeKey, JsValue> {
         if uint8_array.length() as usize != AE_KEY_LEN {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for AeKey: expected {}, got {}",
@@ -38,7 +35,7 @@ impl WasmAeKey {
         let mut bytes = [0u8; AE_KEY_LEN];
         uint8_array.copy_to(&mut bytes);
 
-        AeKey::try_from(bytes.as_ref())
+        auth_encryption::AeKey::try_from(bytes.as_ref())
             .map(|inner| Self { inner })
             .map_err(|e| JsValue::from_str(&e.to_string()))
     }
@@ -55,13 +52,13 @@ impl WasmAeKey {
 
     /// Encrypts a 64-bit amount.
     #[wasm_bindgen]
-    pub fn encrypt(&self, amount: u64) -> WasmAeCiphertext {
+    pub fn encrypt(&self, amount: u64) -> AeCiphertext {
         self.inner.encrypt(amount).into()
     }
 
     /// Decrypts a ciphertext. Returns the amount if successful, otherwise `undefined`.
     #[wasm_bindgen]
-    pub fn decrypt(&self, ciphertext: &WasmAeCiphertext) -> Result<u64, JsValue> {
+    pub fn decrypt(&self, ciphertext: &AeCiphertext) -> Result<u64, JsValue> {
         self.inner.decrypt(&ciphertext.inner).ok_or_else(|| {
             JsValue::from_str(
                 "Decryption failed: The ciphertext may be tampered or the key incorrect.",
@@ -70,18 +67,18 @@ impl WasmAeKey {
     }
 }
 
-#[wasm_bindgen(js_name = "AeCiphertext")]
-pub struct WasmAeCiphertext {
-    pub(crate) inner: AeCiphertext,
+#[wasm_bindgen]
+pub struct AeCiphertext {
+    pub(crate) inner: auth_encryption::AeCiphertext,
 }
 
-crate::conversion::impl_inner_conversion!(WasmAeCiphertext, AeCiphertext);
+crate::conversion::impl_inner_conversion!(AeCiphertext, auth_encryption::AeCiphertext);
 
 #[wasm_bindgen]
-impl WasmAeCiphertext {
+impl AeCiphertext {
     /// Deserializes an AeCiphertext from a byte slice.
     #[wasm_bindgen(js_name = "fromBytes")]
-    pub fn from_bytes(uint8_array: Uint8Array) -> Option<WasmAeCiphertext> {
+    pub fn from_bytes(uint8_array: Uint8Array) -> Option<AeCiphertext> {
         if uint8_array.length() as usize != AE_CIPHERTEXT_LEN {
             return None;
         }
@@ -89,7 +86,7 @@ impl WasmAeCiphertext {
         let mut bytes = [0u8; AE_CIPHERTEXT_LEN];
         uint8_array.copy_to(&mut bytes);
 
-        AeCiphertext::from_bytes(&bytes).map(|inner| Self { inner })
+        auth_encryption::AeCiphertext::from_bytes(&bytes).map(|inner| Self { inner })
     }
 
     /// Serializes the AeCiphertext to a byte array.
@@ -100,7 +97,7 @@ impl WasmAeCiphertext {
 
     /// Decrypts the ciphertext. Returns the amount if successful, otherwise `undefined`.
     #[wasm_bindgen]
-    pub fn decrypt(&self, key: &WasmAeKey) -> Option<u64> {
+    pub fn decrypt(&self, key: &AeKey) -> Option<u64> {
         self.inner.decrypt(key)
     }
 }
@@ -111,24 +108,24 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_ae_key_roundtrip() {
-        let key = WasmAeKey::new_rand();
+        let key = AeKey::new_rand();
         let key_bytes = key.to_bytes();
         assert_eq!(key_bytes.len(), 16);
-        let recovered_key = WasmAeKey::from_bytes(Uint8Array::from(key_bytes.as_slice())).unwrap();
+        let recovered_key = AeKey::from_bytes(Uint8Array::from(key_bytes.as_slice())).unwrap();
         assert_eq!(key.inner, recovered_key.inner);
     }
 
     #[wasm_bindgen_test]
     fn test_from_bytes_with_invalid_key() {
         let short_bytes = vec![0; 15];
-        assert!(WasmAeKey::from_bytes(Uint8Array::from(short_bytes.as_slice())).is_err());
+        assert!(AeKey::from_bytes(Uint8Array::from(short_bytes.as_slice())).is_err());
         let long_bytes = vec![0; 17];
-        assert!(WasmAeKey::from_bytes(Uint8Array::from(long_bytes.as_slice())).is_err());
+        assert!(AeKey::from_bytes(Uint8Array::from(long_bytes.as_slice())).is_err());
     }
 
     #[wasm_bindgen_test]
     fn test_encrypt_decrypt_cycle() {
-        let key = WasmAeKey::new_rand();
+        let key = AeKey::new_rand();
         let amount: u64 = 987654321;
 
         let ciphertext = key.encrypt(amount);
@@ -141,7 +138,7 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_ciphertext_is_not_deterministic() {
-        let key = WasmAeKey::new_rand();
+        let key = AeKey::new_rand();
         let amount: u64 = 555;
 
         let ciphertext1 = key.encrypt(amount);
@@ -153,8 +150,8 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_decryption_with_wrong_key_fails() {
-        let key1 = WasmAeKey::new_rand();
-        let key2 = WasmAeKey::new_rand(); // A different key
+        let key1 = AeKey::new_rand();
+        let key2 = AeKey::new_rand(); // A different key
         let amount: u64 = 100;
         let ciphertext = key1.encrypt(amount);
 

--- a/zk-sdk-wasm-js/src/encryption/elgamal.rs
+++ b/zk-sdk-wasm-js/src/encryption/elgamal.rs
@@ -1,36 +1,34 @@
 use {
-    crate::encryption::pedersen::{WasmPedersenCommitment, WasmPedersenOpening},
+    crate::encryption::pedersen::{PedersenCommitment, PedersenOpening},
     js_sys::Uint8Array,
     solana_zk_sdk::encryption::{
-        elgamal::{
-            DecryptHandle, ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey, ElGamalSecretKey,
-        },
-        DECRYPT_HANDLE_LEN, ELGAMAL_CIPHERTEXT_LEN, ELGAMAL_PUBKEY_LEN, ELGAMAL_SECRET_KEY_LEN,
+        elgamal, DECRYPT_HANDLE_LEN, ELGAMAL_CIPHERTEXT_LEN, ELGAMAL_PUBKEY_LEN,
+        ELGAMAL_SECRET_KEY_LEN,
     },
     wasm_bindgen::prelude::{wasm_bindgen, JsValue},
 };
 
-#[wasm_bindgen(js_name = "ElGamalPubkey")]
-pub struct WasmElGamalPubkey {
-    pub(crate) inner: ElGamalPubkey,
+#[wasm_bindgen]
+pub struct ElGamalPubkey {
+    pub(crate) inner: elgamal::ElGamalPubkey,
 }
 
-crate::conversion::impl_inner_conversion!(WasmElGamalPubkey, ElGamalPubkey);
+crate::conversion::impl_inner_conversion!(ElGamalPubkey, elgamal::ElGamalPubkey);
 
 #[wasm_bindgen]
-impl WasmElGamalPubkey {
+impl ElGamalPubkey {
     /// Creates an ElGamal public key from a secret key.
     #[wasm_bindgen(js_name = "fromSecretKey")]
-    pub fn from_secret_key(secret_key: &WasmElGamalSecretKey) -> Self {
+    pub fn from_secret_key(secret_key: &ElGamalSecretKey) -> Self {
         Self {
-            inner: ElGamalPubkey::new(secret_key),
+            inner: elgamal::ElGamalPubkey::new(secret_key),
         }
     }
 
     /// Deserializes an ElGamal public key from a byte slice.
     /// Throws an error if the bytes are invalid.
     #[wasm_bindgen(js_name = "fromBytes")]
-    pub fn from_bytes(uint8_array: Uint8Array) -> Result<WasmElGamalPubkey, JsValue> {
+    pub fn from_bytes(uint8_array: Uint8Array) -> Result<ElGamalPubkey, JsValue> {
         if uint8_array.length() as usize != ELGAMAL_PUBKEY_LEN {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for ElGamalPubkey: expected {}, got {}",
@@ -42,7 +40,7 @@ impl WasmElGamalPubkey {
         let mut bytes = [0u8; ELGAMAL_PUBKEY_LEN];
         uint8_array.copy_to(&mut bytes);
 
-        ElGamalPubkey::try_from(bytes.as_ref())
+        elgamal::ElGamalPubkey::try_from(bytes.as_ref())
             .map(|inner| Self { inner })
             .map_err(|e| JsValue::from_str(&e.to_string()))
     }
@@ -56,32 +54,32 @@ impl WasmElGamalPubkey {
 
     /// Encrypts a 64-bit amount using the public key.
     #[wasm_bindgen(js_name = "encryptU64")]
-    pub fn encrypt_u64(&self, amount: u64) -> WasmElGamalCiphertext {
+    pub fn encrypt_u64(&self, amount: u64) -> ElGamalCiphertext {
         self.inner.encrypt(amount).into()
     }
 }
 
-#[wasm_bindgen(js_name = "ElGamalSecretKey")]
-pub struct WasmElGamalSecretKey {
-    pub(crate) inner: ElGamalSecretKey,
+#[wasm_bindgen]
+pub struct ElGamalSecretKey {
+    pub(crate) inner: elgamal::ElGamalSecretKey,
 }
 
-crate::conversion::impl_inner_conversion!(WasmElGamalSecretKey, ElGamalSecretKey);
+crate::conversion::impl_inner_conversion!(ElGamalSecretKey, elgamal::ElGamalSecretKey);
 
 #[wasm_bindgen]
-impl WasmElGamalSecretKey {
+impl ElGamalSecretKey {
     /// Creates a new, random ElGamal secret key.
     #[wasm_bindgen(constructor)]
     pub fn new_rand() -> Self {
         Self {
-            inner: ElGamalSecretKey::new_rand(),
+            inner: elgamal::ElGamalSecretKey::new_rand(),
         }
     }
 
     /// Deserializes an ElGamal secret key from a byte slice.
     /// Throws an error if the bytes are invalid.
     #[wasm_bindgen(js_name = "fromBytes")]
-    pub fn from_bytes(uint8_array: Uint8Array) -> Result<WasmElGamalSecretKey, JsValue> {
+    pub fn from_bytes(uint8_array: Uint8Array) -> Result<ElGamalSecretKey, JsValue> {
         if uint8_array.length() as usize != ELGAMAL_SECRET_KEY_LEN {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for ElGamalSecretKey: expected {}, got {}",
@@ -93,7 +91,7 @@ impl WasmElGamalSecretKey {
         let mut bytes = [0u8; ELGAMAL_SECRET_KEY_LEN];
         uint8_array.copy_to(&mut bytes);
 
-        ElGamalSecretKey::try_from(bytes.as_ref())
+        elgamal::ElGamalSecretKey::try_from(bytes.as_ref())
             .map(|inner| Self { inner })
             .map_err(|e| JsValue::from_str(&e.to_string()))
     }
@@ -107,7 +105,7 @@ impl WasmElGamalSecretKey {
     /// Decrypts an ElGamal ciphertext.
     /// Returns the decrypted amount as a u64, or `undefined` if decryption fails.
     #[wasm_bindgen(js_name = "decrypt")]
-    pub fn decrypt(&self, ciphertext: &WasmElGamalCiphertext) -> Result<u64, JsValue> {
+    pub fn decrypt(&self, ciphertext: &ElGamalCiphertext) -> Result<u64, JsValue> {
         self.inner
             .decrypt_u32(&ciphertext.inner)
             .ok_or_else(|| {
@@ -118,59 +116,59 @@ impl WasmElGamalSecretKey {
     }
 }
 
-#[wasm_bindgen(js_name = "ElGamalKeypair")]
-pub struct WasmElGamalKeypair {
-    pub(crate) inner: ElGamalKeypair,
+#[wasm_bindgen]
+pub struct ElGamalKeypair {
+    pub(crate) inner: elgamal::ElGamalKeypair,
 }
 
-crate::conversion::impl_inner_conversion!(WasmElGamalKeypair, ElGamalKeypair);
+crate::conversion::impl_inner_conversion!(ElGamalKeypair, elgamal::ElGamalKeypair);
 
 #[wasm_bindgen]
-impl WasmElGamalKeypair {
+impl ElGamalKeypair {
     /// Creates a new, random ElGamal keypair.
     #[wasm_bindgen(constructor)]
     pub fn new_rand() -> Self {
         Self {
-            inner: ElGamalKeypair::new_rand(),
+            inner: elgamal::ElGamalKeypair::new_rand(),
         }
     }
 
     /// Creates an ElGamal keypair from a secret key.
     #[wasm_bindgen(js_name = "fromSecretKey")]
-    pub fn from_secret_key(secret_key: &WasmElGamalSecretKey) -> Self {
+    pub fn from_secret_key(secret_key: &ElGamalSecretKey) -> Self {
         Self {
-            inner: ElGamalKeypair::new(secret_key.inner.clone()),
+            inner: elgamal::ElGamalKeypair::new(secret_key.inner.clone()),
         }
     }
 
     /// Returns the public key of the keypair.
-    pub fn pubkey(&self) -> WasmElGamalPubkey {
-        WasmElGamalPubkey {
+    pub fn pubkey(&self) -> ElGamalPubkey {
+        ElGamalPubkey {
             inner: *self.inner.pubkey(),
         }
     }
 
     /// Returns the secret key of the keypair.
-    pub fn secret(&self) -> WasmElGamalSecretKey {
-        WasmElGamalSecretKey {
+    pub fn secret(&self) -> ElGamalSecretKey {
+        ElGamalSecretKey {
             inner: self.inner.secret().clone(),
         }
     }
 }
 
-#[wasm_bindgen(js_name = "ElGamalCiphertext")]
-pub struct WasmElGamalCiphertext {
-    pub(crate) inner: ElGamalCiphertext,
+#[wasm_bindgen]
+pub struct ElGamalCiphertext {
+    pub(crate) inner: elgamal::ElGamalCiphertext,
 }
 
-crate::conversion::impl_inner_conversion!(WasmElGamalCiphertext, ElGamalCiphertext);
+crate::conversion::impl_inner_conversion!(ElGamalCiphertext, elgamal::ElGamalCiphertext);
 
 #[wasm_bindgen]
-impl WasmElGamalCiphertext {
+impl ElGamalCiphertext {
     /// Deserializes an ElGamal ciphertext from a byte slice.
     /// Returns `undefined` if the bytes are invalid.
     #[wasm_bindgen(js_name = "fromBytes")]
-    pub fn from_bytes(uint8_array: Uint8Array) -> Option<WasmElGamalCiphertext> {
+    pub fn from_bytes(uint8_array: Uint8Array) -> Option<ElGamalCiphertext> {
         if uint8_array.length() as usize != ELGAMAL_CIPHERTEXT_LEN {
             return None;
         }
@@ -178,7 +176,7 @@ impl WasmElGamalCiphertext {
         let mut bytes = [0u8; ELGAMAL_CIPHERTEXT_LEN];
         uint8_array.copy_to(&mut bytes);
 
-        ElGamalCiphertext::from_bytes(&bytes).map(|inner| Self { inner })
+        elgamal::ElGamalCiphertext::from_bytes(&bytes).map(|inner| Self { inner })
     }
 
     /// Serializes the ElGamal ciphertext to a byte array.
@@ -188,33 +186,33 @@ impl WasmElGamalCiphertext {
     }
 
     /// Returns the commitment component of the ciphertext.
-    pub fn commitment(&self) -> WasmPedersenCommitment {
-        WasmPedersenCommitment {
+    pub fn commitment(&self) -> PedersenCommitment {
+        PedersenCommitment {
             inner: self.inner.commitment,
         }
     }
 
     /// Returns the decryption handle component of the ciphertext.
-    pub fn handle(&self) -> WasmDecryptHandle {
-        WasmDecryptHandle {
+    pub fn handle(&self) -> DecryptHandle {
+        DecryptHandle {
             inner: self.inner.handle,
         }
     }
 }
 
-#[wasm_bindgen(js_name = "DecryptHandle")]
-pub struct WasmDecryptHandle {
-    pub(crate) inner: DecryptHandle,
+#[wasm_bindgen]
+pub struct DecryptHandle {
+    pub(crate) inner: elgamal::DecryptHandle,
 }
 
-crate::conversion::impl_inner_conversion!(WasmDecryptHandle, DecryptHandle);
+crate::conversion::impl_inner_conversion!(DecryptHandle, elgamal::DecryptHandle);
 
 #[wasm_bindgen]
-impl WasmDecryptHandle {
+impl DecryptHandle {
     /// Deserializes a decryption handle from a byte slice.
     /// Returns `undefined` if the bytes are invalid.
     #[wasm_bindgen(js_name = "fromBytes")]
-    pub fn from_bytes(uint8_array: Uint8Array) -> Option<WasmDecryptHandle> {
+    pub fn from_bytes(uint8_array: Uint8Array) -> Option<DecryptHandle> {
         if uint8_array.length() as usize != DECRYPT_HANDLE_LEN {
             return None;
         }
@@ -222,7 +220,7 @@ impl WasmDecryptHandle {
         let mut bytes = [0u8; DECRYPT_HANDLE_LEN];
         uint8_array.copy_to(&mut bytes);
 
-        DecryptHandle::from_bytes(&bytes).map(|inner| Self { inner })
+        elgamal::DecryptHandle::from_bytes(&bytes).map(|inner| Self { inner })
     }
 
     /// Serializes the decryption handle to a byte array.
@@ -238,42 +236,42 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_elgamal_keypair_creation_and_accessors() {
-        let secret = WasmElGamalSecretKey::new_rand();
-        let keypair = WasmElGamalKeypair::from_secret_key(&secret);
+        let secret = ElGamalSecretKey::new_rand();
+        let keypair = ElGamalKeypair::from_secret_key(&secret);
 
         let pubkey = keypair.pubkey();
-        let derived_pubkey = WasmElGamalPubkey::from_secret_key(&secret);
+        let derived_pubkey = ElGamalPubkey::from_secret_key(&secret);
 
         assert_eq!(pubkey.to_bytes(), derived_pubkey.to_bytes());
         assert_eq!(secret.to_bytes(), keypair.secret().to_bytes());
 
-        let rand_keypair = WasmElGamalKeypair::new_rand();
+        let rand_keypair = ElGamalKeypair::new_rand();
         assert_ne!(rand_keypair.secret().to_bytes(), secret.to_bytes());
     }
 
     #[wasm_bindgen_test]
     fn test_pubkey_and_secretkey_bytes_roundtrip() {
-        let keypair = WasmElGamalKeypair::new_rand();
+        let keypair = ElGamalKeypair::new_rand();
         let secret = keypair.secret();
         let pubkey = keypair.pubkey();
 
         // Secret Key roundtrip
         let secret_bytes = secret.to_bytes();
         let recovered_secret =
-            WasmElGamalSecretKey::from_bytes(Uint8Array::from(secret_bytes.as_slice())).unwrap();
+            ElGamalSecretKey::from_bytes(Uint8Array::from(secret_bytes.as_slice())).unwrap();
         assert_eq!(secret.inner, recovered_secret.inner);
 
         // Public Key roundtrip
         let pubkey_bytes = pubkey.to_bytes();
         let recovered_pubkey =
-            WasmElGamalPubkey::from_bytes(Uint8Array::from(pubkey_bytes.as_slice())).unwrap();
+            ElGamalPubkey::from_bytes(Uint8Array::from(pubkey_bytes.as_slice())).unwrap();
         assert_eq!(pubkey.inner, recovered_pubkey.inner);
     }
 
     #[wasm_bindgen_test]
     fn test_encrypt_decrypt_cycle() {
         let amount_to_encrypt: u64 = 55;
-        let keypair = WasmElGamalKeypair::new_rand();
+        let keypair = ElGamalKeypair::new_rand();
         let pubkey = keypair.pubkey();
         let secret_key = keypair.secret();
 
@@ -284,27 +282,26 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_ciphertext_and_handle_bytes_roundtrip() {
-        let keypair = WasmElGamalKeypair::new_rand();
+        let keypair = ElGamalKeypair::new_rand();
         let ciphertext = keypair.pubkey().encrypt_u64(123);
 
         // Ciphertext roundtrip
         let ciphertext_bytes = ciphertext.to_bytes();
         let recovered_ciphertext =
-            WasmElGamalCiphertext::from_bytes(Uint8Array::from(ciphertext_bytes.as_slice()))
-                .unwrap();
+            ElGamalCiphertext::from_bytes(Uint8Array::from(ciphertext_bytes.as_slice())).unwrap();
         assert_eq!(ciphertext.inner, recovered_ciphertext.inner);
 
         // Handle roundtrip
         let handle = ciphertext.handle();
         let handle_bytes = handle.to_bytes();
         let recovered_handle =
-            WasmDecryptHandle::from_bytes(Uint8Array::from(handle_bytes.as_slice())).unwrap();
+            DecryptHandle::from_bytes(Uint8Array::from(handle_bytes.as_slice())).unwrap();
         assert_eq!(handle.inner, recovered_handle.inner);
 
         // Commitment roundtrip
         let commitment = ciphertext.commitment();
         let commitment_bytes = commitment.to_bytes();
-        let recovered_commitment = crate::encryption::pedersen::WasmPedersenCommitment::from_bytes(
+        let recovered_commitment = crate::encryption::pedersen::PedersenCommitment::from_bytes(
             Uint8Array::from(commitment_bytes.as_slice()),
         )
         .unwrap();
@@ -315,8 +312,8 @@ mod tests {
     fn test_decryption_with_wrong_key_fails() {
         let amount: u64 = 100;
 
-        let keypair1 = WasmElGamalKeypair::new_rand();
-        let keypair2 = WasmElGamalKeypair::new_rand(); // A different keypair
+        let keypair1 = ElGamalKeypair::new_rand();
+        let keypair2 = ElGamalKeypair::new_rand(); // A different keypair
 
         let ciphertext = keypair1.pubkey().encrypt_u64(amount);
         let decrypted_result = keypair2.secret().decrypt(&ciphertext);
@@ -325,7 +322,7 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_elgamal_encryption_is_not_deterministic() {
-        let keypair = WasmElGamalKeypair::new_rand();
+        let keypair = ElGamalKeypair::new_rand();
         let pubkey = keypair.pubkey();
         let amount: u64 = 77;
 
@@ -339,46 +336,36 @@ mod tests {
     #[wasm_bindgen_test]
     fn test_from_bytes_with_invalid_input() {
         let short_pubkey = vec![0; 31];
-        assert!(WasmElGamalPubkey::from_bytes(Uint8Array::from(short_pubkey.as_slice())).is_err());
+        assert!(ElGamalPubkey::from_bytes(Uint8Array::from(short_pubkey.as_slice())).is_err());
         let long_pubkey = vec![0; 33];
-        assert!(WasmElGamalPubkey::from_bytes(Uint8Array::from(long_pubkey.as_slice())).is_err());
+        assert!(ElGamalPubkey::from_bytes(Uint8Array::from(long_pubkey.as_slice())).is_err());
         let invalid_pubkey = vec![0xFF; 32];
-        assert!(
-            WasmElGamalPubkey::from_bytes(Uint8Array::from(invalid_pubkey.as_slice())).is_err()
-        );
+        assert!(ElGamalPubkey::from_bytes(Uint8Array::from(invalid_pubkey.as_slice())).is_err());
 
         let short_secret = vec![0; 31];
-        assert!(
-            WasmElGamalSecretKey::from_bytes(Uint8Array::from(short_secret.as_slice())).is_err()
-        );
+        assert!(ElGamalSecretKey::from_bytes(Uint8Array::from(short_secret.as_slice())).is_err());
         let long_secret = vec![0; 33];
-        assert!(
-            WasmElGamalSecretKey::from_bytes(Uint8Array::from(long_secret.as_slice())).is_err()
-        );
+        assert!(ElGamalSecretKey::from_bytes(Uint8Array::from(long_secret.as_slice())).is_err());
 
         let short_ciphertext = vec![0; 63];
         assert!(
-            WasmElGamalCiphertext::from_bytes(Uint8Array::from(short_ciphertext.as_slice()))
-                .is_none()
+            ElGamalCiphertext::from_bytes(Uint8Array::from(short_ciphertext.as_slice())).is_none()
         );
         let long_ciphertext = vec![0; 65];
         assert!(
-            WasmElGamalCiphertext::from_bytes(Uint8Array::from(long_ciphertext.as_slice()))
-                .is_none()
+            ElGamalCiphertext::from_bytes(Uint8Array::from(long_ciphertext.as_slice())).is_none()
         );
         let invalid_ciphertext = vec![0xFF; 64];
         assert!(
-            WasmElGamalCiphertext::from_bytes(Uint8Array::from(invalid_ciphertext.as_slice()))
+            ElGamalCiphertext::from_bytes(Uint8Array::from(invalid_ciphertext.as_slice()))
                 .is_none()
         );
 
         let short_handle = vec![0; 31];
-        assert!(WasmDecryptHandle::from_bytes(Uint8Array::from(short_handle.as_slice())).is_none());
+        assert!(DecryptHandle::from_bytes(Uint8Array::from(short_handle.as_slice())).is_none());
         let long_handle = vec![0; 33];
-        assert!(WasmDecryptHandle::from_bytes(Uint8Array::from(long_handle.as_slice())).is_none());
+        assert!(DecryptHandle::from_bytes(Uint8Array::from(long_handle.as_slice())).is_none());
         let invalid_handle = vec![0xFF; 32];
-        assert!(
-            WasmDecryptHandle::from_bytes(Uint8Array::from(invalid_handle.as_slice())).is_none()
-        );
+        assert!(DecryptHandle::from_bytes(Uint8Array::from(invalid_handle.as_slice())).is_none());
     }
 }

--- a/zk-sdk-wasm-js/src/encryption/grouped_elgamal.rs
+++ b/zk-sdk-wasm-js/src/encryption/grouped_elgamal.rs
@@ -1,10 +1,7 @@
 use {
-    crate::encryption::elgamal::{WasmElGamalPubkey, WasmElGamalSecretKey},
+    crate::encryption::elgamal::{ElGamalPubkey, ElGamalSecretKey},
     js_sys::Uint8Array,
-    solana_zk_sdk::encryption::{
-        grouped_elgamal::{GroupedElGamal, GroupedElGamalCiphertext},
-        DECRYPT_HANDLE_LEN, PEDERSEN_COMMITMENT_LEN,
-    },
+    solana_zk_sdk::encryption::{grouped_elgamal, DECRYPT_HANDLE_LEN, PEDERSEN_COMMITMENT_LEN},
     wasm_bindgen::prelude::*,
 };
 
@@ -13,33 +10,36 @@ const GROUPED_ELGAMAL_CIPHERTEXT_2_HANDLES_LEN: usize =
 const GROUPED_ELGAMAL_CIPHERTEXT_3_HANDLES_LEN: usize =
     DECRYPT_HANDLE_LEN * 3 + PEDERSEN_COMMITMENT_LEN;
 
-#[wasm_bindgen(js_name = "GroupedElGamalCiphertext2Handles")]
-pub struct WasmGroupedElGamalCiphertext2Handles {
-    pub(crate) inner: GroupedElGamalCiphertext<2>,
+#[wasm_bindgen]
+pub struct GroupedElGamalCiphertext2Handles {
+    pub(crate) inner: grouped_elgamal::GroupedElGamalCiphertext<2>,
 }
 
 crate::conversion::impl_inner_conversion!(
-    WasmGroupedElGamalCiphertext2Handles,
-    GroupedElGamalCiphertext<2>
+    GroupedElGamalCiphertext2Handles,
+    grouped_elgamal::GroupedElGamalCiphertext<2>
 );
 
 #[wasm_bindgen]
-impl WasmGroupedElGamalCiphertext2Handles {
+impl GroupedElGamalCiphertext2Handles {
     /// Encrypts a 64-bit amount under two ElGamal public keys.
     #[wasm_bindgen(js_name = "encrypt")]
     pub fn encrypt(
-        first_pubkey: &WasmElGamalPubkey,
-        second_pubkey: &WasmElGamalPubkey,
+        first_pubkey: &ElGamalPubkey,
+        second_pubkey: &ElGamalPubkey,
         amount: u64,
     ) -> Self {
-        let inner = GroupedElGamal::encrypt([&first_pubkey.inner, &second_pubkey.inner], amount);
+        let inner = grouped_elgamal::GroupedElGamal::encrypt(
+            [&first_pubkey.inner, &second_pubkey.inner],
+            amount,
+        );
         Self { inner }
     }
 
     /// Decrypts the ciphertext using a secret key and a handle index.
     /// Returns the decrypted amount as a u64, or `undefined` if decryption fails.
     #[wasm_bindgen(js_name = "decrypt")]
-    pub fn decrypt(&self, secret_key: &WasmElGamalSecretKey, index: usize) -> Result<u64, JsValue> {
+    pub fn decrypt(&self, secret_key: &ElGamalSecretKey, index: usize) -> Result<u64, JsValue> {
         match self.inner.decrypt_u32(&secret_key.inner, index) {
             Ok(Some(amount)) => Ok(amount),
             Ok(None) => Err(JsValue::from_str(
@@ -52,7 +52,7 @@ impl WasmGroupedElGamalCiphertext2Handles {
     /// Deserializes a 2-handle grouped ElGamal ciphertext from a byte slice.
     /// Throws an error if the bytes are invalid.
     #[wasm_bindgen(js_name = "fromBytes")]
-    pub fn from_bytes(bytes: &Uint8Array) -> Result<WasmGroupedElGamalCiphertext2Handles, JsValue> {
+    pub fn from_bytes(bytes: &Uint8Array) -> Result<GroupedElGamalCiphertext2Handles, JsValue> {
         let expected_length = GROUPED_ELGAMAL_CIPHERTEXT_2_HANDLES_LEN;
         if bytes.length() as usize != expected_length {
             return Err(JsValue::from_str(&format!(
@@ -65,7 +65,7 @@ impl WasmGroupedElGamalCiphertext2Handles {
         let mut arr = vec![0u8; bytes.length() as usize];
         bytes.copy_to(&mut arr);
 
-        GroupedElGamalCiphertext::<2>::from_bytes(&arr)
+        grouped_elgamal::GroupedElGamalCiphertext::<2>::from_bytes(&arr)
             .map(|inner| Self { inner })
             .ok_or_else(|| JsValue::from_str("Invalid bytes for GroupedElGamalCiphertext2Handles"))
     }
@@ -77,27 +77,27 @@ impl WasmGroupedElGamalCiphertext2Handles {
     }
 }
 
-#[wasm_bindgen(js_name = "GroupedElGamalCiphertext3Handles")]
-pub struct WasmGroupedElGamalCiphertext3Handles {
-    pub(crate) inner: GroupedElGamalCiphertext<3>,
+#[wasm_bindgen]
+pub struct GroupedElGamalCiphertext3Handles {
+    pub(crate) inner: grouped_elgamal::GroupedElGamalCiphertext<3>,
 }
 
 crate::conversion::impl_inner_conversion!(
-    WasmGroupedElGamalCiphertext3Handles,
-    GroupedElGamalCiphertext<3>
+    GroupedElGamalCiphertext3Handles,
+    grouped_elgamal::GroupedElGamalCiphertext<3>
 );
 
 #[wasm_bindgen]
-impl WasmGroupedElGamalCiphertext3Handles {
+impl GroupedElGamalCiphertext3Handles {
     /// Encrypts a 64-bit amount under three ElGamal public keys.
     #[wasm_bindgen(js_name = "encrypt")]
     pub fn encrypt(
-        first_pubkey: &WasmElGamalPubkey,
-        second_pubkey: &WasmElGamalPubkey,
-        third_pubkey: &WasmElGamalPubkey,
+        first_pubkey: &ElGamalPubkey,
+        second_pubkey: &ElGamalPubkey,
+        third_pubkey: &ElGamalPubkey,
         amount: u64,
     ) -> Self {
-        let inner = GroupedElGamal::encrypt(
+        let inner = grouped_elgamal::GroupedElGamal::encrypt(
             [
                 &first_pubkey.inner,
                 &second_pubkey.inner,
@@ -111,7 +111,7 @@ impl WasmGroupedElGamalCiphertext3Handles {
     /// Decrypts the ciphertext using a secret key and a handle index.
     /// Returns the decrypted amount as a u64, or `undefined` if decryption fails.
     #[wasm_bindgen(js_name = "decrypt")]
-    pub fn decrypt(&self, secret_key: &WasmElGamalSecretKey, index: usize) -> Result<u64, JsValue> {
+    pub fn decrypt(&self, secret_key: &ElGamalSecretKey, index: usize) -> Result<u64, JsValue> {
         match self.inner.decrypt_u32(&secret_key.inner, index) {
             Ok(Some(amount)) => Ok(amount),
             Ok(None) => Err(JsValue::from_str(
@@ -124,7 +124,7 @@ impl WasmGroupedElGamalCiphertext3Handles {
     /// Deserializes a 3-handle grouped ElGamal ciphertext from a byte slice.
     /// Throws an error if the bytes are invalid.
     #[wasm_bindgen(js_name = "fromBytes")]
-    pub fn from_bytes(bytes: &Uint8Array) -> Result<WasmGroupedElGamalCiphertext3Handles, JsValue> {
+    pub fn from_bytes(bytes: &Uint8Array) -> Result<GroupedElGamalCiphertext3Handles, JsValue> {
         let expected_length = GROUPED_ELGAMAL_CIPHERTEXT_3_HANDLES_LEN;
         if bytes.length() as usize != expected_length {
             return Err(JsValue::from_str(&format!(
@@ -137,7 +137,7 @@ impl WasmGroupedElGamalCiphertext3Handles {
         let mut arr = vec![0u8; bytes.length() as usize];
         bytes.copy_to(&mut arr);
 
-        GroupedElGamalCiphertext::<3>::from_bytes(&arr)
+        grouped_elgamal::GroupedElGamalCiphertext::<3>::from_bytes(&arr)
             .map(|inner| Self { inner })
             .ok_or_else(|| JsValue::from_str("Invalid bytes for GroupedElGamalCiphertext3Handles"))
     }
@@ -151,15 +151,15 @@ impl WasmGroupedElGamalCiphertext3Handles {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, crate::encryption::elgamal::WasmElGamalKeypair, wasm_bindgen_test::*};
+    use {super::*, crate::encryption::elgamal::ElGamalKeypair, wasm_bindgen_test::*};
 
     #[wasm_bindgen_test]
     fn test_grouped_elgamal_2_handles_cycle() {
-        let keypair1 = WasmElGamalKeypair::new_rand();
-        let keypair2 = WasmElGamalKeypair::new_rand();
+        let keypair1 = ElGamalKeypair::new_rand();
+        let keypair2 = ElGamalKeypair::new_rand();
         let amount: u64 = 123456789;
 
-        let ciphertext = WasmGroupedElGamalCiphertext2Handles::encrypt(
+        let ciphertext = GroupedElGamalCiphertext2Handles::encrypt(
             &keypair1.pubkey(),
             &keypair2.pubkey(),
             amount,
@@ -174,7 +174,7 @@ mod tests {
         assert_eq!(decrypted2, Ok(amount));
 
         // Decrypt with wrong key fails
-        let keypair_wrong = WasmElGamalKeypair::new_rand();
+        let keypair_wrong = ElGamalKeypair::new_rand();
         let decrypted_wrong = ciphertext.decrypt(&keypair_wrong.secret(), 0);
         assert!(decrypted_wrong.is_err());
 
@@ -185,12 +185,12 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_grouped_elgamal_3_handles_cycle() {
-        let keypair1 = WasmElGamalKeypair::new_rand();
-        let keypair2 = WasmElGamalKeypair::new_rand();
-        let keypair3 = WasmElGamalKeypair::new_rand();
+        let keypair1 = ElGamalKeypair::new_rand();
+        let keypair2 = ElGamalKeypair::new_rand();
+        let keypair3 = ElGamalKeypair::new_rand();
         let amount: u64 = 987654321;
 
-        let ciphertext = WasmGroupedElGamalCiphertext3Handles::encrypt(
+        let ciphertext = GroupedElGamalCiphertext3Handles::encrypt(
             &keypair1.pubkey(),
             &keypair2.pubkey(),
             &keypair3.pubkey(),
@@ -203,17 +203,17 @@ mod tests {
         assert_eq!(ciphertext.decrypt(&keypair3.secret(), 2), Ok(amount));
 
         // Decrypt with wrong key fails
-        let keypair_wrong = WasmElGamalKeypair::new_rand();
+        let keypair_wrong = ElGamalKeypair::new_rand();
         assert!(ciphertext.decrypt(&keypair_wrong.secret(), 1).is_err());
     }
 
     #[wasm_bindgen_test]
     fn test_bytes_roundtrip_2_handles() {
-        let keypair1 = WasmElGamalKeypair::new_rand();
-        let keypair2 = WasmElGamalKeypair::new_rand();
+        let keypair1 = ElGamalKeypair::new_rand();
+        let keypair2 = ElGamalKeypair::new_rand();
         let amount: u64 = 55;
 
-        let ciphertext = WasmGroupedElGamalCiphertext2Handles::encrypt(
+        let ciphertext = GroupedElGamalCiphertext2Handles::encrypt(
             &keypair1.pubkey(),
             &keypair2.pubkey(),
             amount,
@@ -223,7 +223,7 @@ mod tests {
         // N=2 -> (2+1)*32 = 96 bytes
         assert_eq!(bytes.len(), 96);
         let recovered =
-            WasmGroupedElGamalCiphertext2Handles::from_bytes(&Uint8Array::from(bytes.as_slice()))
+            GroupedElGamalCiphertext2Handles::from_bytes(&Uint8Array::from(bytes.as_slice()))
                 .unwrap();
 
         assert_eq!(recovered.decrypt(&keypair1.secret(), 0), Ok(amount));
@@ -232,12 +232,12 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_bytes_roundtrip_3_handles() {
-        let keypair1 = WasmElGamalKeypair::new_rand();
-        let keypair2 = WasmElGamalKeypair::new_rand();
-        let keypair3 = WasmElGamalKeypair::new_rand();
+        let keypair1 = ElGamalKeypair::new_rand();
+        let keypair2 = ElGamalKeypair::new_rand();
+        let keypair3 = ElGamalKeypair::new_rand();
         let amount: u64 = 77;
 
-        let ciphertext = WasmGroupedElGamalCiphertext3Handles::encrypt(
+        let ciphertext = GroupedElGamalCiphertext3Handles::encrypt(
             &keypair1.pubkey(),
             &keypair2.pubkey(),
             &keypair3.pubkey(),
@@ -248,7 +248,7 @@ mod tests {
         // N=3 -> (3+1)*32 = 128 bytes
         assert_eq!(bytes.len(), 128);
         let recovered =
-            WasmGroupedElGamalCiphertext3Handles::from_bytes(&Uint8Array::from(bytes.as_slice()))
+            GroupedElGamalCiphertext3Handles::from_bytes(&Uint8Array::from(bytes.as_slice()))
                 .unwrap();
 
         assert_eq!(recovered.decrypt(&keypair1.secret(), 0), Ok(amount));

--- a/zk-sdk-wasm-js/src/encryption/pedersen.rs
+++ b/zk-sdk-wasm-js/src/encryption/pedersen.rs
@@ -1,33 +1,30 @@
 use {
     js_sys::Uint8Array,
-    solana_zk_sdk::encryption::{
-        pedersen::{Pedersen, PedersenCommitment, PedersenOpening},
-        PEDERSEN_COMMITMENT_LEN,
-    },
+    solana_zk_sdk::encryption::{pedersen, PEDERSEN_COMMITMENT_LEN},
     wasm_bindgen::prelude::{wasm_bindgen, JsValue},
 };
 
-#[wasm_bindgen(js_name = "PedersenCommitment")]
-pub struct WasmPedersenCommitment {
-    pub(crate) inner: PedersenCommitment,
+#[wasm_bindgen]
+pub struct PedersenCommitment {
+    pub(crate) inner: pedersen::PedersenCommitment,
 }
 
-crate::conversion::impl_inner_conversion!(WasmPedersenCommitment, PedersenCommitment);
+crate::conversion::impl_inner_conversion!(PedersenCommitment, pedersen::PedersenCommitment);
 
 #[wasm_bindgen]
-impl WasmPedersenCommitment {
+impl PedersenCommitment {
     /// Creates a Pedersen commitment from a 64-bit amount and a Pedersen opening.
     #[wasm_bindgen(js_name = from)]
-    pub fn with_u64(amount: u64, opening: &WasmPedersenOpening) -> Self {
+    pub fn with_u64(amount: u64, opening: &PedersenOpening) -> Self {
         Self {
-            inner: Pedersen::with(amount, opening),
+            inner: pedersen::Pedersen::with(amount, opening),
         }
     }
 
     /// Deserializes a Pedersen commitment from a byte slice.
     /// Throws an error if the bytes are invalid.
     #[wasm_bindgen(js_name = "fromBytes")]
-    pub fn from_bytes(uint8_array: Uint8Array) -> Result<WasmPedersenCommitment, JsValue> {
+    pub fn from_bytes(uint8_array: Uint8Array) -> Result<PedersenCommitment, JsValue> {
         if uint8_array.length() as usize != PEDERSEN_COMMITMENT_LEN {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for PedersenCommitment: expected {}, got {}",
@@ -39,7 +36,7 @@ impl WasmPedersenCommitment {
         let mut bytes = [0u8; PEDERSEN_COMMITMENT_LEN];
         uint8_array.copy_to(&mut bytes);
 
-        PedersenCommitment::from_bytes(&bytes)
+        pedersen::PedersenCommitment::from_bytes(&bytes)
             .map(|inner| Self { inner })
             .ok_or_else(|| JsValue::from_str("Invalid bytes for PedersenCommitment"))
     }
@@ -51,20 +48,20 @@ impl WasmPedersenCommitment {
     }
 }
 
-#[wasm_bindgen(js_name = "PedersenOpening")]
-pub struct WasmPedersenOpening {
-    pub(crate) inner: PedersenOpening,
+#[wasm_bindgen]
+pub struct PedersenOpening {
+    pub(crate) inner: pedersen::PedersenOpening,
 }
 
-crate::conversion::impl_inner_conversion!(WasmPedersenOpening, PedersenOpening);
+crate::conversion::impl_inner_conversion!(PedersenOpening, pedersen::PedersenOpening);
 
 #[wasm_bindgen]
-impl WasmPedersenOpening {
+impl PedersenOpening {
     /// Creates a new, random Pedersen opening.
     #[wasm_bindgen(constructor)]
     pub fn new_rand() -> Self {
         Self {
-            inner: PedersenOpening::new_rand(),
+            inner: pedersen::PedersenOpening::new_rand(),
         }
     }
 }
@@ -75,8 +72,8 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_opening_creation() {
-        let opening1 = WasmPedersenOpening::new_rand();
-        let opening2 = WasmPedersenOpening::new_rand();
+        let opening1 = PedersenOpening::new_rand();
+        let opening2 = PedersenOpening::new_rand();
 
         assert_ne!(opening1.inner.as_bytes(), opening2.inner.as_bytes());
     }
@@ -84,38 +81,34 @@ mod tests {
     #[wasm_bindgen_test]
     fn test_commitment_creation_and_bytes_roundtrip() {
         let amount: u64 = 12345;
-        let opening = WasmPedersenOpening::new_rand();
+        let opening = PedersenOpening::new_rand();
 
-        let commitment = WasmPedersenCommitment::with_u64(amount, &opening);
+        let commitment = PedersenCommitment::with_u64(amount, &opening);
 
         // Check if the commitment matches what the zk-sdk would create.
-        let expected_inner = Pedersen::with(amount, &opening.inner);
+        let expected_inner = pedersen::Pedersen::with(amount, &opening.inner);
         assert_eq!(commitment.inner, expected_inner);
 
         // Serialization
         let bytes = commitment.to_bytes();
         assert_eq!(bytes.len(), 32); // Ristretto points are 32 bytes.
         let new_commitment =
-            WasmPedersenCommitment::from_bytes(Uint8Array::from(bytes.as_slice())).unwrap();
+            PedersenCommitment::from_bytes(Uint8Array::from(bytes.as_slice())).unwrap();
         assert_eq!(commitment.inner, new_commitment.inner);
     }
 
     #[wasm_bindgen_test]
     fn test_from_bytes_with_invalid_input() {
         let short_bytes = vec![0; 31];
-        assert!(
-            WasmPedersenCommitment::from_bytes(Uint8Array::from(short_bytes.as_slice())).is_err()
-        );
+        assert!(PedersenCommitment::from_bytes(Uint8Array::from(short_bytes.as_slice())).is_err());
 
         let long_bytes = vec![0; 33];
-        assert!(
-            WasmPedersenCommitment::from_bytes(Uint8Array::from(long_bytes.as_slice())).is_err()
-        );
+        assert!(PedersenCommitment::from_bytes(Uint8Array::from(long_bytes.as_slice())).is_err());
 
         let invalid_point_bytes = vec![0xFF; 32];
-        assert!(WasmPedersenCommitment::from_bytes(Uint8Array::from(
-            invalid_point_bytes.as_slice()
-        ))
-        .is_err());
+        assert!(
+            PedersenCommitment::from_bytes(Uint8Array::from(invalid_point_bytes.as_slice()))
+                .is_err()
+        );
     }
 }

--- a/zk-sdk-wasm-js/src/proof_data/batched_grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk-wasm-js/src/proof_data/batched_grouped_ciphertext_validity/handles_2.rs
@@ -1,47 +1,44 @@
 use {
     crate::encryption::{
-        elgamal::WasmElGamalPubkey, grouped_elgamal::WasmGroupedElGamalCiphertext2Handles,
-        pedersen::WasmPedersenOpening,
+        elgamal::ElGamalPubkey, grouped_elgamal::GroupedElGamalCiphertext2Handles,
+        pedersen::PedersenOpening,
     },
     js_sys::Uint8Array,
     solana_zk_sdk::zk_elgamal_proof_program::proof_data::{
-        batched_grouped_ciphertext_validity::{
-            BatchedGroupedCiphertext2HandlesValidityProofContext,
-            BatchedGroupedCiphertext2HandlesValidityProofData,
-        },
-        ZkProofData,
+        batched_grouped_ciphertext_validity, ZkProofData,
     },
     wasm_bindgen::prelude::*,
 };
 
 /// A batched grouped ciphertext validity proof with two decryption handles. This proof certifies
 /// the validity of two grouped ElGamal ciphertexts that are encrypted under the same public keys.
-#[wasm_bindgen(js_name = "BatchedGroupedCiphertext2HandlesValidityProof")]
-pub struct WasmBatchedGroupedCiphertext2HandlesValidityProofData {
-    pub(crate) inner: BatchedGroupedCiphertext2HandlesValidityProofData,
+#[wasm_bindgen]
+pub struct BatchedGroupedCiphertext2HandlesValidityProofData {
+    pub(crate) inner:
+        batched_grouped_ciphertext_validity::BatchedGroupedCiphertext2HandlesValidityProofData,
 }
 
 crate::conversion::impl_inner_conversion!(
-    WasmBatchedGroupedCiphertext2HandlesValidityProofData,
-    BatchedGroupedCiphertext2HandlesValidityProofData
+    BatchedGroupedCiphertext2HandlesValidityProofData,
+    batched_grouped_ciphertext_validity::BatchedGroupedCiphertext2HandlesValidityProofData
 );
 
 #[wasm_bindgen]
-impl WasmBatchedGroupedCiphertext2HandlesValidityProofData {
+impl BatchedGroupedCiphertext2HandlesValidityProofData {
     /// Creates a new batched grouped ciphertext validity proof with two handles.
     #[wasm_bindgen(constructor)]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        first_pubkey: &WasmElGamalPubkey,
-        second_pubkey: &WasmElGamalPubkey,
-        grouped_ciphertext_lo: &WasmGroupedElGamalCiphertext2Handles,
-        grouped_ciphertext_hi: &WasmGroupedElGamalCiphertext2Handles,
+        first_pubkey: &ElGamalPubkey,
+        second_pubkey: &ElGamalPubkey,
+        grouped_ciphertext_lo: &GroupedElGamalCiphertext2Handles,
+        grouped_ciphertext_hi: &GroupedElGamalCiphertext2Handles,
         amount_lo: u64,
         amount_hi: u64,
-        opening_lo: &WasmPedersenOpening,
-        opening_hi: &WasmPedersenOpening,
-    ) -> Result<WasmBatchedGroupedCiphertext2HandlesValidityProofData, JsValue> {
-        BatchedGroupedCiphertext2HandlesValidityProofData::new(
+        opening_lo: &PedersenOpening,
+        opening_hi: &PedersenOpening,
+    ) -> Result<BatchedGroupedCiphertext2HandlesValidityProofData, JsValue> {
+        batched_grouped_ciphertext_validity::BatchedGroupedCiphertext2HandlesValidityProofData::new(
             &first_pubkey.inner,
             &second_pubkey.inner,
             &grouped_ciphertext_lo.inner,
@@ -57,7 +54,7 @@ impl WasmBatchedGroupedCiphertext2HandlesValidityProofData {
 
     /// Returns the context data associated with the proof.
     #[wasm_bindgen]
-    pub fn context(&self) -> WasmBatchedGroupedCiphertext2HandlesValidityProofContext {
+    pub fn context(&self) -> BatchedGroupedCiphertext2HandlesValidityProofContext {
         self.inner.context.into()
     }
 
@@ -75,10 +72,11 @@ impl WasmBatchedGroupedCiphertext2HandlesValidityProofData {
     #[wasm_bindgen(js_name = "fromBytes")]
     pub fn from_bytes(
         bytes: &Uint8Array,
-    ) -> Result<WasmBatchedGroupedCiphertext2HandlesValidityProofData, JsValue> {
+    ) -> Result<BatchedGroupedCiphertext2HandlesValidityProofData, JsValue> {
         // Define expected length as a constant for stack allocation
-        const EXPECTED_LEN: usize =
-            std::mem::size_of::<BatchedGroupedCiphertext2HandlesValidityProofData>();
+        const EXPECTED_LEN: usize = std::mem::size_of::<
+            batched_grouped_ciphertext_validity::BatchedGroupedCiphertext2HandlesValidityProofData,
+        >();
         if bytes.length() as usize != EXPECTED_LEN {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for BatchedGroupedCiphertext2HandlesValidityProof: expected {}, got {}",
@@ -91,7 +89,7 @@ impl WasmBatchedGroupedCiphertext2HandlesValidityProofData {
         bytes.copy_to(&mut data);
 
         bytemuck::try_from_bytes(&data)
-            .map(|pod: &BatchedGroupedCiphertext2HandlesValidityProofData| Self { inner: *pod })
+            .map(|pod: &batched_grouped_ciphertext_validity::BatchedGroupedCiphertext2HandlesValidityProofData| Self { inner: *pod })
             .map_err(|_| {
                 JsValue::from_str("Invalid bytes for BatchedGroupedCiphertext2HandlesValidityProof")
             })
@@ -106,25 +104,26 @@ impl WasmBatchedGroupedCiphertext2HandlesValidityProofData {
 
 /// The context data needed to verify a batched grouped ciphertext 2-handles validity proof.
 #[wasm_bindgen]
-pub struct WasmBatchedGroupedCiphertext2HandlesValidityProofContext {
-    pub(crate) inner: BatchedGroupedCiphertext2HandlesValidityProofContext,
+pub struct BatchedGroupedCiphertext2HandlesValidityProofContext {
+    pub(crate) inner:
+        batched_grouped_ciphertext_validity::BatchedGroupedCiphertext2HandlesValidityProofContext,
 }
 
 crate::conversion::impl_inner_conversion!(
-    WasmBatchedGroupedCiphertext2HandlesValidityProofContext,
-    BatchedGroupedCiphertext2HandlesValidityProofContext
+    BatchedGroupedCiphertext2HandlesValidityProofContext,
+    batched_grouped_ciphertext_validity::BatchedGroupedCiphertext2HandlesValidityProofContext
 );
 
 #[wasm_bindgen]
-impl WasmBatchedGroupedCiphertext2HandlesValidityProofContext {
+impl BatchedGroupedCiphertext2HandlesValidityProofContext {
     /// Deserializes a batched grouped ciphertext 2-handles validity proof context from a byte slice.
     /// Throws an error if the bytes are invalid.
     #[wasm_bindgen(js_name = "fromBytes")]
     pub fn from_bytes(
         bytes: &Uint8Array,
-    ) -> Result<WasmBatchedGroupedCiphertext2HandlesValidityProofContext, JsValue> {
+    ) -> Result<BatchedGroupedCiphertext2HandlesValidityProofContext, JsValue> {
         let expected_len =
-            std::mem::size_of::<BatchedGroupedCiphertext2HandlesValidityProofContext>();
+            std::mem::size_of::<batched_grouped_ciphertext_validity::BatchedGroupedCiphertext2HandlesValidityProofContext>();
         if bytes.length() as usize != expected_len {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for BatchedGroupedCiphertext2HandlesValidityProofContext: expected {}, got {}",
@@ -135,7 +134,7 @@ impl WasmBatchedGroupedCiphertext2HandlesValidityProofContext {
         let mut data = vec![0u8; expected_len];
         bytes.copy_to(&mut data);
         bytemuck::try_from_bytes(&data)
-            .map(|pod: &BatchedGroupedCiphertext2HandlesValidityProofContext| Self { inner: *pod })
+            .map(|pod: &batched_grouped_ciphertext_validity::BatchedGroupedCiphertext2HandlesValidityProofContext| Self { inner: *pod })
             .map_err(|_| {
                 JsValue::from_str(
                     "Invalid bytes for BatchedGroupedCiphertext2HandlesValidityProofContext",
@@ -153,20 +152,20 @@ impl WasmBatchedGroupedCiphertext2HandlesValidityProofContext {
 #[cfg(test)]
 mod tests {
     use {
-        super::*, crate::encryption::elgamal::WasmElGamalKeypair,
+        super::*, crate::encryption::elgamal::ElGamalKeypair,
         solana_zk_sdk::encryption::grouped_elgamal::GroupedElGamal, wasm_bindgen_test::*,
     };
 
     #[wasm_bindgen_test]
     fn test_batched_grouped_ciphertext_2_handles_validity_proof_creation_and_verification() {
-        let first_keypair = WasmElGamalKeypair::new_rand();
-        let second_keypair = WasmElGamalKeypair::new_rand();
+        let first_keypair = ElGamalKeypair::new_rand();
+        let second_keypair = ElGamalKeypair::new_rand();
         let amount_lo: u64 = 11;
         let amount_hi: u64 = 22;
-        let opening_lo = WasmPedersenOpening::new_rand();
-        let opening_hi = WasmPedersenOpening::new_rand();
+        let opening_lo = PedersenOpening::new_rand();
+        let opening_hi = PedersenOpening::new_rand();
 
-        let grouped_ciphertext_lo = WasmGroupedElGamalCiphertext2Handles {
+        let grouped_ciphertext_lo = GroupedElGamalCiphertext2Handles {
             inner: GroupedElGamal::encrypt_with(
                 [
                     &first_keypair.pubkey().inner,
@@ -177,7 +176,7 @@ mod tests {
             ),
         };
 
-        let grouped_ciphertext_hi = WasmGroupedElGamalCiphertext2Handles {
+        let grouped_ciphertext_hi = GroupedElGamalCiphertext2Handles {
             inner: GroupedElGamal::encrypt_with(
                 [
                     &first_keypair.pubkey().inner,
@@ -188,7 +187,7 @@ mod tests {
             ),
         };
 
-        let proof = WasmBatchedGroupedCiphertext2HandlesValidityProofData::new(
+        let proof = BatchedGroupedCiphertext2HandlesValidityProofData::new(
             &first_keypair.pubkey(),
             &second_keypair.pubkey(),
             &grouped_ciphertext_lo,
@@ -205,14 +204,14 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_batched_grouped_ciphertext_2_handles_validity_proof_bytes_roundtrip() {
-        let first_keypair = WasmElGamalKeypair::new_rand();
-        let second_keypair = WasmElGamalKeypair::new_rand();
+        let first_keypair = ElGamalKeypair::new_rand();
+        let second_keypair = ElGamalKeypair::new_rand();
         let amount_lo: u64 = 11;
         let amount_hi: u64 = 22;
-        let opening_lo = WasmPedersenOpening::new_rand();
-        let opening_hi = WasmPedersenOpening::new_rand();
+        let opening_lo = PedersenOpening::new_rand();
+        let opening_hi = PedersenOpening::new_rand();
 
-        let grouped_ciphertext_lo = WasmGroupedElGamalCiphertext2Handles {
+        let grouped_ciphertext_lo = GroupedElGamalCiphertext2Handles {
             inner: GroupedElGamal::encrypt_with(
                 [
                     &first_keypair.pubkey().inner,
@@ -223,7 +222,7 @@ mod tests {
             ),
         };
 
-        let grouped_ciphertext_hi = WasmGroupedElGamalCiphertext2Handles {
+        let grouped_ciphertext_hi = GroupedElGamalCiphertext2Handles {
             inner: GroupedElGamal::encrypt_with(
                 [
                     &first_keypair.pubkey().inner,
@@ -234,7 +233,7 @@ mod tests {
             ),
         };
 
-        let proof = WasmBatchedGroupedCiphertext2HandlesValidityProofData::new(
+        let proof = BatchedGroupedCiphertext2HandlesValidityProofData::new(
             &first_keypair.pubkey(),
             &second_keypair.pubkey(),
             &grouped_ciphertext_lo,
@@ -247,7 +246,7 @@ mod tests {
         .unwrap();
 
         let bytes = proof.to_bytes();
-        let recovered_proof = WasmBatchedGroupedCiphertext2HandlesValidityProofData::from_bytes(
+        let recovered_proof = BatchedGroupedCiphertext2HandlesValidityProofData::from_bytes(
             &Uint8Array::from(bytes.as_slice()),
         )
         .unwrap();
@@ -256,11 +255,10 @@ mod tests {
 
         let context = proof.context();
         let context_bytes = context.to_bytes();
-        let recovered_context =
-            WasmBatchedGroupedCiphertext2HandlesValidityProofContext::from_bytes(
-                &Uint8Array::from(context_bytes.as_slice()),
-            )
-            .unwrap();
+        let recovered_context = BatchedGroupedCiphertext2HandlesValidityProofContext::from_bytes(
+            &Uint8Array::from(context_bytes.as_slice()),
+        )
+        .unwrap();
         assert_eq!(context_bytes, recovered_context.to_bytes());
     }
 }

--- a/zk-sdk-wasm-js/src/proof_data/batched_grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk-wasm-js/src/proof_data/batched_grouped_ciphertext_validity/handles_3.rs
@@ -1,48 +1,45 @@
 use {
     crate::encryption::{
-        elgamal::WasmElGamalPubkey, grouped_elgamal::WasmGroupedElGamalCiphertext3Handles,
-        pedersen::WasmPedersenOpening,
+        elgamal::ElGamalPubkey, grouped_elgamal::GroupedElGamalCiphertext3Handles,
+        pedersen::PedersenOpening,
     },
     js_sys::Uint8Array,
     solana_zk_sdk::zk_elgamal_proof_program::proof_data::{
-        batched_grouped_ciphertext_validity::{
-            BatchedGroupedCiphertext3HandlesValidityProofContext,
-            BatchedGroupedCiphertext3HandlesValidityProofData,
-        },
-        ZkProofData,
+        batched_grouped_ciphertext_validity, ZkProofData,
     },
     wasm_bindgen::prelude::*,
 };
 
 /// A batched grouped ciphertext validity proof with three decryption handles. This proof certifies
 /// the validity of two grouped ElGamal ciphertexts that are encrypted under the same public keys.
-#[wasm_bindgen(js_name = "BatchedGroupedCiphertext3HandlesValidityProof")]
-pub struct WasmBatchedGroupedCiphertext3HandlesValidityProofData {
-    pub(crate) inner: BatchedGroupedCiphertext3HandlesValidityProofData,
+#[wasm_bindgen]
+pub struct BatchedGroupedCiphertext3HandlesValidityProofData {
+    pub(crate) inner:
+        batched_grouped_ciphertext_validity::BatchedGroupedCiphertext3HandlesValidityProofData,
 }
 
 crate::conversion::impl_inner_conversion!(
-    WasmBatchedGroupedCiphertext3HandlesValidityProofData,
-    BatchedGroupedCiphertext3HandlesValidityProofData
+    BatchedGroupedCiphertext3HandlesValidityProofData,
+    batched_grouped_ciphertext_validity::BatchedGroupedCiphertext3HandlesValidityProofData
 );
 
 #[wasm_bindgen]
-impl WasmBatchedGroupedCiphertext3HandlesValidityProofData {
+impl BatchedGroupedCiphertext3HandlesValidityProofData {
     /// Creates a new batched grouped ciphertext validity proof with three handles.
     #[wasm_bindgen(constructor)]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        first_pubkey: &WasmElGamalPubkey,
-        second_pubkey: &WasmElGamalPubkey,
-        third_pubkey: &WasmElGamalPubkey,
-        grouped_ciphertext_lo: &WasmGroupedElGamalCiphertext3Handles,
-        grouped_ciphertext_hi: &WasmGroupedElGamalCiphertext3Handles,
+        first_pubkey: &ElGamalPubkey,
+        second_pubkey: &ElGamalPubkey,
+        third_pubkey: &ElGamalPubkey,
+        grouped_ciphertext_lo: &GroupedElGamalCiphertext3Handles,
+        grouped_ciphertext_hi: &GroupedElGamalCiphertext3Handles,
         amount_lo: u64,
         amount_hi: u64,
-        opening_lo: &WasmPedersenOpening,
-        opening_hi: &WasmPedersenOpening,
-    ) -> Result<WasmBatchedGroupedCiphertext3HandlesValidityProofData, JsValue> {
-        BatchedGroupedCiphertext3HandlesValidityProofData::new(
+        opening_lo: &PedersenOpening,
+        opening_hi: &PedersenOpening,
+    ) -> Result<BatchedGroupedCiphertext3HandlesValidityProofData, JsValue> {
+        batched_grouped_ciphertext_validity::BatchedGroupedCiphertext3HandlesValidityProofData::new(
             &first_pubkey.inner,
             &second_pubkey.inner,
             &third_pubkey.inner,
@@ -59,7 +56,7 @@ impl WasmBatchedGroupedCiphertext3HandlesValidityProofData {
 
     /// Returns the context data associated with the proof.
     #[wasm_bindgen]
-    pub fn context(&self) -> WasmBatchedGroupedCiphertext3HandlesValidityProofContext {
+    pub fn context(&self) -> BatchedGroupedCiphertext3HandlesValidityProofContext {
         self.inner.context.into()
     }
 
@@ -77,8 +74,10 @@ impl WasmBatchedGroupedCiphertext3HandlesValidityProofData {
     #[wasm_bindgen(js_name = "fromBytes")]
     pub fn from_bytes(
         bytes: &Uint8Array,
-    ) -> Result<WasmBatchedGroupedCiphertext3HandlesValidityProofData, JsValue> {
-        let expected_len = std::mem::size_of::<BatchedGroupedCiphertext3HandlesValidityProofData>();
+    ) -> Result<BatchedGroupedCiphertext3HandlesValidityProofData, JsValue> {
+        let expected_len = std::mem::size_of::<
+            batched_grouped_ciphertext_validity::BatchedGroupedCiphertext3HandlesValidityProofData,
+        >();
         if bytes.length() as usize != expected_len {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for BatchedGroupedCiphertext3HandlesValidityProof: expected {}, got {}",
@@ -91,7 +90,7 @@ impl WasmBatchedGroupedCiphertext3HandlesValidityProofData {
         bytes.copy_to(&mut data);
 
         bytemuck::try_from_bytes(&data)
-            .map(|pod: &BatchedGroupedCiphertext3HandlesValidityProofData| Self { inner: *pod })
+            .map(|pod: &batched_grouped_ciphertext_validity::BatchedGroupedCiphertext3HandlesValidityProofData| Self { inner: *pod })
             .map_err(|_| {
                 JsValue::from_str("Invalid bytes for BatchedGroupedCiphertext3HandlesValidityProof")
             })
@@ -106,26 +105,27 @@ impl WasmBatchedGroupedCiphertext3HandlesValidityProofData {
 
 /// The context data needed to verify a batched grouped ciphertext 3-handles validity proof.
 #[wasm_bindgen]
-pub struct WasmBatchedGroupedCiphertext3HandlesValidityProofContext {
-    pub(crate) inner: BatchedGroupedCiphertext3HandlesValidityProofContext,
+pub struct BatchedGroupedCiphertext3HandlesValidityProofContext {
+    pub(crate) inner:
+        batched_grouped_ciphertext_validity::BatchedGroupedCiphertext3HandlesValidityProofContext,
 }
 
 crate::conversion::impl_inner_conversion!(
-    WasmBatchedGroupedCiphertext3HandlesValidityProofContext,
-    BatchedGroupedCiphertext3HandlesValidityProofContext
+    BatchedGroupedCiphertext3HandlesValidityProofContext,
+    batched_grouped_ciphertext_validity::BatchedGroupedCiphertext3HandlesValidityProofContext
 );
 
 #[wasm_bindgen]
-impl WasmBatchedGroupedCiphertext3HandlesValidityProofContext {
+impl BatchedGroupedCiphertext3HandlesValidityProofContext {
     /// Deserializes a batched grouped ciphertext 3-handles validity proof context from a byte slice.
     /// Throws an error if the bytes are invalid.
     #[wasm_bindgen(js_name = "fromBytes")]
     pub fn from_bytes(
         bytes: &Uint8Array,
-    ) -> Result<WasmBatchedGroupedCiphertext3HandlesValidityProofContext, JsValue> {
+    ) -> Result<BatchedGroupedCiphertext3HandlesValidityProofContext, JsValue> {
         // Define expected length as a constant for stack allocation
         const EXPECTED_LEN: usize =
-            std::mem::size_of::<BatchedGroupedCiphertext3HandlesValidityProofContext>();
+            std::mem::size_of::<batched_grouped_ciphertext_validity::BatchedGroupedCiphertext3HandlesValidityProofContext>();
         if bytes.length() as usize != EXPECTED_LEN {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for BatchedGroupedCiphertext3HandlesValidityProofContext: expected {}, got {}",
@@ -136,7 +136,7 @@ impl WasmBatchedGroupedCiphertext3HandlesValidityProofContext {
         let mut data = [0u8; EXPECTED_LEN];
         bytes.copy_to(&mut data);
         bytemuck::try_from_bytes(&data)
-            .map(|pod: &BatchedGroupedCiphertext3HandlesValidityProofContext| Self { inner: *pod })
+            .map(|pod: &batched_grouped_ciphertext_validity::BatchedGroupedCiphertext3HandlesValidityProofContext| Self { inner: *pod })
             .map_err(|_| {
                 JsValue::from_str(
                     "Invalid bytes for BatchedGroupedCiphertext3HandlesValidityProofContext",
@@ -154,21 +154,21 @@ impl WasmBatchedGroupedCiphertext3HandlesValidityProofContext {
 #[cfg(test)]
 mod tests {
     use {
-        super::*, crate::encryption::elgamal::WasmElGamalKeypair,
+        super::*, crate::encryption::elgamal::ElGamalKeypair,
         solana_zk_sdk::encryption::grouped_elgamal::GroupedElGamal, wasm_bindgen_test::*,
     };
 
     #[wasm_bindgen_test]
     fn test_batched_grouped_ciphertext_3_handles_validity_proof_creation_and_verification() {
-        let first_keypair = WasmElGamalKeypair::new_rand();
-        let second_keypair = WasmElGamalKeypair::new_rand();
-        let third_keypair = WasmElGamalKeypair::new_rand();
+        let first_keypair = ElGamalKeypair::new_rand();
+        let second_keypair = ElGamalKeypair::new_rand();
+        let third_keypair = ElGamalKeypair::new_rand();
         let amount_lo: u64 = 11;
         let amount_hi: u64 = 22;
-        let opening_lo = WasmPedersenOpening::new_rand();
-        let opening_hi = WasmPedersenOpening::new_rand();
+        let opening_lo = PedersenOpening::new_rand();
+        let opening_hi = PedersenOpening::new_rand();
 
-        let grouped_ciphertext_lo = WasmGroupedElGamalCiphertext3Handles {
+        let grouped_ciphertext_lo = GroupedElGamalCiphertext3Handles {
             inner: GroupedElGamal::encrypt_with(
                 [
                     &first_keypair.pubkey().inner,
@@ -180,7 +180,7 @@ mod tests {
             ),
         };
 
-        let grouped_ciphertext_hi = WasmGroupedElGamalCiphertext3Handles {
+        let grouped_ciphertext_hi = GroupedElGamalCiphertext3Handles {
             inner: GroupedElGamal::encrypt_with(
                 [
                     &first_keypair.pubkey().inner,
@@ -192,7 +192,7 @@ mod tests {
             ),
         };
 
-        let proof = WasmBatchedGroupedCiphertext3HandlesValidityProofData::new(
+        let proof = BatchedGroupedCiphertext3HandlesValidityProofData::new(
             &first_keypair.pubkey(),
             &second_keypair.pubkey(),
             &third_keypair.pubkey(),
@@ -210,15 +210,15 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_batched_grouped_ciphertext_3_handles_validity_proof_bytes_roundtrip() {
-        let first_keypair = WasmElGamalKeypair::new_rand();
-        let second_keypair = WasmElGamalKeypair::new_rand();
-        let third_keypair = WasmElGamalKeypair::new_rand();
+        let first_keypair = ElGamalKeypair::new_rand();
+        let second_keypair = ElGamalKeypair::new_rand();
+        let third_keypair = ElGamalKeypair::new_rand();
         let amount_lo: u64 = 11;
         let amount_hi: u64 = 22;
-        let opening_lo = WasmPedersenOpening::new_rand();
-        let opening_hi = WasmPedersenOpening::new_rand();
+        let opening_lo = PedersenOpening::new_rand();
+        let opening_hi = PedersenOpening::new_rand();
 
-        let grouped_ciphertext_lo = WasmGroupedElGamalCiphertext3Handles {
+        let grouped_ciphertext_lo = GroupedElGamalCiphertext3Handles {
             inner: GroupedElGamal::encrypt_with(
                 [
                     &first_keypair.pubkey().inner,
@@ -230,7 +230,7 @@ mod tests {
             ),
         };
 
-        let grouped_ciphertext_hi = WasmGroupedElGamalCiphertext3Handles {
+        let grouped_ciphertext_hi = GroupedElGamalCiphertext3Handles {
             inner: GroupedElGamal::encrypt_with(
                 [
                     &first_keypair.pubkey().inner,
@@ -242,7 +242,7 @@ mod tests {
             ),
         };
 
-        let proof = WasmBatchedGroupedCiphertext3HandlesValidityProofData::new(
+        let proof = BatchedGroupedCiphertext3HandlesValidityProofData::new(
             &first_keypair.pubkey(),
             &second_keypair.pubkey(),
             &third_keypair.pubkey(),
@@ -256,7 +256,7 @@ mod tests {
         .unwrap();
 
         let bytes = proof.to_bytes();
-        let recovered_proof = WasmBatchedGroupedCiphertext3HandlesValidityProofData::from_bytes(
+        let recovered_proof = BatchedGroupedCiphertext3HandlesValidityProofData::from_bytes(
             &Uint8Array::from(bytes.as_slice()),
         )
         .unwrap();
@@ -265,11 +265,10 @@ mod tests {
 
         let context = proof.context();
         let context_bytes = context.to_bytes();
-        let recovered_context =
-            WasmBatchedGroupedCiphertext3HandlesValidityProofContext::from_bytes(
-                &Uint8Array::from(context_bytes.as_slice()),
-            )
-            .unwrap();
+        let recovered_context = BatchedGroupedCiphertext3HandlesValidityProofContext::from_bytes(
+            &Uint8Array::from(context_bytes.as_slice()),
+        )
+        .unwrap();
         assert_eq!(context_bytes, recovered_context.to_bytes());
     }
 }

--- a/zk-sdk-wasm-js/src/proof_data/batched_grouped_ciphertext_validity/mod.rs
+++ b/zk-sdk-wasm-js/src/proof_data/batched_grouped_ciphertext_validity/mod.rs
@@ -3,11 +3,11 @@ mod handles_3;
 
 pub use {
     handles_2::{
-        WasmBatchedGroupedCiphertext2HandlesValidityProofContext,
-        WasmBatchedGroupedCiphertext2HandlesValidityProofData,
+        BatchedGroupedCiphertext2HandlesValidityProofContext,
+        BatchedGroupedCiphertext2HandlesValidityProofData,
     },
     handles_3::{
-        WasmBatchedGroupedCiphertext3HandlesValidityProofContext,
-        WasmBatchedGroupedCiphertext3HandlesValidityProofData,
+        BatchedGroupedCiphertext3HandlesValidityProofContext,
+        BatchedGroupedCiphertext3HandlesValidityProofData,
     },
 };

--- a/zk-sdk-wasm-js/src/proof_data/batched_range_proof/mod.rs
+++ b/zk-sdk-wasm-js/src/proof_data/batched_range_proof/mod.rs
@@ -1,6 +1,5 @@
 use {
-    js_sys::Uint8Array,
-    solana_zk_sdk::zk_elgamal_proof_program::proof_data::batched_range_proof::BatchedRangeProofContext,
+    js_sys::Uint8Array, solana_zk_sdk::zk_elgamal_proof_program::proof_data::batched_range_proof,
     wasm_bindgen::prelude::*,
 };
 
@@ -10,21 +9,25 @@ pub mod batched_range_proof_u64;
 
 /// The context data for a batched range proof. This context is shared by all
 /// batched range proof instructions.
-#[wasm_bindgen(js_name = "BatchedRangeProofContext")]
-pub struct WasmBatchedRangeProofContext {
-    pub(crate) inner: BatchedRangeProofContext,
+#[wasm_bindgen]
+pub struct BatchedRangeProofContext {
+    pub(crate) inner: batched_range_proof::BatchedRangeProofContext,
 }
 
-crate::conversion::impl_inner_conversion!(WasmBatchedRangeProofContext, BatchedRangeProofContext);
+crate::conversion::impl_inner_conversion!(
+    BatchedRangeProofContext,
+    batched_range_proof::BatchedRangeProofContext
+);
 
 #[wasm_bindgen]
-impl WasmBatchedRangeProofContext {
+impl BatchedRangeProofContext {
     /// Deserializes a batched range proof context from a byte slice.
     /// Throws an error if the bytes are invalid.
     #[wasm_bindgen(js_name = "fromBytes")]
-    pub fn from_bytes(bytes: &Uint8Array) -> Result<WasmBatchedRangeProofContext, JsValue> {
+    pub fn from_bytes(bytes: &Uint8Array) -> Result<BatchedRangeProofContext, JsValue> {
         // Define expected length as a constant for stack allocation
-        const EXPECTED_LEN: usize = std::mem::size_of::<BatchedRangeProofContext>();
+        const EXPECTED_LEN: usize =
+            std::mem::size_of::<batched_range_proof::BatchedRangeProofContext>();
         if bytes.length() as usize != EXPECTED_LEN {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for BatchedRangeProofContext: expected {}, got {}",
@@ -37,7 +40,7 @@ impl WasmBatchedRangeProofContext {
         bytes.copy_to(&mut data);
 
         bytemuck::try_from_bytes(&data)
-            .map(|pod: &BatchedRangeProofContext| Self { inner: *pod })
+            .map(|pod: &batched_range_proof::BatchedRangeProofContext| Self { inner: *pod })
             .map_err(|_| JsValue::from_str("Invalid bytes for BatchedRangeProofContext"))
     }
 
@@ -54,13 +57,13 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_batched_range_proof_context_bytes_roundtrip() {
-        let context = WasmBatchedRangeProofContext {
-            inner: BatchedRangeProofContext::zeroed(),
+        let context = BatchedRangeProofContext {
+            inner: batched_range_proof::BatchedRangeProofContext::zeroed(),
         };
 
         let bytes = context.to_bytes();
         let recovered_context =
-            WasmBatchedRangeProofContext::from_bytes(&Uint8Array::from(bytes.as_slice())).unwrap();
+            BatchedRangeProofContext::from_bytes(&Uint8Array::from(bytes.as_slice())).unwrap();
 
         assert_eq!(bytes, recovered_context.to_bytes());
     }

--- a/zk-sdk-wasm-js/src/proof_data/ciphertext_ciphertext_equality.rs
+++ b/zk-sdk-wasm-js/src/proof_data/ciphertext_ciphertext_equality.rs
@@ -1,44 +1,41 @@
 use {
     crate::encryption::{
-        elgamal::{WasmElGamalCiphertext, WasmElGamalKeypair, WasmElGamalPubkey},
-        pedersen::WasmPedersenOpening,
+        elgamal::{ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey},
+        pedersen::PedersenOpening,
     },
     js_sys::Uint8Array,
     solana_zk_sdk::zk_elgamal_proof_program::proof_data::{
-        ciphertext_ciphertext_equality::{
-            CiphertextCiphertextEqualityProofContext, CiphertextCiphertextEqualityProofData,
-        },
-        ZkProofData,
+        ciphertext_ciphertext_equality, ZkProofData,
     },
     wasm_bindgen::prelude::*,
 };
 
 /// A ciphertext-ciphertext equality proof. This proof certifies that two ElGamal
 /// ciphertexts encrypt the same message.
-#[wasm_bindgen(js_name = "CiphertextCiphertextEqualityProof")]
-pub struct WasmCiphertextCiphertextEqualityProofData {
-    pub(crate) inner: CiphertextCiphertextEqualityProofData,
+#[wasm_bindgen]
+pub struct CiphertextCiphertextEqualityProofData {
+    pub(crate) inner: ciphertext_ciphertext_equality::CiphertextCiphertextEqualityProofData,
 }
 
 crate::conversion::impl_inner_conversion!(
-    WasmCiphertextCiphertextEqualityProofData,
-    CiphertextCiphertextEqualityProofData
+    CiphertextCiphertextEqualityProofData,
+    ciphertext_ciphertext_equality::CiphertextCiphertextEqualityProofData
 );
 
 #[wasm_bindgen]
-impl WasmCiphertextCiphertextEqualityProofData {
+impl CiphertextCiphertextEqualityProofData {
     /// Creates a new ciphertext-ciphertext equality proof.
     #[wasm_bindgen(constructor)]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        first_keypair: &WasmElGamalKeypair,
-        second_pubkey: &WasmElGamalPubkey,
-        first_ciphertext: &WasmElGamalCiphertext,
-        second_ciphertext: &WasmElGamalCiphertext,
-        second_opening: &WasmPedersenOpening,
+        first_keypair: &ElGamalKeypair,
+        second_pubkey: &ElGamalPubkey,
+        first_ciphertext: &ElGamalCiphertext,
+        second_ciphertext: &ElGamalCiphertext,
+        second_opening: &PedersenOpening,
         amount: u64,
-    ) -> Result<WasmCiphertextCiphertextEqualityProofData, JsValue> {
-        CiphertextCiphertextEqualityProofData::new(
+    ) -> Result<CiphertextCiphertextEqualityProofData, JsValue> {
+        ciphertext_ciphertext_equality::CiphertextCiphertextEqualityProofData::new(
             &first_keypair.inner,
             &second_pubkey.inner,
             &first_ciphertext.inner,
@@ -52,7 +49,7 @@ impl WasmCiphertextCiphertextEqualityProofData {
 
     /// Returns the context data associated with the proof.
     #[wasm_bindgen]
-    pub fn context(&self) -> WasmCiphertextCiphertextEqualityProofContext {
+    pub fn context(&self) -> CiphertextCiphertextEqualityProofContext {
         self.inner.context.into()
     }
 
@@ -70,9 +67,11 @@ impl WasmCiphertextCiphertextEqualityProofData {
     #[wasm_bindgen(js_name = "fromBytes")]
     pub fn from_bytes(
         bytes: &Uint8Array,
-    ) -> Result<WasmCiphertextCiphertextEqualityProofData, JsValue> {
+    ) -> Result<CiphertextCiphertextEqualityProofData, JsValue> {
         // Define expected length as a constant for stack allocation
-        const EXPECTED_LEN: usize = std::mem::size_of::<CiphertextCiphertextEqualityProofData>();
+        const EXPECTED_LEN: usize = std::mem::size_of::<
+            ciphertext_ciphertext_equality::CiphertextCiphertextEqualityProofData,
+        >();
         if bytes.length() as usize != EXPECTED_LEN {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for CiphertextCiphertextEqualityProof: expected {}, got {}",
@@ -85,7 +84,11 @@ impl WasmCiphertextCiphertextEqualityProofData {
         bytes.copy_to(&mut data);
 
         bytemuck::try_from_bytes(&data)
-            .map(|pod: &CiphertextCiphertextEqualityProofData| Self { inner: *pod })
+            .map(
+                |pod: &ciphertext_ciphertext_equality::CiphertextCiphertextEqualityProofData| {
+                    Self { inner: *pod }
+                },
+            )
             .map_err(|_| JsValue::from_str("Invalid bytes for CiphertextCiphertextEqualityProof"))
     }
 
@@ -98,24 +101,26 @@ impl WasmCiphertextCiphertextEqualityProofData {
 
 /// The context data needed to verify a ciphertext-ciphertext equality proof.
 #[wasm_bindgen]
-pub struct WasmCiphertextCiphertextEqualityProofContext {
-    pub(crate) inner: CiphertextCiphertextEqualityProofContext,
+pub struct CiphertextCiphertextEqualityProofContext {
+    pub(crate) inner: ciphertext_ciphertext_equality::CiphertextCiphertextEqualityProofContext,
 }
 
 crate::conversion::impl_inner_conversion!(
-    WasmCiphertextCiphertextEqualityProofContext,
-    CiphertextCiphertextEqualityProofContext
+    CiphertextCiphertextEqualityProofContext,
+    ciphertext_ciphertext_equality::CiphertextCiphertextEqualityProofContext
 );
 
 #[wasm_bindgen]
-impl WasmCiphertextCiphertextEqualityProofContext {
+impl CiphertextCiphertextEqualityProofContext {
     /// Deserializes a ciphertext-ciphertext equality proof context from a byte slice.
     /// Throws an error if the bytes are invalid.
     #[wasm_bindgen(js_name = "fromBytes")]
     pub fn from_bytes(
         bytes: &Uint8Array,
-    ) -> Result<WasmCiphertextCiphertextEqualityProofContext, JsValue> {
-        let expected_len = std::mem::size_of::<CiphertextCiphertextEqualityProofContext>();
+    ) -> Result<CiphertextCiphertextEqualityProofContext, JsValue> {
+        let expected_len = std::mem::size_of::<
+            ciphertext_ciphertext_equality::CiphertextCiphertextEqualityProofContext,
+        >();
         if bytes.length() as usize != expected_len {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for CiphertextCiphertextEqualityProofContext: expected {}, got {}",
@@ -126,7 +131,11 @@ impl WasmCiphertextCiphertextEqualityProofContext {
         let mut data = vec![0u8; expected_len];
         bytes.copy_to(&mut data);
         bytemuck::try_from_bytes(&data)
-            .map(|pod: &CiphertextCiphertextEqualityProofContext| Self { inner: *pod })
+            .map(
+                |pod: &ciphertext_ciphertext_equality::CiphertextCiphertextEqualityProofContext| {
+                    Self { inner: *pod }
+                },
+            )
             .map_err(|_| {
                 JsValue::from_str("Invalid bytes for CiphertextCiphertextEqualityProofContext")
             })
@@ -145,20 +154,20 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_ciphertext_ciphertext_equality_proof_creation_and_verification() {
-        let first_keypair = WasmElGamalKeypair::new_rand();
-        let second_keypair = WasmElGamalKeypair::new_rand();
+        let first_keypair = ElGamalKeypair::new_rand();
+        let second_keypair = ElGamalKeypair::new_rand();
         let amount: u64 = 55;
 
         let first_ciphertext = first_keypair.pubkey().encrypt_u64(amount);
-        let second_opening = WasmPedersenOpening::new_rand();
-        let second_ciphertext = WasmElGamalCiphertext {
+        let second_opening = PedersenOpening::new_rand();
+        let second_ciphertext = ElGamalCiphertext {
             inner: second_keypair
                 .pubkey()
                 .inner
                 .encrypt_with(amount, &second_opening.inner),
         };
 
-        let proof = WasmCiphertextCiphertextEqualityProofData::new(
+        let proof = CiphertextCiphertextEqualityProofData::new(
             &first_keypair,
             &second_keypair.pubkey(),
             &first_ciphertext,
@@ -173,20 +182,20 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_ciphertext_ciphertext_equality_proof_bytes_roundtrip() {
-        let first_keypair = WasmElGamalKeypair::new_rand();
-        let second_keypair = WasmElGamalKeypair::new_rand();
+        let first_keypair = ElGamalKeypair::new_rand();
+        let second_keypair = ElGamalKeypair::new_rand();
         let amount: u64 = 55;
 
         let first_ciphertext = first_keypair.pubkey().encrypt_u64(amount);
-        let second_opening = WasmPedersenOpening::new_rand();
-        let second_ciphertext = WasmElGamalCiphertext {
+        let second_opening = PedersenOpening::new_rand();
+        let second_ciphertext = ElGamalCiphertext {
             inner: second_keypair
                 .pubkey()
                 .inner
                 .encrypt_with(amount, &second_opening.inner),
         };
 
-        let proof = WasmCiphertextCiphertextEqualityProofData::new(
+        let proof = CiphertextCiphertextEqualityProofData::new(
             &first_keypair,
             &second_keypair.pubkey(),
             &first_ciphertext,
@@ -197,16 +206,15 @@ mod tests {
         .unwrap();
 
         let bytes = proof.to_bytes();
-        let recovered_proof = WasmCiphertextCiphertextEqualityProofData::from_bytes(
-            &Uint8Array::from(bytes.as_slice()),
-        )
-        .unwrap();
+        let recovered_proof =
+            CiphertextCiphertextEqualityProofData::from_bytes(&Uint8Array::from(bytes.as_slice()))
+                .unwrap();
 
         assert_eq!(proof.to_bytes(), recovered_proof.to_bytes());
 
         let context = proof.context();
         let context_bytes = context.to_bytes();
-        let recovered_context = WasmCiphertextCiphertextEqualityProofContext::from_bytes(
+        let recovered_context = CiphertextCiphertextEqualityProofContext::from_bytes(
             &Uint8Array::from(context_bytes.as_slice()),
         )
         .unwrap();

--- a/zk-sdk-wasm-js/src/proof_data/ciphertext_commitment_equality.rs
+++ b/zk-sdk-wasm-js/src/proof_data/ciphertext_commitment_equality.rs
@@ -1,43 +1,40 @@
 use {
     crate::encryption::{
-        elgamal::{WasmElGamalCiphertext, WasmElGamalKeypair, WasmElGamalPubkey},
-        pedersen::{WasmPedersenCommitment, WasmPedersenOpening},
+        elgamal::{ElGamalCiphertext, ElGamalKeypair, ElGamalPubkey},
+        pedersen::{PedersenCommitment, PedersenOpening},
     },
     js_sys::Uint8Array,
     solana_zk_sdk::zk_elgamal_proof_program::proof_data::{
-        ciphertext_commitment_equality::{
-            CiphertextCommitmentEqualityProofContext, CiphertextCommitmentEqualityProofData,
-        },
-        ZkProofData,
+        ciphertext_commitment_equality, ZkProofData,
     },
     wasm_bindgen::prelude::*,
 };
 
 /// A ciphertext-commitment equality proof. This proof certifies that an ElGamal
 /// ciphertext and a Pedersen commitment encrypt/encode the same message.
-#[wasm_bindgen(js_name = "CiphertextCommitmentEqualityProof")]
-pub struct WasmCiphertextCommitmentEqualityProofData {
-    pub(crate) inner: CiphertextCommitmentEqualityProofData,
+#[wasm_bindgen]
+pub struct CiphertextCommitmentEqualityProofData {
+    pub(crate) inner: ciphertext_commitment_equality::CiphertextCommitmentEqualityProofData,
 }
 
 crate::conversion::impl_inner_conversion!(
-    WasmCiphertextCommitmentEqualityProofData,
-    CiphertextCommitmentEqualityProofData
+    CiphertextCommitmentEqualityProofData,
+    ciphertext_commitment_equality::CiphertextCommitmentEqualityProofData
 );
 
 #[wasm_bindgen]
-impl WasmCiphertextCommitmentEqualityProofData {
+impl CiphertextCommitmentEqualityProofData {
     /// Creates a new ciphertext-commitment equality proof.
     #[wasm_bindgen(constructor)]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        keypair: &WasmElGamalKeypair,
-        ciphertext: &WasmElGamalCiphertext,
-        commitment: &WasmPedersenCommitment,
-        opening: &WasmPedersenOpening,
+        keypair: &ElGamalKeypair,
+        ciphertext: &ElGamalCiphertext,
+        commitment: &PedersenCommitment,
+        opening: &PedersenOpening,
         amount: u64,
-    ) -> Result<WasmCiphertextCommitmentEqualityProofData, JsValue> {
-        CiphertextCommitmentEqualityProofData::new(
+    ) -> Result<CiphertextCommitmentEqualityProofData, JsValue> {
+        ciphertext_commitment_equality::CiphertextCommitmentEqualityProofData::new(
             &keypair.inner,
             &ciphertext.inner,
             &commitment.inner,
@@ -50,7 +47,7 @@ impl WasmCiphertextCommitmentEqualityProofData {
 
     /// Returns the context data associated with the proof.
     #[wasm_bindgen]
-    pub fn context(&self) -> WasmCiphertextCommitmentEqualityProofContext {
+    pub fn context(&self) -> CiphertextCommitmentEqualityProofContext {
         self.inner.context.into()
     }
 
@@ -68,9 +65,11 @@ impl WasmCiphertextCommitmentEqualityProofData {
     #[wasm_bindgen(js_name = "fromBytes")]
     pub fn from_bytes(
         bytes: &Uint8Array,
-    ) -> Result<WasmCiphertextCommitmentEqualityProofData, JsValue> {
+    ) -> Result<CiphertextCommitmentEqualityProofData, JsValue> {
         // Define expected length as a constant for stack allocation
-        const EXPECTED_LEN: usize = std::mem::size_of::<CiphertextCommitmentEqualityProofData>();
+        const EXPECTED_LEN: usize = std::mem::size_of::<
+            ciphertext_commitment_equality::CiphertextCommitmentEqualityProofData,
+        >();
         if bytes.length() as usize != EXPECTED_LEN {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for CiphertextCommitmentEqualityProof: expected {}, got {}",
@@ -83,7 +82,11 @@ impl WasmCiphertextCommitmentEqualityProofData {
         bytes.copy_to(&mut data);
 
         bytemuck::try_from_bytes(&data)
-            .map(|pod: &CiphertextCommitmentEqualityProofData| Self { inner: *pod })
+            .map(
+                |pod: &ciphertext_commitment_equality::CiphertextCommitmentEqualityProofData| {
+                    Self { inner: *pod }
+                },
+            )
             .map_err(|_| JsValue::from_str("Invalid bytes for CiphertextCommitmentEqualityProof"))
     }
 
@@ -96,24 +99,26 @@ impl WasmCiphertextCommitmentEqualityProofData {
 
 /// The context data needed to verify a ciphertext-commitment equality proof.
 #[wasm_bindgen]
-pub struct WasmCiphertextCommitmentEqualityProofContext {
-    pub(crate) inner: CiphertextCommitmentEqualityProofContext,
+pub struct CiphertextCommitmentEqualityProofContext {
+    pub(crate) inner: ciphertext_commitment_equality::CiphertextCommitmentEqualityProofContext,
 }
 
 crate::conversion::impl_inner_conversion!(
-    WasmCiphertextCommitmentEqualityProofContext,
-    CiphertextCommitmentEqualityProofContext
+    CiphertextCommitmentEqualityProofContext,
+    ciphertext_commitment_equality::CiphertextCommitmentEqualityProofContext
 );
 
 #[wasm_bindgen]
-impl WasmCiphertextCommitmentEqualityProofContext {
+impl CiphertextCommitmentEqualityProofContext {
     /// Deserializes a ciphertext-commitment equality proof context from a byte slice.
     /// Throws an error if the bytes are invalid.
     #[wasm_bindgen(js_name = "fromBytes")]
     pub fn from_bytes(
         bytes: &Uint8Array,
-    ) -> Result<WasmCiphertextCommitmentEqualityProofContext, JsValue> {
-        let expected_len = std::mem::size_of::<CiphertextCommitmentEqualityProofContext>();
+    ) -> Result<CiphertextCommitmentEqualityProofContext, JsValue> {
+        let expected_len = std::mem::size_of::<
+            ciphertext_commitment_equality::CiphertextCommitmentEqualityProofContext,
+        >();
         if bytes.length() as usize != expected_len {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for CiphertextCommitmentEqualityProofContext: expected {}, got {}",
@@ -124,7 +129,11 @@ impl WasmCiphertextCommitmentEqualityProofContext {
         let mut data = vec![0u8; expected_len];
         bytes.copy_to(&mut data);
         bytemuck::try_from_bytes(&data)
-            .map(|pod: &CiphertextCommitmentEqualityProofContext| Self { inner: *pod })
+            .map(
+                |pod: &ciphertext_commitment_equality::CiphertextCommitmentEqualityProofContext| {
+                    Self { inner: *pod }
+                },
+            )
             .map_err(|_| {
                 JsValue::from_str("Invalid bytes for CiphertextCommitmentEqualityProofContext")
             })
@@ -143,14 +152,14 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_ciphertext_commitment_equality_proof_creation_and_verification() {
-        let keypair = WasmElGamalKeypair::new_rand();
+        let keypair = ElGamalKeypair::new_rand();
         let amount: u64 = 55;
 
         let ciphertext = keypair.pubkey().encrypt_u64(amount);
-        let opening = WasmPedersenOpening::new_rand();
-        let commitment = WasmPedersenCommitment::with_u64(amount, &opening);
+        let opening = PedersenOpening::new_rand();
+        let commitment = PedersenCommitment::with_u64(amount, &opening);
 
-        let proof = WasmCiphertextCommitmentEqualityProofData::new(
+        let proof = CiphertextCommitmentEqualityProofData::new(
             &keypair,
             &ciphertext,
             &commitment,
@@ -164,14 +173,14 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_ciphertext_commitment_equality_proof_bytes_roundtrip() {
-        let keypair = WasmElGamalKeypair::new_rand();
+        let keypair = ElGamalKeypair::new_rand();
         let amount: u64 = 55;
 
         let ciphertext = keypair.pubkey().encrypt_u64(amount);
-        let opening = WasmPedersenOpening::new_rand();
-        let commitment = WasmPedersenCommitment::with_u64(amount, &opening);
+        let opening = PedersenOpening::new_rand();
+        let commitment = PedersenCommitment::with_u64(amount, &opening);
 
-        let proof = WasmCiphertextCommitmentEqualityProofData::new(
+        let proof = CiphertextCommitmentEqualityProofData::new(
             &keypair,
             &ciphertext,
             &commitment,
@@ -181,16 +190,15 @@ mod tests {
         .unwrap();
 
         let bytes = proof.to_bytes();
-        let recovered_proof = WasmCiphertextCommitmentEqualityProofData::from_bytes(
-            &Uint8Array::from(bytes.as_slice()),
-        )
-        .unwrap();
+        let recovered_proof =
+            CiphertextCommitmentEqualityProofData::from_bytes(&Uint8Array::from(bytes.as_slice()))
+                .unwrap();
 
         assert_eq!(proof.to_bytes(), recovered_proof.to_bytes());
 
         let context = proof.context();
         let context_bytes = context.to_bytes();
-        let recovered_context = WasmCiphertextCommitmentEqualityProofContext::from_bytes(
+        let recovered_context = CiphertextCommitmentEqualityProofContext::from_bytes(
             &Uint8Array::from(context_bytes.as_slice()),
         )
         .unwrap();

--- a/zk-sdk-wasm-js/src/proof_data/grouped_ciphertext_validity/handles_2.rs
+++ b/zk-sdk-wasm-js/src/proof_data/grouped_ciphertext_validity/handles_2.rs
@@ -1,43 +1,39 @@
 use {
     crate::encryption::{
-        elgamal::WasmElGamalPubkey, grouped_elgamal::WasmGroupedElGamalCiphertext2Handles,
-        pedersen::WasmPedersenOpening,
+        elgamal::ElGamalPubkey, grouped_elgamal::GroupedElGamalCiphertext2Handles,
+        pedersen::PedersenOpening,
     },
     js_sys::Uint8Array,
     solana_zk_sdk::zk_elgamal_proof_program::proof_data::{
-        grouped_ciphertext_validity::{
-            GroupedCiphertext2HandlesValidityProofContext,
-            GroupedCiphertext2HandlesValidityProofData,
-        },
-        ZkProofData,
+        grouped_ciphertext_validity, ZkProofData,
     },
     wasm_bindgen::prelude::*,
 };
 
 /// A grouped ciphertext validity proof with two decryption handles. This proof certifies
 /// that a given grouped ElGamal ciphertext with two handles is well-formed.
-#[wasm_bindgen(js_name = "GroupedCiphertext2HandlesValidityProof")]
-pub struct WasmGroupedCiphertext2HandlesValidityProofData {
-    pub(crate) inner: GroupedCiphertext2HandlesValidityProofData,
+#[wasm_bindgen]
+pub struct GroupedCiphertext2HandlesValidityProofData {
+    pub(crate) inner: grouped_ciphertext_validity::GroupedCiphertext2HandlesValidityProofData,
 }
 
 crate::conversion::impl_inner_conversion!(
-    WasmGroupedCiphertext2HandlesValidityProofData,
-    GroupedCiphertext2HandlesValidityProofData
+    GroupedCiphertext2HandlesValidityProofData,
+    grouped_ciphertext_validity::GroupedCiphertext2HandlesValidityProofData
 );
 
 #[wasm_bindgen]
-impl WasmGroupedCiphertext2HandlesValidityProofData {
+impl GroupedCiphertext2HandlesValidityProofData {
     /// Creates a new grouped ciphertext validity proof with two handles.
     #[wasm_bindgen(constructor)]
     pub fn new(
-        first_pubkey: &WasmElGamalPubkey,
-        second_pubkey: &WasmElGamalPubkey,
-        grouped_ciphertext: &WasmGroupedElGamalCiphertext2Handles,
+        first_pubkey: &ElGamalPubkey,
+        second_pubkey: &ElGamalPubkey,
+        grouped_ciphertext: &GroupedElGamalCiphertext2Handles,
         amount: u64,
-        opening: &WasmPedersenOpening,
-    ) -> Result<WasmGroupedCiphertext2HandlesValidityProofData, JsValue> {
-        GroupedCiphertext2HandlesValidityProofData::new(
+        opening: &PedersenOpening,
+    ) -> Result<GroupedCiphertext2HandlesValidityProofData, JsValue> {
+        grouped_ciphertext_validity::GroupedCiphertext2HandlesValidityProofData::new(
             &first_pubkey.inner,
             &second_pubkey.inner,
             &grouped_ciphertext.inner,
@@ -50,7 +46,7 @@ impl WasmGroupedCiphertext2HandlesValidityProofData {
 
     /// Returns the context data associated with the proof.
     #[wasm_bindgen]
-    pub fn context(&self) -> WasmGroupedCiphertext2HandlesValidityProofContext {
+    pub fn context(&self) -> GroupedCiphertext2HandlesValidityProofContext {
         self.inner.context.into()
     }
 
@@ -68,8 +64,10 @@ impl WasmGroupedCiphertext2HandlesValidityProofData {
     #[wasm_bindgen(js_name = "fromBytes")]
     pub fn from_bytes(
         bytes: &Uint8Array,
-    ) -> Result<WasmGroupedCiphertext2HandlesValidityProofData, JsValue> {
-        let expected_len = std::mem::size_of::<GroupedCiphertext2HandlesValidityProofData>();
+    ) -> Result<GroupedCiphertext2HandlesValidityProofData, JsValue> {
+        let expected_len = std::mem::size_of::<
+            grouped_ciphertext_validity::GroupedCiphertext2HandlesValidityProofData,
+        >();
         if bytes.length() as usize != expected_len {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for GroupedCiphertext2HandlesValidityProof: expected {}, got {}",
@@ -82,7 +80,11 @@ impl WasmGroupedCiphertext2HandlesValidityProofData {
         bytes.copy_to(&mut data);
 
         bytemuck::try_from_bytes(&data)
-            .map(|pod: &GroupedCiphertext2HandlesValidityProofData| Self { inner: *pod })
+            .map(
+                |pod: &grouped_ciphertext_validity::GroupedCiphertext2HandlesValidityProofData| {
+                    Self { inner: *pod }
+                },
+            )
             .map_err(|_| {
                 JsValue::from_str("Invalid bytes for GroupedCiphertext2HandlesValidityProof")
             })
@@ -97,26 +99,27 @@ impl WasmGroupedCiphertext2HandlesValidityProofData {
 
 /// The context data needed to verify a grouped ciphertext 2-handles validity proof.
 #[wasm_bindgen]
-pub struct WasmGroupedCiphertext2HandlesValidityProofContext {
-    pub(crate) inner: GroupedCiphertext2HandlesValidityProofContext,
+pub struct GroupedCiphertext2HandlesValidityProofContext {
+    pub(crate) inner: grouped_ciphertext_validity::GroupedCiphertext2HandlesValidityProofContext,
 }
 
 crate::conversion::impl_inner_conversion!(
-    WasmGroupedCiphertext2HandlesValidityProofContext,
-    GroupedCiphertext2HandlesValidityProofContext
+    GroupedCiphertext2HandlesValidityProofContext,
+    grouped_ciphertext_validity::GroupedCiphertext2HandlesValidityProofContext
 );
 
 #[wasm_bindgen]
-impl WasmGroupedCiphertext2HandlesValidityProofContext {
+impl GroupedCiphertext2HandlesValidityProofContext {
     /// Deserializes a grouped ciphertext 2-handles validity proof context from a byte slice.
     /// Throws an error if the bytes are invalid.
     #[wasm_bindgen(js_name = "fromBytes")]
     pub fn from_bytes(
         bytes: &Uint8Array,
-    ) -> Result<WasmGroupedCiphertext2HandlesValidityProofContext, JsValue> {
+    ) -> Result<GroupedCiphertext2HandlesValidityProofContext, JsValue> {
         // Define expected length as a constant for stack allocation
-        const EXPECTED_LEN: usize =
-            std::mem::size_of::<GroupedCiphertext2HandlesValidityProofContext>();
+        const EXPECTED_LEN: usize = std::mem::size_of::<
+            grouped_ciphertext_validity::GroupedCiphertext2HandlesValidityProofContext,
+        >();
         if bytes.length() as usize != EXPECTED_LEN {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for GroupedCiphertext2HandlesValidityProofContext: expected {}, got {}",
@@ -127,7 +130,7 @@ impl WasmGroupedCiphertext2HandlesValidityProofContext {
         let mut data = [0u8; EXPECTED_LEN];
         bytes.copy_to(&mut data);
         bytemuck::try_from_bytes(&data)
-            .map(|pod: &GroupedCiphertext2HandlesValidityProofContext| Self { inner: *pod })
+            .map(|pod: &grouped_ciphertext_validity::GroupedCiphertext2HandlesValidityProofContext| Self { inner: *pod })
             .map_err(|_| {
                 JsValue::from_str("Invalid bytes for GroupedCiphertext2HandlesValidityProofContext")
             })
@@ -143,18 +146,18 @@ impl WasmGroupedCiphertext2HandlesValidityProofContext {
 #[cfg(test)]
 mod tests {
     use {
-        super::*, crate::encryption::elgamal::WasmElGamalKeypair,
+        super::*, crate::encryption::elgamal::ElGamalKeypair,
         solana_zk_sdk::encryption::grouped_elgamal::GroupedElGamal, wasm_bindgen_test::*,
     };
 
     #[wasm_bindgen_test]
     fn test_grouped_ciphertext_2_handles_validity_proof_creation_and_verification() {
-        let first_keypair = WasmElGamalKeypair::new_rand();
-        let second_keypair = WasmElGamalKeypair::new_rand();
+        let first_keypair = ElGamalKeypair::new_rand();
+        let second_keypair = ElGamalKeypair::new_rand();
         let amount: u64 = 55;
-        let opening = WasmPedersenOpening::new_rand();
+        let opening = PedersenOpening::new_rand();
 
-        let grouped_ciphertext = WasmGroupedElGamalCiphertext2Handles {
+        let grouped_ciphertext = GroupedElGamalCiphertext2Handles {
             inner: GroupedElGamal::encrypt_with(
                 [
                     &first_keypair.pubkey().inner,
@@ -165,7 +168,7 @@ mod tests {
             ),
         };
 
-        let proof = WasmGroupedCiphertext2HandlesValidityProofData::new(
+        let proof = GroupedCiphertext2HandlesValidityProofData::new(
             &first_keypair.pubkey(),
             &second_keypair.pubkey(),
             &grouped_ciphertext,
@@ -179,12 +182,12 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_grouped_ciphertext_2_handles_validity_proof_bytes_roundtrip() {
-        let first_keypair = WasmElGamalKeypair::new_rand();
-        let second_keypair = WasmElGamalKeypair::new_rand();
+        let first_keypair = ElGamalKeypair::new_rand();
+        let second_keypair = ElGamalKeypair::new_rand();
         let amount: u64 = 55;
-        let opening = WasmPedersenOpening::new_rand();
+        let opening = PedersenOpening::new_rand();
 
-        let grouped_ciphertext = WasmGroupedElGamalCiphertext2Handles {
+        let grouped_ciphertext = GroupedElGamalCiphertext2Handles {
             inner: GroupedElGamal::encrypt_with(
                 [
                     &first_keypair.pubkey().inner,
@@ -195,7 +198,7 @@ mod tests {
             ),
         };
 
-        let proof = WasmGroupedCiphertext2HandlesValidityProofData::new(
+        let proof = GroupedCiphertext2HandlesValidityProofData::new(
             &first_keypair.pubkey(),
             &second_keypair.pubkey(),
             &grouped_ciphertext,
@@ -205,7 +208,7 @@ mod tests {
         .unwrap();
 
         let bytes = proof.to_bytes();
-        let recovered_proof = WasmGroupedCiphertext2HandlesValidityProofData::from_bytes(
+        let recovered_proof = GroupedCiphertext2HandlesValidityProofData::from_bytes(
             &Uint8Array::from(bytes.as_slice()),
         )
         .unwrap();
@@ -214,7 +217,7 @@ mod tests {
 
         let context = proof.context();
         let context_bytes = context.to_bytes();
-        let recovered_context = WasmGroupedCiphertext2HandlesValidityProofContext::from_bytes(
+        let recovered_context = GroupedCiphertext2HandlesValidityProofContext::from_bytes(
             &Uint8Array::from(context_bytes.as_slice()),
         )
         .unwrap();

--- a/zk-sdk-wasm-js/src/proof_data/grouped_ciphertext_validity/handles_3.rs
+++ b/zk-sdk-wasm-js/src/proof_data/grouped_ciphertext_validity/handles_3.rs
@@ -1,45 +1,41 @@
 use {
     crate::encryption::{
-        elgamal::WasmElGamalPubkey, grouped_elgamal::WasmGroupedElGamalCiphertext3Handles,
-        pedersen::WasmPedersenOpening,
+        elgamal::ElGamalPubkey, grouped_elgamal::GroupedElGamalCiphertext3Handles,
+        pedersen::PedersenOpening,
     },
     js_sys::Uint8Array,
     solana_zk_sdk::zk_elgamal_proof_program::proof_data::{
-        grouped_ciphertext_validity::{
-            GroupedCiphertext3HandlesValidityProofContext,
-            GroupedCiphertext3HandlesValidityProofData,
-        },
-        ZkProofData,
+        grouped_ciphertext_validity, ZkProofData,
     },
     wasm_bindgen::prelude::*,
 };
 
 /// A grouped ciphertext validity proof with three decryption handles. This proof certifies
 /// that a given grouped ElGamal ciphertext with three handles is well-formed.
-#[wasm_bindgen(js_name = "GroupedCiphertext3HandlesValidityProof")]
-pub struct WasmGroupedCiphertext3HandlesValidityProofData {
-    pub(crate) inner: GroupedCiphertext3HandlesValidityProofData,
+#[wasm_bindgen]
+pub struct GroupedCiphertext3HandlesValidityProofData {
+    pub(crate) inner: grouped_ciphertext_validity::GroupedCiphertext3HandlesValidityProofData,
 }
 
 crate::conversion::impl_inner_conversion!(
-    WasmGroupedCiphertext3HandlesValidityProofData,
-    GroupedCiphertext3HandlesValidityProofData
+    GroupedCiphertext3HandlesValidityProofData,
+    grouped_ciphertext_validity::GroupedCiphertext3HandlesValidityProofData
 );
 
 #[wasm_bindgen]
-impl WasmGroupedCiphertext3HandlesValidityProofData {
+impl GroupedCiphertext3HandlesValidityProofData {
     /// Creates a new grouped ciphertext validity proof with three handles.
     #[wasm_bindgen(constructor)]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        first_pubkey: &WasmElGamalPubkey,
-        second_pubkey: &WasmElGamalPubkey,
-        third_pubkey: &WasmElGamalPubkey,
-        grouped_ciphertext: &WasmGroupedElGamalCiphertext3Handles,
+        first_pubkey: &ElGamalPubkey,
+        second_pubkey: &ElGamalPubkey,
+        third_pubkey: &ElGamalPubkey,
+        grouped_ciphertext: &GroupedElGamalCiphertext3Handles,
         amount: u64,
-        opening: &WasmPedersenOpening,
-    ) -> Result<WasmGroupedCiphertext3HandlesValidityProofData, JsValue> {
-        GroupedCiphertext3HandlesValidityProofData::new(
+        opening: &PedersenOpening,
+    ) -> Result<GroupedCiphertext3HandlesValidityProofData, JsValue> {
+        grouped_ciphertext_validity::GroupedCiphertext3HandlesValidityProofData::new(
             &first_pubkey.inner,
             &second_pubkey.inner,
             &third_pubkey.inner,
@@ -53,7 +49,7 @@ impl WasmGroupedCiphertext3HandlesValidityProofData {
 
     /// Returns the context data associated with the proof.
     #[wasm_bindgen]
-    pub fn context(&self) -> WasmGroupedCiphertext3HandlesValidityProofContext {
+    pub fn context(&self) -> GroupedCiphertext3HandlesValidityProofContext {
         self.inner.context.into()
     }
 
@@ -71,8 +67,10 @@ impl WasmGroupedCiphertext3HandlesValidityProofData {
     #[wasm_bindgen(js_name = "fromBytes")]
     pub fn from_bytes(
         bytes: &Uint8Array,
-    ) -> Result<WasmGroupedCiphertext3HandlesValidityProofData, JsValue> {
-        let expected_len = std::mem::size_of::<GroupedCiphertext3HandlesValidityProofData>();
+    ) -> Result<GroupedCiphertext3HandlesValidityProofData, JsValue> {
+        let expected_len = std::mem::size_of::<
+            grouped_ciphertext_validity::GroupedCiphertext3HandlesValidityProofData,
+        >();
         if bytes.length() as usize != expected_len {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for GroupedCiphertext3HandlesValidityProof: expected {}, got {}",
@@ -85,7 +83,11 @@ impl WasmGroupedCiphertext3HandlesValidityProofData {
         bytes.copy_to(&mut data);
 
         bytemuck::try_from_bytes(&data)
-            .map(|pod: &GroupedCiphertext3HandlesValidityProofData| Self { inner: *pod })
+            .map(
+                |pod: &grouped_ciphertext_validity::GroupedCiphertext3HandlesValidityProofData| {
+                    Self { inner: *pod }
+                },
+            )
             .map_err(|_| {
                 JsValue::from_str("Invalid bytes for GroupedCiphertext3HandlesValidityProof")
             })
@@ -100,26 +102,27 @@ impl WasmGroupedCiphertext3HandlesValidityProofData {
 
 /// The context data needed to verify a grouped ciphertext 3-handles validity proof.
 #[wasm_bindgen]
-pub struct WasmGroupedCiphertext3HandlesValidityProofContext {
-    pub(crate) inner: GroupedCiphertext3HandlesValidityProofContext,
+pub struct GroupedCiphertext3HandlesValidityProofContext {
+    pub(crate) inner: grouped_ciphertext_validity::GroupedCiphertext3HandlesValidityProofContext,
 }
 
 crate::conversion::impl_inner_conversion!(
-    WasmGroupedCiphertext3HandlesValidityProofContext,
-    GroupedCiphertext3HandlesValidityProofContext
+    GroupedCiphertext3HandlesValidityProofContext,
+    grouped_ciphertext_validity::GroupedCiphertext3HandlesValidityProofContext
 );
 
 #[wasm_bindgen]
-impl WasmGroupedCiphertext3HandlesValidityProofContext {
+impl GroupedCiphertext3HandlesValidityProofContext {
     /// Deserializes a grouped ciphertext 3-handles validity proof context from a byte slice.
     /// Throws an error if the bytes are invalid.
     #[wasm_bindgen(js_name = "fromBytes")]
     pub fn from_bytes(
         bytes: &Uint8Array,
-    ) -> Result<WasmGroupedCiphertext3HandlesValidityProofContext, JsValue> {
+    ) -> Result<GroupedCiphertext3HandlesValidityProofContext, JsValue> {
         // Define expected length as a constant for stack allocation
-        const EXPECTED_LEN: usize =
-            std::mem::size_of::<GroupedCiphertext3HandlesValidityProofContext>();
+        const EXPECTED_LEN: usize = std::mem::size_of::<
+            grouped_ciphertext_validity::GroupedCiphertext3HandlesValidityProofContext,
+        >();
         if bytes.length() as usize != EXPECTED_LEN {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for GroupedCiphertext3HandlesValidityProofContext: expected {}, got {}",
@@ -130,7 +133,7 @@ impl WasmGroupedCiphertext3HandlesValidityProofContext {
         let mut data = [0u8; EXPECTED_LEN];
         bytes.copy_to(&mut data);
         bytemuck::try_from_bytes(&data)
-            .map(|pod: &GroupedCiphertext3HandlesValidityProofContext| Self { inner: *pod })
+            .map(|pod: &grouped_ciphertext_validity::GroupedCiphertext3HandlesValidityProofContext| Self { inner: *pod })
             .map_err(|_| {
                 JsValue::from_str("Invalid bytes for GroupedCiphertext3HandlesValidityProofContext")
             })
@@ -146,19 +149,19 @@ impl WasmGroupedCiphertext3HandlesValidityProofContext {
 #[cfg(test)]
 mod tests {
     use {
-        super::*, crate::encryption::elgamal::WasmElGamalKeypair,
+        super::*, crate::encryption::elgamal::ElGamalKeypair,
         solana_zk_sdk::encryption::grouped_elgamal::GroupedElGamal, wasm_bindgen_test::*,
     };
 
     #[wasm_bindgen_test]
     fn test_grouped_ciphertext_3_handles_validity_proof_creation_and_verification() {
-        let first_keypair = WasmElGamalKeypair::new_rand();
-        let second_keypair = WasmElGamalKeypair::new_rand();
-        let third_keypair = WasmElGamalKeypair::new_rand();
+        let first_keypair = ElGamalKeypair::new_rand();
+        let second_keypair = ElGamalKeypair::new_rand();
+        let third_keypair = ElGamalKeypair::new_rand();
         let amount: u64 = 55;
-        let opening = WasmPedersenOpening::new_rand();
+        let opening = PedersenOpening::new_rand();
 
-        let grouped_ciphertext = WasmGroupedElGamalCiphertext3Handles {
+        let grouped_ciphertext = GroupedElGamalCiphertext3Handles {
             inner: GroupedElGamal::encrypt_with(
                 [
                     &first_keypair.pubkey().inner,
@@ -170,7 +173,7 @@ mod tests {
             ),
         };
 
-        let proof = WasmGroupedCiphertext3HandlesValidityProofData::new(
+        let proof = GroupedCiphertext3HandlesValidityProofData::new(
             &first_keypair.pubkey(),
             &second_keypair.pubkey(),
             &third_keypair.pubkey(),
@@ -185,13 +188,13 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_grouped_ciphertext_3_handles_validity_proof_bytes_roundtrip() {
-        let first_keypair = WasmElGamalKeypair::new_rand();
-        let second_keypair = WasmElGamalKeypair::new_rand();
-        let third_keypair = WasmElGamalKeypair::new_rand();
+        let first_keypair = ElGamalKeypair::new_rand();
+        let second_keypair = ElGamalKeypair::new_rand();
+        let third_keypair = ElGamalKeypair::new_rand();
         let amount: u64 = 55;
-        let opening = WasmPedersenOpening::new_rand();
+        let opening = PedersenOpening::new_rand();
 
-        let grouped_ciphertext = WasmGroupedElGamalCiphertext3Handles {
+        let grouped_ciphertext = GroupedElGamalCiphertext3Handles {
             inner: GroupedElGamal::encrypt_with(
                 [
                     &first_keypair.pubkey().inner,
@@ -203,7 +206,7 @@ mod tests {
             ),
         };
 
-        let proof = WasmGroupedCiphertext3HandlesValidityProofData::new(
+        let proof = GroupedCiphertext3HandlesValidityProofData::new(
             &first_keypair.pubkey(),
             &second_keypair.pubkey(),
             &third_keypair.pubkey(),
@@ -214,7 +217,7 @@ mod tests {
         .unwrap();
 
         let bytes = proof.to_bytes();
-        let recovered_proof = WasmGroupedCiphertext3HandlesValidityProofData::from_bytes(
+        let recovered_proof = GroupedCiphertext3HandlesValidityProofData::from_bytes(
             &Uint8Array::from(bytes.as_slice()),
         )
         .unwrap();
@@ -223,7 +226,7 @@ mod tests {
 
         let context = proof.context();
         let context_bytes = context.to_bytes();
-        let recovered_context = WasmGroupedCiphertext3HandlesValidityProofContext::from_bytes(
+        let recovered_context = GroupedCiphertext3HandlesValidityProofContext::from_bytes(
             &Uint8Array::from(context_bytes.as_slice()),
         )
         .unwrap();

--- a/zk-sdk-wasm-js/src/proof_data/grouped_ciphertext_validity/mod.rs
+++ b/zk-sdk-wasm-js/src/proof_data/grouped_ciphertext_validity/mod.rs
@@ -3,11 +3,9 @@ mod handles_3;
 
 pub use {
     handles_2::{
-        WasmGroupedCiphertext2HandlesValidityProofContext,
-        WasmGroupedCiphertext2HandlesValidityProofData,
+        GroupedCiphertext2HandlesValidityProofContext, GroupedCiphertext2HandlesValidityProofData,
     },
     handles_3::{
-        WasmGroupedCiphertext3HandlesValidityProofContext,
-        WasmGroupedCiphertext3HandlesValidityProofData,
+        GroupedCiphertext3HandlesValidityProofContext, GroupedCiphertext3HandlesValidityProofData,
     },
 };

--- a/zk-sdk-wasm-js/src/proof_data/mod.rs
+++ b/zk-sdk-wasm-js/src/proof_data/mod.rs
@@ -9,29 +9,27 @@ pub mod zero_ciphertext;
 
 pub use {
     batched_grouped_ciphertext_validity::{
-        WasmBatchedGroupedCiphertext2HandlesValidityProofContext,
-        WasmBatchedGroupedCiphertext2HandlesValidityProofData,
-        WasmBatchedGroupedCiphertext3HandlesValidityProofContext,
-        WasmBatchedGroupedCiphertext3HandlesValidityProofData,
+        BatchedGroupedCiphertext2HandlesValidityProofContext,
+        BatchedGroupedCiphertext2HandlesValidityProofData,
+        BatchedGroupedCiphertext3HandlesValidityProofContext,
+        BatchedGroupedCiphertext3HandlesValidityProofData,
     },
     batched_range_proof::{
-        batched_range_proof_u128::WasmBatchedRangeProofU128Data,
-        batched_range_proof_u256::WasmBatchedRangeProofU256Data,
-        batched_range_proof_u64::WasmBatchedRangeProofU64Data, WasmBatchedRangeProofContext,
+        batched_range_proof_u128::BatchedRangeProofU128Data,
+        batched_range_proof_u256::BatchedRangeProofU256Data,
+        batched_range_proof_u64::BatchedRangeProofU64Data, BatchedRangeProofContext,
     },
     ciphertext_ciphertext_equality::{
-        WasmCiphertextCiphertextEqualityProofContext, WasmCiphertextCiphertextEqualityProofData,
+        CiphertextCiphertextEqualityProofContext, CiphertextCiphertextEqualityProofData,
     },
     ciphertext_commitment_equality::{
-        WasmCiphertextCommitmentEqualityProofContext, WasmCiphertextCommitmentEqualityProofData,
+        CiphertextCommitmentEqualityProofContext, CiphertextCommitmentEqualityProofData,
     },
     grouped_ciphertext_validity::{
-        WasmGroupedCiphertext2HandlesValidityProofContext,
-        WasmGroupedCiphertext2HandlesValidityProofData,
-        WasmGroupedCiphertext3HandlesValidityProofContext,
-        WasmGroupedCiphertext3HandlesValidityProofData,
+        GroupedCiphertext2HandlesValidityProofContext, GroupedCiphertext2HandlesValidityProofData,
+        GroupedCiphertext3HandlesValidityProofContext, GroupedCiphertext3HandlesValidityProofData,
     },
-    percentage_with_cap::{WasmPercentageWithCapProofContext, WasmPercentageWithCapProofData},
-    pubkey_validity::{WasmPubkeyValidityProofContext, WasmPubkeyValidityProofData},
-    zero_ciphertext::{WasmZeroCiphertextProofContext, WasmZeroCiphertextProofData},
+    percentage_with_cap::{PercentageWithCapProofContext, PercentageWithCapProofData},
+    pubkey_validity::{PubkeyValidityProofContext, PubkeyValidityProofData},
+    zero_ciphertext::{ZeroCiphertextProofContext, ZeroCiphertextProofData},
 };

--- a/zk-sdk-wasm-js/src/proof_data/percentage_with_cap.rs
+++ b/zk-sdk-wasm-js/src/proof_data/percentage_with_cap.rs
@@ -1,42 +1,39 @@
 use {
-    crate::encryption::pedersen::{WasmPedersenCommitment, WasmPedersenOpening},
+    crate::encryption::pedersen::{PedersenCommitment, PedersenOpening},
     js_sys::Uint8Array,
-    solana_zk_sdk::zk_elgamal_proof_program::proof_data::{
-        percentage_with_cap::{PercentageWithCapProofContext, PercentageWithCapProofData},
-        ZkProofData,
-    },
+    solana_zk_sdk::zk_elgamal_proof_program::proof_data::{percentage_with_cap, ZkProofData},
     wasm_bindgen::prelude::*,
 };
 
 /// A percentage-with-cap proof. This proof is used to certify that a transfer
 /// amount is within a certain percentage of a base amount, with a cap.
-#[wasm_bindgen(js_name = "PercentageWithCapProof")]
-pub struct WasmPercentageWithCapProofData {
-    pub(crate) inner: PercentageWithCapProofData,
+#[wasm_bindgen]
+pub struct PercentageWithCapProofData {
+    pub(crate) inner: percentage_with_cap::PercentageWithCapProofData,
 }
 
 crate::conversion::impl_inner_conversion!(
-    WasmPercentageWithCapProofData,
-    PercentageWithCapProofData
+    PercentageWithCapProofData,
+    percentage_with_cap::PercentageWithCapProofData
 );
 
 #[wasm_bindgen]
-impl WasmPercentageWithCapProofData {
+impl PercentageWithCapProofData {
     /// Creates a new percentage-with-cap proof.
     #[wasm_bindgen(constructor)]
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        percentage_commitment: &WasmPedersenCommitment,
-        percentage_opening: &WasmPedersenOpening,
+        percentage_commitment: &PedersenCommitment,
+        percentage_opening: &PedersenOpening,
         percentage_amount: u64,
-        delta_commitment: &WasmPedersenCommitment,
-        delta_opening: &WasmPedersenOpening,
+        delta_commitment: &PedersenCommitment,
+        delta_opening: &PedersenOpening,
         delta_amount: u64,
-        claimed_commitment: &WasmPedersenCommitment,
-        claimed_opening: &WasmPedersenOpening,
+        claimed_commitment: &PedersenCommitment,
+        claimed_opening: &PedersenOpening,
         max_value: u64,
-    ) -> Result<WasmPercentageWithCapProofData, JsValue> {
-        PercentageWithCapProofData::new(
+    ) -> Result<PercentageWithCapProofData, JsValue> {
+        percentage_with_cap::PercentageWithCapProofData::new(
             &percentage_commitment.inner,
             &percentage_opening.inner,
             percentage_amount,
@@ -53,7 +50,7 @@ impl WasmPercentageWithCapProofData {
 
     /// Returns the context data associated with the proof.
     #[wasm_bindgen]
-    pub fn context(&self) -> WasmPercentageWithCapProofContext {
+    pub fn context(&self) -> PercentageWithCapProofContext {
         self.inner.context.into()
     }
 
@@ -69,9 +66,10 @@ impl WasmPercentageWithCapProofData {
     /// Deserializes a percentage-with-cap proof from a byte slice.
     /// Throws an error if the bytes are invalid.
     #[wasm_bindgen(js_name = "fromBytes")]
-    pub fn from_bytes(bytes: &Uint8Array) -> Result<WasmPercentageWithCapProofData, JsValue> {
+    pub fn from_bytes(bytes: &Uint8Array) -> Result<PercentageWithCapProofData, JsValue> {
         // Define expected length as a constant for stack allocation
-        const EXPECTED_LEN: usize = std::mem::size_of::<PercentageWithCapProofData>();
+        const EXPECTED_LEN: usize =
+            std::mem::size_of::<percentage_with_cap::PercentageWithCapProofData>();
         if bytes.length() as usize != EXPECTED_LEN {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for PercentageWithCapProof: expected {}, got {}",
@@ -84,7 +82,7 @@ impl WasmPercentageWithCapProofData {
         bytes.copy_to(&mut data);
 
         bytemuck::try_from_bytes(&data)
-            .map(|pod: &PercentageWithCapProofData| Self { inner: *pod })
+            .map(|pod: &percentage_with_cap::PercentageWithCapProofData| Self { inner: *pod })
             .map_err(|_| JsValue::from_str("Invalid bytes for PercentageWithCapProof"))
     }
 
@@ -97,22 +95,23 @@ impl WasmPercentageWithCapProofData {
 
 /// The context data needed to verify a percentage-with-cap proof.
 #[wasm_bindgen]
-pub struct WasmPercentageWithCapProofContext {
-    pub(crate) inner: PercentageWithCapProofContext,
+pub struct PercentageWithCapProofContext {
+    pub(crate) inner: percentage_with_cap::PercentageWithCapProofContext,
 }
 
 crate::conversion::impl_inner_conversion!(
-    WasmPercentageWithCapProofContext,
-    PercentageWithCapProofContext
+    PercentageWithCapProofContext,
+    percentage_with_cap::PercentageWithCapProofContext
 );
 
 #[wasm_bindgen]
-impl WasmPercentageWithCapProofContext {
+impl PercentageWithCapProofContext {
     /// Deserializes a percentage-with-cap proof context from a byte slice.
     /// Throws an error if the bytes are invalid.
     #[wasm_bindgen(js_name = "fromBytes")]
-    pub fn from_bytes(bytes: &Uint8Array) -> Result<WasmPercentageWithCapProofContext, JsValue> {
-        let expected_len = std::mem::size_of::<PercentageWithCapProofContext>();
+    pub fn from_bytes(bytes: &Uint8Array) -> Result<PercentageWithCapProofContext, JsValue> {
+        let expected_len =
+            std::mem::size_of::<percentage_with_cap::PercentageWithCapProofContext>();
         if bytes.length() as usize != expected_len {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for PercentageWithCapProofContext: expected {}, got {}",
@@ -123,7 +122,7 @@ impl WasmPercentageWithCapProofContext {
         let mut data = vec![0u8; expected_len];
         bytes.copy_to(&mut data);
         bytemuck::try_from_bytes(&data)
-            .map(|pod: &PercentageWithCapProofContext| Self { inner: *pod })
+            .map(|pod: &percentage_with_cap::PercentageWithCapProofContext| Self { inner: *pod })
             .map_err(|_| JsValue::from_str("Invalid bytes for PercentageWithCapProofContext"))
     }
 
@@ -144,17 +143,17 @@ mod tests {
         let delta_amount: u64 = 9600;
         let max_value: u64 = 3;
 
-        let percentage_opening = WasmPedersenOpening::new_rand();
+        let percentage_opening = PedersenOpening::new_rand();
         let percentage_commitment =
-            WasmPedersenCommitment::with_u64(percentage_amount, &percentage_opening);
+            PedersenCommitment::with_u64(percentage_amount, &percentage_opening);
 
-        let delta_opening = WasmPedersenOpening::new_rand();
-        let delta_commitment = WasmPedersenCommitment::with_u64(delta_amount, &delta_opening);
+        let delta_opening = PedersenOpening::new_rand();
+        let delta_commitment = PedersenCommitment::with_u64(delta_amount, &delta_opening);
 
-        let claimed_opening = WasmPedersenOpening::new_rand();
-        let claimed_commitment = WasmPedersenCommitment::with_u64(delta_amount, &claimed_opening);
+        let claimed_opening = PedersenOpening::new_rand();
+        let claimed_commitment = PedersenCommitment::with_u64(delta_amount, &claimed_opening);
 
-        let proof = WasmPercentageWithCapProofData::new(
+        let proof = PercentageWithCapProofData::new(
             &percentage_commitment,
             &percentage_opening,
             percentage_amount,
@@ -176,17 +175,17 @@ mod tests {
         let delta_amount: u64 = 9600;
         let max_value: u64 = 3;
 
-        let percentage_opening = WasmPedersenOpening::new_rand();
+        let percentage_opening = PedersenOpening::new_rand();
         let percentage_commitment =
-            WasmPedersenCommitment::with_u64(percentage_amount, &percentage_opening);
+            PedersenCommitment::with_u64(percentage_amount, &percentage_opening);
 
-        let delta_opening = WasmPedersenOpening::new_rand();
-        let delta_commitment = WasmPedersenCommitment::with_u64(delta_amount, &delta_opening);
+        let delta_opening = PedersenOpening::new_rand();
+        let delta_commitment = PedersenCommitment::with_u64(delta_amount, &delta_opening);
 
-        let claimed_opening = WasmPedersenOpening::new_rand();
-        let claimed_commitment = WasmPedersenCommitment::with_u64(delta_amount, &claimed_opening);
+        let claimed_opening = PedersenOpening::new_rand();
+        let claimed_commitment = PedersenCommitment::with_u64(delta_amount, &claimed_opening);
 
-        let proof = WasmPercentageWithCapProofData::new(
+        let proof = PercentageWithCapProofData::new(
             &percentage_commitment,
             &percentage_opening,
             percentage_amount,
@@ -201,17 +200,15 @@ mod tests {
 
         let bytes = proof.to_bytes();
         let recovered_proof =
-            WasmPercentageWithCapProofData::from_bytes(&Uint8Array::from(bytes.as_slice()))
-                .unwrap();
+            PercentageWithCapProofData::from_bytes(&Uint8Array::from(bytes.as_slice())).unwrap();
 
         assert_eq!(proof.to_bytes(), recovered_proof.to_bytes());
 
         let context = proof.context();
         let context_bytes = context.to_bytes();
-        let recovered_context = WasmPercentageWithCapProofContext::from_bytes(&Uint8Array::from(
-            context_bytes.as_slice(),
-        ))
-        .unwrap();
+        let recovered_context =
+            PercentageWithCapProofContext::from_bytes(&Uint8Array::from(context_bytes.as_slice()))
+                .unwrap();
         assert_eq!(context_bytes, recovered_context.to_bytes());
     }
 }

--- a/zk-sdk-wasm-js/src/proof_data/pubkey_validity.rs
+++ b/zk-sdk-wasm-js/src/proof_data/pubkey_validity.rs
@@ -1,35 +1,35 @@
 use {
-    crate::encryption::elgamal::{WasmElGamalKeypair, WasmElGamalPubkey},
+    crate::encryption::elgamal::{ElGamalKeypair, ElGamalPubkey},
     js_sys::Uint8Array,
-    solana_zk_sdk::zk_elgamal_proof_program::proof_data::{
-        pubkey_validity::{PubkeyValidityProofContext, PubkeyValidityProofData},
-        ZkProofData,
-    },
+    solana_zk_sdk::zk_elgamal_proof_program::proof_data::{pubkey_validity, ZkProofData},
     wasm_bindgen::prelude::*,
 };
 
 /// A public-key validity proof. This proof is used to certify that an ElGamal
 /// public key is valid (i.e., the prover knows the corresponding secret key).
-#[wasm_bindgen(js_name = "PubkeyValidityProof")]
-pub struct WasmPubkeyValidityProofData {
-    pub(crate) inner: PubkeyValidityProofData,
+#[wasm_bindgen]
+pub struct PubkeyValidityProofData {
+    pub(crate) inner: pubkey_validity::PubkeyValidityProofData,
 }
 
-crate::conversion::impl_inner_conversion!(WasmPubkeyValidityProofData, PubkeyValidityProofData);
+crate::conversion::impl_inner_conversion!(
+    PubkeyValidityProofData,
+    pubkey_validity::PubkeyValidityProofData
+);
 
 #[wasm_bindgen]
-impl WasmPubkeyValidityProofData {
+impl PubkeyValidityProofData {
     /// Creates a new public-key validity proof.
     #[wasm_bindgen(constructor)]
-    pub fn new(keypair: &WasmElGamalKeypair) -> Result<WasmPubkeyValidityProofData, JsValue> {
-        PubkeyValidityProofData::new(&keypair.inner)
+    pub fn new(keypair: &ElGamalKeypair) -> Result<PubkeyValidityProofData, JsValue> {
+        pubkey_validity::PubkeyValidityProofData::new(&keypair.inner)
             .map(|inner| Self { inner })
             .map_err(|e| JsValue::from_str(&e.to_string()))
     }
 
     /// Returns the context data associated with the proof.
     #[wasm_bindgen]
-    pub fn context(&self) -> WasmPubkeyValidityProofContext {
+    pub fn context(&self) -> PubkeyValidityProofContext {
         self.inner.context.into()
     }
 
@@ -45,9 +45,9 @@ impl WasmPubkeyValidityProofData {
     /// Deserializes a pubkey validity proof from a byte slice.
     /// Throws an error if the bytes are invalid.
     #[wasm_bindgen(js_name = "fromBytes")]
-    pub fn from_bytes(bytes: &Uint8Array) -> Result<WasmPubkeyValidityProofData, JsValue> {
+    pub fn from_bytes(bytes: &Uint8Array) -> Result<PubkeyValidityProofData, JsValue> {
         // Define expected length as a constant for stack allocation
-        const EXPECTED_LEN: usize = std::mem::size_of::<PubkeyValidityProofData>();
+        const EXPECTED_LEN: usize = std::mem::size_of::<pubkey_validity::PubkeyValidityProofData>();
         if bytes.length() as usize != EXPECTED_LEN {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for PubkeyValidityProof: expected {}, got {}",
@@ -60,7 +60,7 @@ impl WasmPubkeyValidityProofData {
         bytes.copy_to(&mut data);
 
         bytemuck::try_from_bytes(&data)
-            .map(|pod: &PubkeyValidityProofData| Self { inner: *pod })
+            .map(|pod: &pubkey_validity::PubkeyValidityProofData| Self { inner: *pod })
             .map_err(|_| JsValue::from_str("Invalid bytes for PubkeyValidityProof"))
     }
 
@@ -73,22 +73,22 @@ impl WasmPubkeyValidityProofData {
 
 /// The context data needed to verify a public-key validity proof.
 #[wasm_bindgen]
-pub struct WasmPubkeyValidityProofContext {
-    pub(crate) inner: PubkeyValidityProofContext,
+pub struct PubkeyValidityProofContext {
+    pub(crate) inner: pubkey_validity::PubkeyValidityProofContext,
 }
 
 crate::conversion::impl_inner_conversion!(
-    WasmPubkeyValidityProofContext,
-    PubkeyValidityProofContext
+    PubkeyValidityProofContext,
+    pubkey_validity::PubkeyValidityProofContext
 );
 
 #[wasm_bindgen]
-impl WasmPubkeyValidityProofContext {
+impl PubkeyValidityProofContext {
     /// Deserializes a public-key validity proof context from a byte slice.
     /// Throws an error if the bytes are invalid.
     #[wasm_bindgen(js_name = "fromBytes")]
-    pub fn from_bytes(bytes: &Uint8Array) -> Result<WasmPubkeyValidityProofContext, JsValue> {
-        let expected_len = std::mem::size_of::<PubkeyValidityProofContext>();
+    pub fn from_bytes(bytes: &Uint8Array) -> Result<PubkeyValidityProofContext, JsValue> {
+        let expected_len = std::mem::size_of::<pubkey_validity::PubkeyValidityProofContext>();
         if bytes.length() as usize != expected_len {
             return Err(JsValue::from_str(&format!(
                 "Invalid byte length for PubkeyValidityProofContext: expected {}, got {}",
@@ -99,7 +99,7 @@ impl WasmPubkeyValidityProofContext {
         let mut data = vec![0u8; expected_len];
         bytes.copy_to(&mut data);
         bytemuck::try_from_bytes(&data)
-            .map(|pod: &PubkeyValidityProofContext| Self { inner: *pod })
+            .map(|pod: &pubkey_validity::PubkeyValidityProofContext| Self { inner: *pod })
             .map_err(|_| JsValue::from_str("Invalid bytes for PubkeyValidityProofContext"))
     }
 
@@ -116,26 +116,26 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_pubkey_validity_proof_creation_and_verification() {
-        let keypair = WasmElGamalKeypair::new_rand();
-        let proof = WasmPubkeyValidityProofData::new(&keypair).unwrap();
+        let keypair = ElGamalKeypair::new_rand();
+        let proof = PubkeyValidityProofData::new(&keypair).unwrap();
         assert!(proof.verify().is_ok());
     }
 
     #[wasm_bindgen_test]
     fn test_pubkey_validity_proof_bytes_roundtrip() {
-        let keypair = WasmElGamalKeypair::new_rand();
-        let proof = WasmPubkeyValidityProofData::new(&keypair).unwrap();
+        let keypair = ElGamalKeypair::new_rand();
+        let proof = PubkeyValidityProofData::new(&keypair).unwrap();
 
         let bytes = proof.to_bytes();
         let recovered_proof =
-            WasmPubkeyValidityProofData::from_bytes(&Uint8Array::from(bytes.as_slice())).unwrap();
+            PubkeyValidityProofData::from_bytes(&Uint8Array::from(bytes.as_slice())).unwrap();
 
         assert_eq!(proof.to_bytes(), recovered_proof.to_bytes());
 
         let context = proof.context();
         let context_bytes = context.to_bytes();
         let recovered_context =
-            WasmPubkeyValidityProofContext::from_bytes(&Uint8Array::from(context_bytes.as_slice()))
+            PubkeyValidityProofContext::from_bytes(&Uint8Array::from(context_bytes.as_slice()))
                 .unwrap();
         assert_eq!(context_bytes, recovered_context.to_bytes());
     }


### PR DESCRIPTION
#### Summary of Changes

Removing the `Wasm` prefix to the wrapper types as suggested in https://github.com/solana-program/zk-elgamal-proof/pull/134#discussion_r2445508614 for simplicity and for consistency with the sdk.