### PR TITLE
[zk-sdk] Make sure that the `L_vec` and `R_vec` in inner product proof have the same lengths

### DIFF
--- a/zk-sdk/src/range_proof/errors.rs
+++ b/zk-sdk/src/range_proof/errors.rs
@@ -36,6 +36,8 @@ pub enum RangeProofVerificationError {
     MaximumGeneratorLengthExceeded,
     #[error("commitments and bit lengths vectors have different lengths")]
     VectorLengthMismatch,
+    #[error("L and R vectors in inner product proof have different lengths")]
+    LRVectorLengthMismatch,
 }
 
 #[cfg(not(target_os = "solana"))]

--- a/zk-sdk/src/range_proof/inner_product.rs
+++ b/zk-sdk/src/range_proof/inner_product.rs
@@ -249,6 +249,9 @@ impl InnerProductProof {
         transcript: &mut Transcript,
     ) -> Result<(Vec<Scalar>, Vec<Scalar>, Vec<Scalar>), RangeProofVerificationError> {
         let lg_n = self.L_vec.len();
+        if lg_n != self.R_vec.len() {
+            return Err(RangeProofVerificationError::LRVectorLengthMismatch);
+        }
         if lg_n == 0 || lg_n >= 32 {
             // 4 billion multiplications should be enough for anyone
             // and this check prevents overflow in 1<<lg_n below.


### PR DESCRIPTION
#### Problem

In the range proof API, if the verifier is given a proof with an `R_vec` field of an expected length, the verifier can panic during direct array [indexing](https://github.com/solana-program/zk-elgamal-proof/blob/main/zk-sdk/src/range_proof/inner_product.rs#L278). 

For example, consider an `L_vec` of length 5 and `R_vec` of length 3. Then the [zip](https://github.com/solana-program/zk-elgamal-proof/pull/154) will be short-circuited to result in the `challenges` vector of length 3. But the [indexing](https://github.com/solana-program/zk-elgamal-proof/blob/main/zk-sdk/src/range_proof/inner_product.rs#L278) will continue to 5, resulting in a panic.

This is not an issue for the token22 application or even for the zk elgamal proof program as we only allow fixed bound and fixed length proofs (the range proof module itself is not a public module), but it would be nice to prevent any panicking behavior altogether.

#### Summary of Changes

I considered using the `.get(i)` indexing and handle the error gracefully, but it seems to hurt the readability of the code as there are many indexing in this function. I think the simplest way to handle this is to just check that `L_vec` and `R_vec` are the same length.