### PR TITLE
Update pod dep version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ solana-signature = { version = "3.1.0", default-features = false }
 solana-signer = "3.0.0"
 solana-zk-elgamal-proof-interface = { path = "interface", version = "0.1.0" }
 solana-zk-sdk = { path = "zk-sdk", version = "6.0.0" }
-solana-zk-sdk-pod = { path = "zk-sdk-pod", version = "0.1.0" }
+solana-zk-sdk-pod = { path = "zk-sdk-pod", version = "0.1.2" }
 solana-zk-sdk-wasm-js = { path = "zk-sdk-wasm-js", version = "0.1.0" }
 subtle = "2.6.1"
 thiserror = { version = "2.0.18", default-features = false }


### PR DESCRIPTION
After https://github.com/solana-program/zk-elgamal-proof/pull/393, v0.1.2 of `zk-sdk-pod` [was published](https://github.com/solana-program/zk-elgamal-proof/actions/runs/25834461718).

`solana-zk-elgamal-proof-interface` inherits its `solana-zk-sdk-pod` dependency from the workspace dependency file. This PR bumps the dependency to `0.1.2` so the next interface release requires the pod crate version containing the no-std dependency fixes.
