### PR TITLE
zk-sdk: Do not require passing owned vectors to `RangeProof`

### DIFF
--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/batched_range_proof_u128.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/batched_range_proof_u128.rs
@@ -10,7 +10,7 @@ use {
             proof_data::batched_range_proof::MAX_COMMITMENTS,
         },
     },
-    std::convert::TryInto,
+    std::{borrow::Borrow, convert::TryInto},
 };
 use {
     crate::{
@@ -39,14 +39,23 @@ pub struct BatchedRangeProofU128Data {
 
 #[cfg(not(target_os = "solana"))]
 impl BatchedRangeProofU128Data {
-    pub fn new(
-        commitments: Vec<&PedersenCommitment>,
-        amounts: Vec<u64>,
-        bit_lengths: Vec<usize>,
-        openings: Vec<&PedersenOpening>,
-    ) -> Result<Self, ProofGenerationError> {
+    pub fn new<C, PC, A, B, O, PO>(
+        commitments: C,
+        amounts: A,
+        bit_lengths: B,
+        openings: O,
+    ) -> Result<Self, ProofGenerationError>
+    where
+        C: AsRef<[PC]>,
+        PC: Borrow<PedersenCommitment>,
+        A: AsRef<[u64]>,
+        B: AsRef<[usize]>,
+        O: AsRef<[PO]>,
+        PO: Borrow<PedersenOpening>,
+    {
         // the sum of the bit lengths must be 128
         let batched_bit_length = bit_lengths
+            .as_ref()
             .iter()
             .try_fold(0_usize, |acc, &x| acc.checked_add(x))
             .ok_or(ProofGenerationError::IllegalAmountBitLength)?;
@@ -102,7 +111,7 @@ impl ZkProofData<BatchedRangeProofContext> for BatchedRangeProofU128Data {
         let proof: RangeProof = self.proof.try_into()?;
 
         proof
-            .verify(commitments.iter().collect(), bit_lengths, &mut transcript)
+            .verify(commitments, bit_lengths, &mut transcript)
             .map_err(|e| e.into())
     }
 }
@@ -138,7 +147,7 @@ mod test {
         let (commitment_8, opening_8) = Pedersen::new(amount_8);
 
         let proof_data = BatchedRangeProofU128Data::new(
-            vec![
+            &[
                 &commitment_1,
                 &commitment_2,
                 &commitment_3,
@@ -148,11 +157,11 @@ mod test {
                 &commitment_7,
                 &commitment_8,
             ],
-            vec![
+            &[
                 amount_1, amount_2, amount_3, amount_4, amount_5, amount_6, amount_7, amount_8,
             ],
-            vec![16, 16, 16, 16, 16, 16, 16, 16],
-            vec![
+            &[16, 16, 16, 16, 16, 16, 16, 16],
+            &[
                 &opening_1, &opening_2, &opening_3, &opening_4, &opening_5, &opening_6, &opening_7,
                 &opening_8,
             ],
@@ -180,7 +189,7 @@ mod test {
         let (commitment_8, opening_8) = Pedersen::new(amount_8);
 
         let proof_data = BatchedRangeProofU128Data::new(
-            vec![
+            &[
                 &commitment_1,
                 &commitment_2,
                 &commitment_3,
@@ -190,11 +199,11 @@ mod test {
                 &commitment_7,
                 &commitment_8,
             ],
-            vec![
+            &[
                 amount_1, amount_2, amount_3, amount_4, amount_5, amount_6, amount_7, amount_8,
             ],
-            vec![16, 16, 16, 16, 16, 16, 16, 16],
-            vec![
+            &[16, 16, 16, 16, 16, 16, 16, 16],
+            &[
                 &opening_1, &opening_2, &opening_3, &opening_4, &opening_5, &opening_6, &opening_7,
                 &opening_8,
             ],

--- a/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/batched_range_proof_u64.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/proof_data/batched_range_proof/batched_range_proof_u64.rs
@@ -10,7 +10,7 @@ use {
             proof_data::batched_range_proof::MAX_COMMITMENTS,
         },
     },
-    std::convert::TryInto,
+    std::{borrow::Borrow, convert::TryInto},
 };
 use {
     crate::{
@@ -39,14 +39,23 @@ pub struct BatchedRangeProofU64Data {
 
 #[cfg(not(target_os = "solana"))]
 impl BatchedRangeProofU64Data {
-    pub fn new(
-        commitments: Vec<&PedersenCommitment>,
-        amounts: Vec<u64>,
-        bit_lengths: Vec<usize>,
-        openings: Vec<&PedersenOpening>,
-    ) -> Result<Self, ProofGenerationError> {
+    pub fn new<C, PC, A, B, O, PO>(
+        commitments: C,
+        amounts: A,
+        bit_lengths: B,
+        openings: O,
+    ) -> Result<Self, ProofGenerationError>
+    where
+        C: AsRef<[PC]>,
+        PC: Borrow<PedersenCommitment>,
+        A: AsRef<[u64]>,
+        B: AsRef<[usize]>,
+        O: AsRef<[PO]>,
+        PO: Borrow<PedersenOpening>,
+    {
         // the sum of the bit lengths must be 64
         let batched_bit_length = bit_lengths
+            .as_ref()
             .iter()
             .try_fold(0_usize, |acc, &x| acc.checked_add(x))
             .ok_or(ProofGenerationError::IllegalAmountBitLength)?;
@@ -60,7 +69,7 @@ impl BatchedRangeProofU64Data {
         }
 
         let context =
-            BatchedRangeProofContext::new(&commitments, &amounts, &bit_lengths, &openings)?;
+            BatchedRangeProofContext::new(commitments, &amounts, &bit_lengths, &openings)?;
 
         let mut transcript = context.new_transcript();
         let proof = RangeProof::new(amounts, bit_lengths, openings, &mut transcript)?
@@ -101,7 +110,7 @@ impl ZkProofData<BatchedRangeProofContext> for BatchedRangeProofU64Data {
         let proof: RangeProof = self.proof.try_into()?;
 
         proof
-            .verify(commitments.iter().collect(), bit_lengths, &mut transcript)
+            .verify(commitments, bit_lengths, &mut transcript)
             .map_err(|e| e.into())
     }
 }
@@ -137,7 +146,7 @@ mod test {
         let (commitment_8, opening_8) = Pedersen::new(amount_8);
 
         let proof_data = BatchedRangeProofU64Data::new(
-            vec![
+            &[
                 &commitment_1,
                 &commitment_2,
                 &commitment_3,
@@ -147,11 +156,11 @@ mod test {
                 &commitment_7,
                 &commitment_8,
             ],
-            vec![
+            &[
                 amount_1, amount_2, amount_3, amount_4, amount_5, amount_6, amount_7, amount_8,
             ],
-            vec![8, 8, 8, 8, 8, 8, 8, 8],
-            vec![
+            &[8, 8, 8, 8, 8, 8, 8, 8],
+            &[
                 &opening_1, &opening_2, &opening_3, &opening_4, &opening_5, &opening_6, &opening_7,
                 &opening_8,
             ],
@@ -179,7 +188,7 @@ mod test {
         let (commitment_8, opening_8) = Pedersen::new(amount_8);
 
         let proof_data = BatchedRangeProofU64Data::new(
-            vec![
+            &[
                 &commitment_1,
                 &commitment_2,
                 &commitment_3,
@@ -189,11 +198,11 @@ mod test {
                 &commitment_7,
                 &commitment_8,
             ],
-            vec![
+            &[
                 amount_1, amount_2, amount_3, amount_4, amount_5, amount_6, amount_7, amount_8,
             ],
-            vec![8, 8, 8, 8, 8, 8, 8, 8],
-            vec![
+            &[8, 8, 8, 8, 8, 8, 8, 8],
+            &[
                 &opening_1, &opening_2, &opening_3, &opening_4, &opening_5, &opening_6, &opening_7,
                 &opening_8,
             ],


### PR DESCRIPTION
The current implementation of `RangeProof::new` and `RangeProof::verify` requires the caller to pass inputs as owned vectors. That requires heap allocations even if the number of inputs is small (even as small as 1).

Remove that requirement by accepting `AsRef<[T]>` trait as inputs, which still makes it possible to pass `Vec<T>`, so we don't break the old users relying on the old API. But for callers who want performance, it accepts also the following types that can be allocated on the stack:

- `[T]`
- `[T; N]`
- `&[T]`

Furthermore, single elements can be passed using `slice::from_ref`[0], e.g.

```rust
let proof = RangeProof::new(
    slice::from_ref(&55),
    slice::from_ref(&64),
    slice::from_ref(&open),
    &mut transcript_create,
)
```

which does not perform any allocation at all. Instead, it performs raw pointer casting to coerce a reference to a single-element slice[1][2].

Additionally, `AsRef<T>` makes it possible to pass the following iterable types:

- `std::slice::Iter<'_, T>`
- `IterMut<'_, T>`
- `IntoIter<T, A>`

[0] https://doc.rust-lang.org/std/slice/fn.from_ref.html
[1] https://github.com/rust-lang/rust/blob/1.92.0/library/core/src/slice/raw.rs#L203-L205
[2] https://github.com/rust-lang/rust/blob/1.92.0/library/core/src/array/mod.rs#L164-L167