### PR TITLE
[zk-sdk] Allow delta amount to be inconsistent with the delta commitment

### DIFF
--- a/zk-sdk/src/encryption/pedersen.rs
+++ b/zk-sdk/src/encryption/pedersen.rs
@@ -476,4 +476,13 @@ mod tests {
 
         assert_eq!(PedersenCommitment::from_bytes(&invalid_bytes), None);
     }
+
+    #[test]
+    fn temp_test() {
+        let temp_g = G;
+        let temp_h = *H;
+
+        println!("G: {:?}", temp_g.compress());
+        println!("H: {:?}", temp_h.compress());
+    }
 }

--- a/zk-sdk/src/encryption/pedersen.rs
+++ b/zk-sdk/src/encryption/pedersen.rs
@@ -476,13 +476,4 @@ mod tests {
 
         assert_eq!(PedersenCommitment::from_bytes(&invalid_bytes), None);
     }
-
-    #[test]
-    fn temp_test() {
-        let temp_g = G;
-        let temp_h = *H;
-
-        println!("G: {:?}", temp_g.compress());
-        println!("H: {:?}", temp_h.compress());
-    }
 }

--- a/zk-sdk/src/zk_elgamal_proof_program/percentage_with_cap.rs
+++ b/zk-sdk/src/zk_elgamal_proof_program/percentage_with_cap.rs
@@ -32,14 +32,11 @@ pub fn build_percentage_with_cap_proof_data(
     if *percentage_commitment != Pedersen::with(percentage_amount, percentage_opening) {
         return Err(ProofGenerationError::InconsistentInput);
     }
-    // Verify delta commitment
-    if *delta_commitment != Pedersen::with(delta_amount, delta_opening) {
-        return Err(ProofGenerationError::InconsistentInput);
-    }
     // Verify claimed commitment
     if *claimed_commitment != Pedersen::with(delta_amount, claimed_opening) {
         return Err(ProofGenerationError::InconsistentInput);
     }
+    // By design, the delta amount can be inconsistent with the delta commitment
 
     let pod_percentage_commitment = PodPedersenCommitment(percentage_commitment.to_bytes());
     let pod_delta_commitment = PodPedersenCommitment(delta_commitment.to_bytes());
@@ -173,5 +170,38 @@ mod test {
         );
 
         assert_eq!(result, Err(ProofGenerationError::InconsistentInput));
+    }
+
+    #[test]
+    fn test_percentage_with_cap_instruction_inconsistent_delta_amount() {
+        let transfer_amount: u64 = 100;
+        let max_value: u64 = 3;
+        let percentage_amount: u64 = 3;
+        let percentage_rate: u64 = 400;
+
+        let (transfer_amount_commitment, transfer_amount_opening) = Pedersen::new(transfer_amount);
+        let (percentage_commitment, percentage_opening) = Pedersen::new(percentage_amount);
+        let delta_commitment =
+            &percentage_commitment * 10_000 - &transfer_amount_commitment * percentage_rate;
+        let delta_opening =
+            &percentage_opening * 10_000 - &transfer_amount_opening * percentage_rate;
+        let (claimed_commitment, claimed_opening) = Pedersen::new(0_u64);
+
+        let delta_amount: u64 = 0; // inconsistent delta amount
+
+        let proof_data = build_percentage_with_cap_proof_data(
+            &percentage_commitment,
+            &percentage_opening,
+            percentage_amount,
+            &delta_commitment,
+            &delta_opening,
+            delta_amount,
+            &claimed_commitment,
+            &claimed_opening,
+            max_value,
+        )
+        .unwrap();
+
+        assert!(proof_data.verify_proof().is_ok());
     }
 }


### PR DESCRIPTION
#### Problem

In https://github.com/solana-program/zk-elgamal-proof/pull/199, I added strict input validation for proof data generation. For most proofs, this works perfectly: if you pass in inputs that don't make mathematical sense, the constructor fails early rather than generating an invalid proof.

However, this validation was too aggressive for the percentage with cap proof, causing the proof generation to fail when a transfer fee hits the maximum capacity.

The Percentage With Cap proof operates on an "OR" condition. It certifies that the committed fee is either:
1. Exactly equal to the calculated percentage (where the remainder/delta math perfectly aligns).
2. Exactly equal to the maximum fee cap.

When a transfer is so large that it hits the maximum fee (Case 2), we abandon the strict percentage math. Consequently, the math relationship that calculates the remainder (`delta`) naturally breaks -the calculation essentially results in a negative number because the capped fee is smaller than the true percentage would have been.

The strict validation check I previously added was rigidly enforcing that the delta math (Case 1) must be perfectly valid even when we are using the max fee cap (Case 2). Because the token program passes in a dummy value of 0 for the delta when the cap is hit, the strict check sees a mismatch and crashes the proof generation.

#### Summary of Changes

I removed the restrictive delta sanity check in `build_percentage_with_cap_proof_data`. The underlying zero-knowledge proof already securely handles evaluating the "OR" condition, so we do not need to (and should not) force the percentage-branch inputs to be perfectly consistent when the max-cap branch is the one being actively utilized.