### PR TITLE
  [zk-sdk-wasm-js] Expose ElGamal and AE key derivation APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1136,6 +1136,8 @@ dependencies = [
  "bytemuck",
  "getrandom 0.2.17",
  "js-sys",
+ "solana-seed-derivable",
+ "solana-signature",
  "solana-zk-elgamal-proof-interface",
  "solana-zk-sdk",
  "solana-zk-sdk-pod",

--- a/scripts/solana.dic
+++ b/scripts/solana.dic
@@ -81,3 +81,5 @@ KDF
 Curve25519
 hashable
 SHAKE256
+ed25519
+BIP39

--- a/zk-sdk-wasm-js/Cargo.toml
+++ b/zk-sdk-wasm-js/Cargo.toml
@@ -23,6 +23,8 @@ test-browser = []
 solana-zk-sdk = { workspace = true }
 solana-zk-sdk-pod = { workspace = true }
 solana-zk-elgamal-proof-interface = { workspace = true }
+solana-seed-derivable = { workspace = true }
+solana-signature = { workspace = true }
 bytemuck = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/zk-sdk-wasm-js/src/encryption/auth_encryption.rs
+++ b/zk-sdk-wasm-js/src/encryption/auth_encryption.rs
@@ -1,9 +1,14 @@
 use {
     js_sys::Uint8Array,
+    solana_seed_derivable::SeedDerivable,
+    solana_signature::Signature,
     solana_zk_sdk::encryption::auth_encryption,
     solana_zk_sdk_pod::encryption::{AE_CIPHERTEXT_LEN, AE_KEY_LEN},
     wasm_bindgen::prelude::{wasm_bindgen, JsValue},
 };
+
+/// Byte length of an ed25519 signature.
+const SIGNATURE_LEN: usize = 64;
 
 #[wasm_bindgen]
 pub struct AeKey {
@@ -20,6 +25,65 @@ impl AeKey {
         Self {
             inner: auth_encryption::AeKey::new_rand(),
         }
+    }
+
+    /// Returns the message that a Solana signer must sign in order to
+    /// deterministically derive an `AeKey` via `fromSignature`.
+    ///
+    /// The message is `b"AeKey" || public_seed`. For the spl-token-2022
+    /// confidential extension, the `public_seed` is the 32-byte token
+    /// account address.
+    #[wasm_bindgen(js_name = "signerMessage")]
+    pub fn signer_message(public_seed: Uint8Array) -> Vec<u8> {
+        let mut seed = vec![0u8; public_seed.length() as usize];
+        public_seed.copy_to(&mut seed);
+        [b"AeKey".as_ref(), seed.as_ref()].concat()
+    }
+
+    /// Derives an `AeKey` from a 64-byte ed25519 signature over the
+    /// message returned by `signerMessage`.
+    #[wasm_bindgen(js_name = "fromSignature")]
+    pub fn from_signature(signature: Uint8Array) -> Result<AeKey, JsValue> {
+        let mut bytes = [0u8; SIGNATURE_LEN];
+        if signature.length() as usize != SIGNATURE_LEN {
+            return Err(JsValue::from_str(&format!(
+                "Invalid signature length: expected {}, got {}",
+                SIGNATURE_LEN,
+                signature.length()
+            )));
+        }
+        signature.copy_to(&mut bytes);
+        let signature = Signature::from(bytes);
+        auth_encryption::AeKey::new_from_signature(&signature)
+            .map(|inner| Self { inner })
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Deterministically derives an `AeKey` from a seed.
+    ///
+    /// The seed must be between 16 and 65535 bytes in length.
+    #[wasm_bindgen(js_name = "fromSeed")]
+    pub fn from_seed(seed: Uint8Array) -> Result<AeKey, JsValue> {
+        let mut bytes = vec![0u8; seed.length() as usize];
+        seed.copy_to(&mut bytes);
+        <auth_encryption::AeKey as SeedDerivable>::from_seed(&bytes)
+            .map(|inner| Self { inner })
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Deterministically derives an `AeKey` from a BIP39 mnemonic seed
+    /// phrase and optional passphrase.
+    #[wasm_bindgen(js_name = "fromSeedPhraseAndPassphrase")]
+    pub fn from_seed_phrase_and_passphrase(
+        seed_phrase: &str,
+        passphrase: &str,
+    ) -> Result<AeKey, JsValue> {
+        <auth_encryption::AeKey as SeedDerivable>::from_seed_phrase_and_passphrase(
+            seed_phrase,
+            passphrase,
+        )
+        .map(|inner| Self { inner })
+        .map_err(|e| JsValue::from_str(&e.to_string()))
     }
 
     /// Deserializes an `AeKey` from a byte slice.
@@ -159,5 +223,71 @@ mod tests {
         // Attempt to decrypt with wrong key
         let result = key2.decrypt(&ciphertext);
         assert!(!result.is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_signer_message_format() {
+        let seed = [7u8; 32];
+        let expected = [b"AeKey".as_ref(), seed.as_ref()].concat();
+        let msg = AeKey::signer_message(Uint8Array::from(seed.as_ref()));
+        assert_eq!(msg, expected);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_signer_message_domain_separated_from_elgamal() {
+        // The AeKey and ElGamalSecretKey domain separators must differ so that
+        // signing the same public seed for both keys yields different signatures.
+        let seed = Uint8Array::from([0u8; 32].as_ref());
+        let ae_msg = AeKey::signer_message(seed.clone());
+        let elgamal_msg = crate::encryption::elgamal::ElGamalSecretKey::signer_message(seed);
+        assert_ne!(ae_msg, elgamal_msg);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_signature_determinism() {
+        let signature_bytes = [3u8; 64];
+        let sig = Uint8Array::from(signature_bytes.as_ref());
+
+        let key_a = AeKey::from_signature(sig.clone()).unwrap();
+        let key_b = AeKey::from_signature(sig).unwrap();
+        assert_eq!(key_a.to_bytes(), key_b.to_bytes());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_signature_rejects_wrong_length() {
+        let short = vec![0u8; 63];
+        assert!(AeKey::from_signature(Uint8Array::from(short.as_slice())).is_err());
+        let long = vec![0u8; 65];
+        assert!(AeKey::from_signature(Uint8Array::from(long.as_slice())).is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_seed_roundtrip() {
+        let seed = [9u8; 32];
+        let seed_arr = Uint8Array::from(seed.as_ref());
+        let key_a = AeKey::from_seed(seed_arr.clone()).unwrap();
+        let key_b = AeKey::from_seed(seed_arr).unwrap();
+        assert_eq!(key_a.to_bytes(), key_b.to_bytes());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_seed_rejects_short_seed() {
+        // `AeKey::from_seed` requires at least 16 bytes of seed material.
+        let too_short = vec![0u8; 8];
+        assert!(AeKey::from_seed(Uint8Array::from(too_short.as_slice())).is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_seed_phrase_roundtrip() {
+        let phrase =
+            "blanket tower apple sunset trigger muscle fame detect absent copper cram guard";
+        let passphrase = "";
+
+        let a = AeKey::from_seed_phrase_and_passphrase(phrase, passphrase).unwrap();
+        let b = AeKey::from_seed_phrase_and_passphrase(phrase, passphrase).unwrap();
+        assert_eq!(a.to_bytes(), b.to_bytes());
+
+        let different = AeKey::from_seed_phrase_and_passphrase(phrase, "pw").unwrap();
+        assert_ne!(different.to_bytes(), a.to_bytes());
     }
 }

--- a/zk-sdk-wasm-js/src/encryption/auth_encryption.rs
+++ b/zk-sdk-wasm-js/src/encryption/auth_encryption.rs
@@ -54,6 +54,11 @@ impl AeKey {
         }
         signature.copy_to(&mut bytes);
         let signature = Signature::from(bytes);
+
+        if signature == Signature::default() {
+            return Err(JsValue::from_str("Rejecting default signature"));
+        }
+
         auth_encryption::AeKey::new_from_signature(&signature)
             .map(|inner| Self { inner })
             .map_err(|e| JsValue::from_str(&e.to_string()))
@@ -76,8 +81,9 @@ impl AeKey {
     #[wasm_bindgen(js_name = "fromSeedPhraseAndPassphrase")]
     pub fn from_seed_phrase_and_passphrase(
         seed_phrase: &str,
-        passphrase: &str,
+        passphrase: Option<String>,
     ) -> Result<AeKey, JsValue> {
+        let passphrase = passphrase.as_deref().unwrap_or("");
         <auth_encryption::AeKey as SeedDerivable>::from_seed_phrase_and_passphrase(
             seed_phrase,
             passphrase,
@@ -262,6 +268,12 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
+    fn test_from_signature_rejects_default_signature() {
+        let default = vec![0u8; 64];
+        assert!(AeKey::from_signature(Uint8Array::from(default.as_slice())).is_err());
+    }
+
+    #[wasm_bindgen_test]
     fn test_from_seed_roundtrip() {
         let seed = [9u8; 32];
         let seed_arr = Uint8Array::from(seed.as_ref());
@@ -281,13 +293,13 @@ mod tests {
     fn test_from_seed_phrase_roundtrip() {
         let phrase =
             "blanket tower apple sunset trigger muscle fame detect absent copper cram guard";
-        let passphrase = "";
 
-        let a = AeKey::from_seed_phrase_and_passphrase(phrase, passphrase).unwrap();
-        let b = AeKey::from_seed_phrase_and_passphrase(phrase, passphrase).unwrap();
+        let a = AeKey::from_seed_phrase_and_passphrase(phrase, None).unwrap();
+        let b = AeKey::from_seed_phrase_and_passphrase(phrase, None).unwrap();
         assert_eq!(a.to_bytes(), b.to_bytes());
 
-        let different = AeKey::from_seed_phrase_and_passphrase(phrase, "pw").unwrap();
+        let different =
+            AeKey::from_seed_phrase_and_passphrase(phrase, Some("pw".to_string())).unwrap();
         assert_ne!(different.to_bytes(), a.to_bytes());
     }
 }

--- a/zk-sdk-wasm-js/src/encryption/elgamal.rs
+++ b/zk-sdk-wasm-js/src/encryption/elgamal.rs
@@ -214,7 +214,7 @@ impl ElGamalKeypair {
     /// Returns the message that a Solana signer must sign in order to
     /// deterministically derive an `ElGamalKeypair` via `fromSignature`.
     ///
-    /// Identical to `ElGamalSecretKey.signerMessage` — provided on `ElGamalKeypair`
+    /// Identical to `ElGamalSecretKey.signerMessage` - provided on `ElGamalKeypair`
     /// for ergonomic access.
     #[wasm_bindgen(js_name = "signerMessage")]
     pub fn signer_message(public_seed: Uint8Array) -> Vec<u8> {

--- a/zk-sdk-wasm-js/src/encryption/elgamal.rs
+++ b/zk-sdk-wasm-js/src/encryption/elgamal.rs
@@ -114,6 +114,11 @@ impl ElGamalSecretKey {
         }
         signature.copy_to(&mut bytes);
         let signature = Signature::from(bytes);
+
+        if signature == Signature::default() {
+            return Err(JsValue::from_str("Rejecting default signature"));
+        }
+
         elgamal::ElGamalSecretKey::new_from_signature(&signature)
             .map(|inner| Self { inner })
             .map_err(|e| JsValue::from_str(&e.to_string()))
@@ -136,8 +141,9 @@ impl ElGamalSecretKey {
     #[wasm_bindgen(js_name = "fromSeedPhraseAndPassphrase")]
     pub fn from_seed_phrase_and_passphrase(
         seed_phrase: &str,
-        passphrase: &str,
+        passphrase: Option<String>,
     ) -> Result<ElGamalSecretKey, JsValue> {
+        let passphrase = passphrase.as_deref().unwrap_or("");
         <elgamal::ElGamalSecretKey as SeedDerivable>::from_seed_phrase_and_passphrase(
             seed_phrase,
             passphrase,
@@ -243,7 +249,7 @@ impl ElGamalKeypair {
     #[wasm_bindgen(js_name = "fromSeedPhraseAndPassphrase")]
     pub fn from_seed_phrase_and_passphrase(
         seed_phrase: &str,
-        passphrase: &str,
+        passphrase: Option<String>,
     ) -> Result<ElGamalKeypair, JsValue> {
         let secret = ElGamalSecretKey::from_seed_phrase_and_passphrase(seed_phrase, passphrase)?;
         Ok(Self::from_secret_key(&secret))
@@ -523,6 +529,13 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
+    fn test_from_signature_rejects_default_signature() {
+        let default = vec![0u8; 64];
+        assert!(ElGamalSecretKey::from_signature(Uint8Array::from(default.as_slice())).is_err());
+        assert!(ElGamalKeypair::from_signature(Uint8Array::from(default.as_slice())).is_err());
+    }
+
+    #[wasm_bindgen_test]
     fn test_from_seed_roundtrip() {
         let seed = [9u8; 32];
         let seed_arr = Uint8Array::from(seed.as_ref());
@@ -547,13 +560,14 @@ mod tests {
     fn test_from_seed_phrase_roundtrip() {
         let phrase =
             "blanket tower apple sunset trigger muscle fame detect absent copper cram guard";
-        let passphrase = "";
 
-        let a = ElGamalSecretKey::from_seed_phrase_and_passphrase(phrase, passphrase).unwrap();
-        let b = ElGamalSecretKey::from_seed_phrase_and_passphrase(phrase, passphrase).unwrap();
+        let a = ElGamalSecretKey::from_seed_phrase_and_passphrase(phrase, None).unwrap();
+        let b = ElGamalSecretKey::from_seed_phrase_and_passphrase(phrase, None).unwrap();
         assert_eq!(a.to_bytes(), b.to_bytes());
 
-        let different = ElGamalSecretKey::from_seed_phrase_and_passphrase(phrase, "pw").unwrap();
+        let different =
+            ElGamalSecretKey::from_seed_phrase_and_passphrase(phrase, Some("pw".to_string()))
+                .unwrap();
         assert_ne!(different.to_bytes(), a.to_bytes());
     }
 

--- a/zk-sdk-wasm-js/src/encryption/elgamal.rs
+++ b/zk-sdk-wasm-js/src/encryption/elgamal.rs
@@ -1,12 +1,17 @@
 use {
     crate::encryption::pedersen::{PedersenCommitment, PedersenOpening},
     js_sys::Uint8Array,
+    solana_seed_derivable::SeedDerivable,
+    solana_signature::Signature,
     solana_zk_sdk::encryption::elgamal,
     solana_zk_sdk_pod::encryption::{
         DECRYPT_HANDLE_LEN, ELGAMAL_CIPHERTEXT_LEN, ELGAMAL_PUBKEY_LEN, ELGAMAL_SECRET_KEY_LEN,
     },
     wasm_bindgen::prelude::{wasm_bindgen, JsValue},
 };
+
+/// Byte length of an ed25519 signature.
+const SIGNATURE_LEN: usize = 64;
 
 #[wasm_bindgen]
 pub struct ElGamalPubkey {
@@ -82,6 +87,65 @@ impl ElGamalSecretKey {
         }
     }
 
+    /// Returns the message that a Solana signer must sign in order to
+    /// deterministically derive an `ElGamalSecretKey` via `fromSignature`.
+    ///
+    /// The message is `b"ElGamalSecretKey" || public_seed`. For the
+    /// spl-token-2022 confidential extension, the `public_seed` is the
+    /// 32-byte token account address.
+    #[wasm_bindgen(js_name = "signerMessage")]
+    pub fn signer_message(public_seed: Uint8Array) -> Vec<u8> {
+        let mut seed = vec![0u8; public_seed.length() as usize];
+        public_seed.copy_to(&mut seed);
+        [b"ElGamalSecretKey".as_ref(), seed.as_ref()].concat()
+    }
+
+    /// Derives an `ElGamalSecretKey` from a 64-byte ed25519 signature
+    /// over the message returned by `signerMessage`.
+    #[wasm_bindgen(js_name = "fromSignature")]
+    pub fn from_signature(signature: Uint8Array) -> Result<ElGamalSecretKey, JsValue> {
+        let mut bytes = [0u8; SIGNATURE_LEN];
+        if signature.length() as usize != SIGNATURE_LEN {
+            return Err(JsValue::from_str(&format!(
+                "Invalid signature length: expected {}, got {}",
+                SIGNATURE_LEN,
+                signature.length()
+            )));
+        }
+        signature.copy_to(&mut bytes);
+        let signature = Signature::from(bytes);
+        elgamal::ElGamalSecretKey::new_from_signature(&signature)
+            .map(|inner| Self { inner })
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Deterministically derives an `ElGamalSecretKey` from a seed.
+    ///
+    /// The seed must be between 32 and 65535 bytes in length.
+    #[wasm_bindgen(js_name = "fromSeed")]
+    pub fn from_seed(seed: Uint8Array) -> Result<ElGamalSecretKey, JsValue> {
+        let mut bytes = vec![0u8; seed.length() as usize];
+        seed.copy_to(&mut bytes);
+        <elgamal::ElGamalSecretKey as SeedDerivable>::from_seed(&bytes)
+            .map(|inner| Self { inner })
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Deterministically derives an `ElGamalSecretKey` from a BIP39 mnemonic
+    /// seed phrase and optional passphrase.
+    #[wasm_bindgen(js_name = "fromSeedPhraseAndPassphrase")]
+    pub fn from_seed_phrase_and_passphrase(
+        seed_phrase: &str,
+        passphrase: &str,
+    ) -> Result<ElGamalSecretKey, JsValue> {
+        <elgamal::ElGamalSecretKey as SeedDerivable>::from_seed_phrase_and_passphrase(
+            seed_phrase,
+            passphrase,
+        )
+        .map(|inner| Self { inner })
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
     /// Deserializes an ElGamal secret key from a byte slice.
     /// Throws an error if the bytes are invalid.
     #[wasm_bindgen(js_name = "fromBytes")]
@@ -145,6 +209,44 @@ impl ElGamalKeypair {
         Self {
             inner: elgamal::ElGamalKeypair::new(secret_key.inner.clone()),
         }
+    }
+
+    /// Returns the message that a Solana signer must sign in order to
+    /// deterministically derive an `ElGamalKeypair` via `fromSignature`.
+    ///
+    /// Identical to `ElGamalSecretKey.signerMessage` — provided on `ElGamalKeypair`
+    /// for ergonomic access.
+    #[wasm_bindgen(js_name = "signerMessage")]
+    pub fn signer_message(public_seed: Uint8Array) -> Vec<u8> {
+        ElGamalSecretKey::signer_message(public_seed)
+    }
+
+    /// Derives an `ElGamalKeypair` from a 64-byte ed25519 signature
+    /// over the message returned by `signerMessage`.
+    #[wasm_bindgen(js_name = "fromSignature")]
+    pub fn from_signature(signature: Uint8Array) -> Result<ElGamalKeypair, JsValue> {
+        let secret = ElGamalSecretKey::from_signature(signature)?;
+        Ok(Self::from_secret_key(&secret))
+    }
+
+    /// Deterministically derives an `ElGamalKeypair` from a seed.
+    ///
+    /// The seed must be between 32 and 65535 bytes in length.
+    #[wasm_bindgen(js_name = "fromSeed")]
+    pub fn from_seed(seed: Uint8Array) -> Result<ElGamalKeypair, JsValue> {
+        let secret = ElGamalSecretKey::from_seed(seed)?;
+        Ok(Self::from_secret_key(&secret))
+    }
+
+    /// Deterministically derives an `ElGamalKeypair` from a BIP39 mnemonic
+    /// seed phrase and optional passphrase.
+    #[wasm_bindgen(js_name = "fromSeedPhraseAndPassphrase")]
+    pub fn from_seed_phrase_and_passphrase(
+        seed_phrase: &str,
+        passphrase: &str,
+    ) -> Result<ElGamalKeypair, JsValue> {
+        let secret = ElGamalSecretKey::from_seed_phrase_and_passphrase(seed_phrase, passphrase)?;
+        Ok(Self::from_secret_key(&secret))
     }
 
     /// Returns the public key of the keypair.
@@ -384,5 +486,87 @@ mod tests {
         let ciphertext = keypair.pubkey().encrypt_with(amount, &opening);
         let decrypted = keypair.secret().decrypt(&ciphertext);
         assert_eq!(decrypted, Ok(amount));
+    }
+
+    #[wasm_bindgen_test]
+    fn test_signer_message_format() {
+        let seed = [7u8; 32];
+        let expected = [b"ElGamalSecretKey".as_ref(), seed.as_ref()].concat();
+
+        let from_secret = ElGamalSecretKey::signer_message(Uint8Array::from(seed.as_ref()));
+        assert_eq!(from_secret, expected);
+
+        let from_keypair = ElGamalKeypair::signer_message(Uint8Array::from(seed.as_ref()));
+        assert_eq!(from_keypair, expected);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_signature_determinism() {
+        let signature_bytes = [1u8; 64];
+        let sig = Uint8Array::from(signature_bytes.as_ref());
+
+        let secret_a = ElGamalSecretKey::from_signature(sig.clone()).unwrap();
+        let secret_b = ElGamalSecretKey::from_signature(sig.clone()).unwrap();
+        assert_eq!(secret_a.to_bytes(), secret_b.to_bytes());
+
+        // Keypair derivation must yield the same secret as the secret-key path.
+        let keypair = ElGamalKeypair::from_signature(sig).unwrap();
+        assert_eq!(keypair.secret().to_bytes(), secret_a.to_bytes());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_signature_rejects_wrong_length() {
+        let short = vec![0u8; 63];
+        assert!(ElGamalSecretKey::from_signature(Uint8Array::from(short.as_slice())).is_err());
+        let long = vec![0u8; 65];
+        assert!(ElGamalKeypair::from_signature(Uint8Array::from(long.as_slice())).is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_seed_roundtrip() {
+        let seed = [9u8; 32];
+        let seed_arr = Uint8Array::from(seed.as_ref());
+
+        let secret_a = ElGamalSecretKey::from_seed(seed_arr.clone()).unwrap();
+        let secret_b = ElGamalSecretKey::from_seed(seed_arr.clone()).unwrap();
+        assert_eq!(secret_a.to_bytes(), secret_b.to_bytes());
+
+        let keypair = ElGamalKeypair::from_seed(seed_arr).unwrap();
+        assert_eq!(keypair.secret().to_bytes(), secret_a.to_bytes());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_seed_rejects_short_seed() {
+        // `ElGamalSecretKey::from_seed` requires at least 32 bytes of seed material.
+        let too_short = vec![0u8; 16];
+        assert!(ElGamalSecretKey::from_seed(Uint8Array::from(too_short.as_slice())).is_err());
+        assert!(ElGamalKeypair::from_seed(Uint8Array::from(too_short.as_slice())).is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_seed_phrase_roundtrip() {
+        let phrase =
+            "blanket tower apple sunset trigger muscle fame detect absent copper cram guard";
+        let passphrase = "";
+
+        let a = ElGamalSecretKey::from_seed_phrase_and_passphrase(phrase, passphrase).unwrap();
+        let b = ElGamalSecretKey::from_seed_phrase_and_passphrase(phrase, passphrase).unwrap();
+        assert_eq!(a.to_bytes(), b.to_bytes());
+
+        let different = ElGamalSecretKey::from_seed_phrase_and_passphrase(phrase, "pw").unwrap();
+        assert_ne!(different.to_bytes(), a.to_bytes());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_different_public_seeds_produce_different_keys() {
+        // Domain separation across token accounts: different public seeds must
+        // yield different signer messages, and therefore different keys for any
+        // given (hypothetical) signer.
+        let seed_a = Uint8Array::from([1u8; 32].as_ref());
+        let seed_b = Uint8Array::from([2u8; 32].as_ref());
+
+        let msg_a = ElGamalSecretKey::signer_message(seed_a);
+        let msg_b = ElGamalSecretKey::signer_message(seed_b);
+        assert_ne!(msg_a, msg_b);
     }
 }


### PR DESCRIPTION
This PR surfaces the existing Rust derivation APIs through `wasm-bindgen` so JS clients can derive keys from a wallet signature

 ## Changes

  Adds four static methods to `ElGamalSecretKey`, `ElGamalKeypair`, and
  `AeKey`:

  - `signerMessage(publicSeed)` - returns the domain-separated message
    (`b"ElGamalSecretKey" || seed` or `b"AeKey" || seed`) to sign
  - `fromSignature(signature)` - wraps `new_from_signature`
  - `fromSeed(seed)` - wraps the `SeedDerivable::from_seed` impl
  - `fromSeedPhraseAndPassphrase(phrase, passphrase)` - BIP39 path
