### PR TITLE
security: RUSTSEC-2026-0097: Bump rand to 0.8.6/0.9.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,9 +650,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -661,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -949,7 +949,7 @@ dependencies = [
  "ed25519-dalek",
  "five8 1.0.0",
  "five8_core 1.0.0",
- "rand 0.9.2",
+ "rand 0.9.4",
  "solana-address 2.6.0",
  "solana-seed-phrase",
  "solana-signature",
@@ -1094,7 +1094,7 @@ dependencies = [
  "curve25519-dalek",
  "itertools",
  "merlin",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1224,7 +1224,7 @@ checksum = "a30fd743a02bf35236f6faf99adb03089bb77e91c998dac2c2ad76bb424f668c"
 dependencies = [
  "once_cell",
  "pbkdf2 0.12.2",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hash",
  "sha2",
  "thiserror 1.0.69",


### PR DESCRIPTION
0.8.5 and 0.9.2 are vulnerable

https://rustsec.org/advisories/RUSTSEC-2026-0097