### PR TITLE
[zk-sdk-wasm-js] Add scripts to test integration examples

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,6 +136,9 @@ jobs:
       - name: Test ZK SDK Wasm
         run: pnpm zk-sdk-wasm-js:test-wasm
 
+      - name: Run Integration Tests
+        run: pnpm zk-sdk-wasm-js:test-integration
+
   build_programs:
     name: Check ZK SDK SBF build
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "zk-sdk-wasm-js:format": "zx ./scripts/rust/format.mjs zk-sdk-wasm-js",
     "zk-sdk-wasm-js:lint": "zx ./scripts/rust/lint.mjs zk-sdk-wasm-js",
     "zk-sdk-wasm-js:test-wasm": "zx ./scripts/rust/test-wasm.mjs zk-sdk-wasm-js",
+    "zk-sdk-wasm-js:test-integration": "zx ./scripts/rust/test-integration.mjs zk-sdk-wasm-js",
     "solana:check": "zx ./scripts/check-solana-version.mjs",
     "solana:link": "zx ./scripts/link-solana-version.mjs",
     "validator:start": "zx ./scripts/start-validator.mjs",
@@ -25,6 +26,7 @@
   },
   "devDependencies": {
     "@iarna/toml": "^2.2.5",
+    "@playwright/test": "^1.56.1",
     "typescript": "^5.9.3",
     "zx": "^8.8.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@iarna/toml':
         specifier: ^2.2.5
         version: 2.2.5
+      '@playwright/test':
+        specifier: ^1.56.1
+        version: 1.56.1
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -22,6 +25,26 @@ packages:
 
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
+
+  '@playwright/test@1.56.1':
+    resolution: {integrity: sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  playwright-core@1.56.1:
+    resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.56.1:
+    resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -36,6 +59,21 @@ packages:
 snapshots:
 
   '@iarna/toml@2.2.5': {}
+
+  '@playwright/test@1.56.1':
+    dependencies:
+      playwright: 1.56.1
+
+  fsevents@2.3.2:
+    optional: true
+
+  playwright-core@1.56.1: {}
+
+  playwright@1.56.1:
+    dependencies:
+      playwright-core: 1.56.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   typescript@5.9.3: {}
 

--- a/scripts/rust/build-wasm.mjs
+++ b/scripts/rust/build-wasm.mjs
@@ -6,5 +6,16 @@ import {
 } from '../utils.mjs';
 
 const [folder, ...args] = cliArguments();
-const manifestPath = path.join(workingDirectory, folder, 'Cargo.toml');
-await $`cargo build --target wasm32-unknown-unknown --manifest-path ${manifestPath} ${args}`;
+
+if (folder === 'zk-sdk-wasm-js') {
+  const cratePath = path.join(workingDirectory, folder);
+  const compileScriptPath = path.join(cratePath, 'compile-wasm.sh');
+  await $`chmod +x ${compileScriptPath}`;
+  await within(async () => {
+    cd(cratePath);
+    await $`./compile-wasm.sh`;
+  });
+} else {
+  const manifestPath = path.join(workingDirectory, folder, 'Cargo.toml');
+  await $`cargo build --target wasm32-unknown-unknown --manifest-path ${manifestPath} ${args}`;
+}

--- a/scripts/rust/test-integration.mjs
+++ b/scripts/rust/test-integration.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env zx
+import "zx/globals";
+import { cliArguments, workingDirectory } from "../utils.mjs";
+
+const [folder, ...args] = cliArguments();
+const cratePath = path.join(workingDirectory, folder);
+const examplesPath = path.join(cratePath, "examples");
+
+console.log(chalk.blue("\n--- Checking prerequisites ---"));
+if (!fs.existsSync(path.join(cratePath, "dist"))) {
+  console.error(
+    chalk.red(
+      "Error: 'dist' directory not found. The build step (pnpm zk-sdk-wasm-js:build-wasm) must run first.",
+    ),
+  );
+  process.exit(1);
+}
+console.log(chalk.green("✅ Wasm artifacts found."));
+
+console.log(chalk.blue("\n--- Installing dependencies for examples ---"));
+
+const examples = [
+  "node-integration",
+  "web-integration",
+  "vite-integration",
+  "webpack-integration",
+];
+for (const example of examples) {
+  console.log(chalk.yellow(`Installing dependencies for ${example}...`));
+  await $`pnpm install --dir ${path.join(examplesPath, example)}`;
+}
+
+console.log(chalk.blue("\n--- Running Node.js integration test ---"));
+try {
+  await $`pnpm test --dir ${path.join(examplesPath, "node-integration")}`;
+  console.log(chalk.green("✅ Node.js integration test passed."));
+} catch (error) {
+  console.error(chalk.red("❌ Node.js integration test failed."));
+  process.exit(1);
+}
+
+console.log(
+  chalk.blue("\n--- Running Browser integration tests (Playwright) ---"),
+);
+
+console.log(
+  chalk.yellow(
+    "Installing Playwright browsers (Chromium) and system dependencies...",
+  ),
+);
+
+await $`pnpm exec playwright install --with-deps`;
+
+console.log(chalk.yellow("Starting servers and running Playwright tests..."));
+try {
+  await $`pnpm exec playwright test --config ${path.join(examplesPath, "playwright.config.js")}`;
+  console.log(chalk.green("✅ Browser integration tests passed."));
+} catch (error) {
+  console.error(chalk.red("❌ Browser integration tests failed."));
+  process.exit(1);
+}
+
+console.log(chalk.green("\n🎉 All integration tests passed!"));

--- a/zk-sdk-wasm-js/examples/integration.spec.js
+++ b/zk-sdk-wasm-js/examples/integration.spec.js
@@ -1,0 +1,34 @@
+import { test, expect } from "@playwright/test";
+
+async function checkWasmStatus(page) {
+  const status = page.locator("#status");
+
+  await expect(status).not.toHaveClass("running", { timeout: 20000 });
+
+  if (await status.evaluate((el) => el.classList.contains("failure"))) {
+    const logs = await page.locator("#logs").textContent();
+    const message = await status.textContent();
+    throw new Error(
+      `❌ Wasm integration tests failed: ${message}\n--- Logs ---\n${logs}`,
+    );
+  }
+
+  await expect(status).toHaveClass("success");
+}
+
+test.describe("Wasm Integration Tests", () => {
+  test("Web (Static Server) @ 8080", async ({ page }) => {
+    await page.goto("http://localhost:8080");
+    await checkWasmStatus(page);
+  });
+
+  test("Vite (Bundler) @ 8081", async ({ page }) => {
+    await page.goto("http://localhost:8081");
+    await checkWasmStatus(page);
+  });
+
+  test("Webpack (Bundler) @ 8082", async ({ page }) => {
+    await page.goto("http://localhost:8082");
+    await checkWasmStatus(page);
+  });
+});

--- a/zk-sdk-wasm-js/examples/playwright.config.js
+++ b/zk-sdk-wasm-js/examples/playwright.config.js
@@ -1,0 +1,48 @@
+import { defineConfig, devices } from "@playwright/test";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const defineServer = (command, port) => ({
+  command,
+  url: `http://localhost:${port}`,
+  reuseExistingServer: !process.env.CI,
+  waitForNavigation: true,
+});
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const examplePath = (name) => path.resolve(__dirname, name);
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: ["*.spec.js"],
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: "list",
+
+  webServer: [
+    defineServer(`pnpm --dir ${examplePath("web-integration")} start`, 8080),
+    defineServer(`pnpm --dir ${examplePath("vite-integration")} start`, 8081),
+    defineServer(
+      `pnpm --dir ${examplePath("webpack-integration")} start`,
+      8082,
+    ),
+  ],
+
+  use: {
+    trace: "on-first-retry",
+  },
+
+  projects: [
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});


### PR DESCRIPTION
#### Summary of Changes

I added a `test-integration.mjs` script to automatically run all the integration examples and added a `zk-sdk-wasm-js:test-inegration` command to run this script in the main `package.json` for the repository. I also integrated this script to the CI.

For the script, I used [playwright](https://playwright.dev/docs/ci-intro). It might slightly be an overkill for running our simple examples, but it works. The current script just creates a server for each of the web, vite, and webpack examples, runs the examples, and then just checks if the status is `running` instead of getting some error.