### PR TITLE
[CI] Fix url `clients/js` to `clients-js` in js publish script

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -6,10 +6,10 @@ on:
       package-path:
         description: Path to directory with package to release
         required: true
-        default: "clients/js"
+        default: "clients-js"
         type: choice
         options:
-          - clients/js
+          - clients-js
       level:
         description: Version level
         required: true


### PR DESCRIPTION
#### Summary of Changes

The JS publish script is using a wrong `clients/js` path. The real js-client lives in the `clients-js` path.

So fix the path in the CI publish script.