### PR TITLE
no-std checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ env:
   RUST_PACKAGES: "['interface', 'zk-sdk', 'zk-sdk-pod', 'zk-sdk-wasm-js']"
   WASM_PACKAGES: "['zk-sdk-wasm-js']"
   WASM_JS_PACKAGES: "['zk-sdk-wasm-js']"
+  NO_STD_ALLOC_PACKAGES: "['interface', 'zk-sdk-pod']"
 
 jobs:
   set_env:
@@ -25,6 +26,7 @@ jobs:
       WASM_JS_PACKAGES: ${{ steps.compute.outputs.WASM_JS_PACKAGES }}
       RUST_TOOLCHAIN_NIGHTLY: ${{ steps.compute.outputs.RUST_TOOLCHAIN_NIGHTLY }}
       SOLANA_CLI_VERSION: ${{ steps.compute.outputs.SOLANA_CLI_VERSION }}
+      NO_STD_ALLOC_PACKAGES: ${{ steps.compute.outputs.NO_STD_ALLOC_PACKAGES }}
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4
@@ -40,6 +42,7 @@ jobs:
           echo "WASM_JS_PACKAGES=${{ env.WASM_JS_PACKAGES }}" >> $GITHUB_OUTPUT
           echo "RUST_TOOLCHAIN_NIGHTLY=$(make rust-toolchain-nightly)" >> "$GITHUB_OUTPUT"
           echo "SOLANA_CLI_VERSION=$(make solana-cli-version)" >> "$GITHUB_OUTPUT"
+          echo "NO_STD_ALLOC_PACKAGES=${{ env.NO_STD_ALLOC_PACKAGES }}" >> $GITHUB_OUTPUT
 
   main:
     needs: set_env
@@ -53,3 +56,5 @@ jobs:
       rustfmt-toolchain: ${{ needs.set_env.outputs.RUST_TOOLCHAIN_NIGHTLY }}
       clippy-toolchain: ${{ needs.set_env.outputs.RUST_TOOLCHAIN_NIGHTLY }}
       solana-cli-version: ${{ needs.set_env.outputs.SOLANA_CLI_VERSION }}
+      no-std-toolchain: ${{ needs.set_env.outputs.RUST_TOOLCHAIN_NIGHTLY }}
+      no-std-alloc-packages: ${{ needs.set_env.outputs.NO_STD_ALLOC_PACKAGES }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,9 +991,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sanitize"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927e833259588ac8f860861db0f6e2668c3cc46d917798ade116858960acfe8a"
+checksum = "dcf09694a0fc14e5ffb18f9b7b7c0f15ecb6eac5b5610bf76a1853459d19daf9"
 
 [[package]]
 name = "solana-sdk-ids"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ config = "scripts/spellcheck.toml"
 
 [workspace.dependencies]
 aes-gcm-siv = "0.11.1"
-base64 = "0.22.1"
+base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
 bincode = "1.3.3"
 bytemuck = "1.25.0"
 bytemuck_derive = "1.10.2"
@@ -31,15 +31,15 @@ itertools = "0.14.0"
 js-sys = "0.3.77"
 merlin = { version = "3", default-features = false }
 num-derive = "0.4"
-num-traits = "0.2"
+num-traits = { version = "0.2", default-features = false }
 rand = "0.8.5"
-serde = "1.0.228"
+serde = { version = "1.0.228", default-features = false }
 serde_derive = "1.0.219"
 serde_json = "1.0.149"
 sha3 = "0.10.8"
 solana-address = { version = "2.5.0", default-features = false }
 solana-derivation-path = "3.0.0"
-solana-instruction = "3.0.0"
+solana-instruction = { version = "3.0.0", default-features = false }
 solana-keypair = "3.0.1"
 solana-nullable = "1.1.0"
 solana-sdk-ids = "3.1.0"
@@ -52,7 +52,7 @@ solana-zk-sdk = { path = "zk-sdk", version = "6.0.0" }
 solana-zk-sdk-pod = { path = "zk-sdk-pod", version = "0.1.0" }
 solana-zk-sdk-wasm-js = { path = "zk-sdk-wasm-js", version = "0.1.0" }
 subtle = "2.6.1"
-thiserror = "2.0.18"
+thiserror = { version = "2.0.18", default-features = false }
 tiny-bip39 = "2.0.0"
 wasm-bindgen = "0.2"
 wasm-bindgen-test = "0.3"

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,14 @@ format-check-%:
 powerset-%:
 	cargo $(nightly) hack check --feature-powerset --all-targets --manifest-path $(call make-path,$*)/Cargo.toml $(ARGS)
 
+check-no-std-alloc-%:
+	cargo $(nightly) hack check \
+		--target bpfel-unknown-none \
+		--each-feature \
+		--manifest-path $(call make-path,$*)/Cargo.toml \
+		-Zbuild-std=alloc,core \
+		$(ARGS)
+
 semver-check-%:
 	cargo semver-checks --manifest-path $(call make-path,$*)/Cargo.toml $(ARGS)
 


### PR DESCRIPTION
Now that https://github.com/solana-program/actions/pull/33 is available, can use those checks to enforce no-std on the interface and zk-pod crates. These are upstream of token-2022 repo which needs these crates to be no-std. 