### PR TITLE
refactor: switch zk-sdk key derivation to HKDF-SHA512

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,12 +1101,14 @@ dependencies = [
  "bincode",
  "bytemuck",
  "curve25519-dalek",
+ "hkdf",
  "itertools",
  "merlin",
  "rand 0.8.6",
  "serde",
  "serde_derive",
  "serde_json",
+ "sha2",
  "sha3",
  "solana-address 2.6.0",
  "solana-derivation-path",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ bytemuck = "1.25.0"
 bytemuck_derive = "1.10.2"
 curve25519-dalek = { version = "4.1.3", features = ["digest", "rand_core"] }
 getrandom = "0.2"
+hkdf = "0.12.4"
 itertools = "0.14.0"
 js-sys = "0.3.77"
 merlin = { version = "3", default-features = false }
@@ -36,6 +37,7 @@ rand = "0.8.5"
 serde = { version = "1.0.228", default-features = false }
 serde_derive = "1.0.219"
 serde_json = "1.0.150"
+sha2 = "0.10.9"
 sha3 = "0.10.8"
 solana-address = { version = "2.5.0", default-features = false }
 solana-derivation-path = "3.0.0"

--- a/scripts/solana.dic
+++ b/scripts/solana.dic
@@ -78,6 +78,11 @@ MPC
 multiscalar
 representable
 KDF
+HKDF
+SHA512
+crypto
+pseudorandom
+SDK
 Curve25519
 hashable
 SHAKE256

--- a/zk-sdk-wasm-js/src/encryption/auth_encryption.rs
+++ b/zk-sdk-wasm-js/src/encryption/auth_encryption.rs
@@ -114,10 +114,7 @@ impl AeKey {
     /// Serializes the `AeKey` to a byte array.
     #[wasm_bindgen(js_name = "toBytes")]
     pub fn to_bytes(&self) -> Vec<u8> {
-        // Clone is needed here because the zk-sdk implements only `From<AeKey>` for
-        // `[u8; AE_KEY_LEN]` and not `From<&AeKey>`.
-        // TODO: Consider implementing `From<&AeKey>` for `[u8; AE_KEY_LEN]`.
-        let bytes: [u8; AE_KEY_LEN] = self.inner.clone().into();
+        let bytes: [u8; AE_KEY_LEN] = (&self.inner).into();
         bytes.to_vec()
     }
 

--- a/zk-sdk/Cargo.toml
+++ b/zk-sdk/Cargo.toml
@@ -18,12 +18,14 @@ base64 = { workspace = true }
 bincode = { workspace = true }
 bytemuck = { workspace = true }
 curve25519-dalek = { workspace = true, features = ["serde"] }
+hkdf = { workspace = true }
 itertools = { workspace = true }
 merlin = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 sha3 = { workspace = true }
 solana-address = { workspace = true, features = ["bytemuck"] }
 solana-derivation-path = { workspace = true }

--- a/zk-sdk/src/encryption/auth_encryption.rs
+++ b/zk-sdk/src/encryption/auth_encryption.rs
@@ -10,7 +10,9 @@ use {
         Aes128GcmSiv,
     },
     base64::{prelude::BASE64_STANDARD, Engine},
+    hkdf::Hkdf,
     rand::{rngs::OsRng, Rng},
+    sha2::Sha512,
     sha3::{Digest, Sha3_512},
     solana_derivation_path::DerivationPath,
     solana_seed_derivable::SeedDerivable,
@@ -28,6 +30,16 @@ use {
     subtle::ConstantTimeEq,
     zeroize::{Zeroize, Zeroizing},
 };
+
+/// HKDF salt used when deriving an `AeKey`. Versioned so that future revisions
+/// of the key derivation scheme can coexist with the current one by bumping the
+/// `:vN` suffix.
+const AE_HKDF_SALT: &[u8] = b"solana-zk-sdk:AeKey:v1:hkdf-sha512";
+
+/// HKDF info string used to bind the expanded output to the `AeKey` key type.
+/// Combined with the salt this provides domain separation against ElGamal
+/// derivation even when both share the same input key material.
+const AE_HKDF_INFO: &[u8] = b"AeKey";
 
 /// Byte length of an authenticated encryption nonce component
 const NONCE_LEN: usize = 12;
@@ -105,13 +117,14 @@ impl AeKey {
 
     /// Derive a seed from a Solana signer used to generate an authenticated encryption key.
     ///
-    /// The seed is derived as the hash of the signature of a public seed.
+    /// The signer is asked to sign the message `b"AeKey" || public_seed`. The
+    /// resulting Ed25519 signature is fed into HKDF-SHA512 (RFC 5869) to
+    /// produce 64 bytes of pseudorandom seed material suitable for
+    /// [`AeKey::from_seed`].
     pub fn seed_from_signer(
         signer: &dyn Signer,
         public_seed: &[u8],
     ) -> Result<Vec<u8>, SignerError> {
-        // TODO: This function uses a non-standard KDF and should be refactored.
-        // See: https://github.com/solana-program/zk-elgamal-proof/issues/35
         let message = [b"AeKey", public_seed].concat();
         let signature = signer.try_sign_message(&message)?;
 
@@ -130,13 +143,139 @@ impl AeKey {
         Self::from_seed(&seed)
     }
 
-    /// Derive a seed from a signature used to generate an authenticated encryption key.
+    /// Derive a seed from a signature used to generate an authenticated
+    /// encryption key.
+    ///
+    /// The signature is treated as input key material for HKDF-Extract
+    /// (HKDF-SHA512, RFC 5869) using a versioned, domain-separated salt. The
+    /// returned 64-byte pseudorandom key is then fed into [`AeKey::from_seed`]
+    /// which performs the corresponding HKDF-Expand step.
     pub fn seed_from_signature(signature: &Signature) -> Vec<u8> {
+        let (prk, _) = Hkdf::<Sha512>::extract(Some(AE_HKDF_SALT), signature.as_ref());
+        prk.to_vec()
+    }
+
+    /// Derive an authenticated encryption key from a Solana signer using the
+    /// legacy SHA3-512-based KDF.
+    ///
+    /// Retained only so wallets can recover keys for accounts that were
+    /// provisioned under `solana-zk-sdk` versions that shipped the
+    /// non-standard `Truncate-128(SHA3-512(...))` derivation. New code should
+    /// use [`AeKey::new_from_signer`].
+    #[deprecated(
+        note = "Non-standard SHA3-512 KDF; new code should use `AeKey::new_from_signer`. \
+                Retained for backward compatibility with accounts provisioned under \
+                solana-zk-sdk versions prior to the HKDF-SHA512 migration. \
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35."
+    )]
+    #[allow(deprecated)]
+    pub fn new_from_signer_legacy(
+        signer: &dyn Signer,
+        public_seed: &[u8],
+    ) -> Result<Self, Box<dyn error::Error>> {
+        let seed = Self::seed_from_signer_legacy(signer, public_seed)?;
+        Self::from_seed_legacy(&seed)
+    }
+
+    /// Derive a seed from a Solana signer using the legacy SHA3-512 KDF.
+    ///
+    /// See [`AeKey::new_from_signer_legacy`] for context.
+    #[deprecated(
+        note = "Non-standard SHA3-512 KDF; new code should use `AeKey::seed_from_signer`. \
+                Retained for backward compatibility. \
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35."
+    )]
+    #[allow(deprecated)]
+    pub fn seed_from_signer_legacy(
+        signer: &dyn Signer,
+        public_seed: &[u8],
+    ) -> Result<Vec<u8>, SignerError> {
+        let message = [b"AeKey", public_seed].concat();
+        let signature = signer.try_sign_message(&message)?;
+
+        if bool::from(signature.as_ref().ct_eq(Signature::default().as_ref())) {
+            return Err(SignerError::Custom("Rejecting default signature".into()));
+        }
+
+        Ok(Self::seed_from_signature_legacy(&signature))
+    }
+
+    /// Derive an authenticated encryption key from a raw signature using the
+    /// legacy SHA3-512 KDF.
+    ///
+    /// See [`AeKey::new_from_signer_legacy`] for context.
+    #[deprecated(
+        note = "Non-standard SHA3-512 KDF; new code should use `AeKey::new_from_signature`. \
+                Retained for backward compatibility. \
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35."
+    )]
+    #[allow(deprecated)]
+    pub fn new_from_signature_legacy(signature: &Signature) -> Result<Self, Box<dyn error::Error>> {
+        let seed = Self::seed_from_signature_legacy(signature);
+        Self::from_seed_legacy(&seed)
+    }
+
+    /// Derive a seed from a signature using the legacy SHA3-512 KDF.
+    ///
+    /// See [`AeKey::new_from_signer_legacy`] for context.
+    #[deprecated(
+        note = "Non-standard SHA3-512 KDF; new code should use `AeKey::seed_from_signature`. \
+                Retained for backward compatibility. \
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35."
+    )]
+    pub fn seed_from_signature_legacy(signature: &Signature) -> Vec<u8> {
         let mut hasher = Sha3_512::new();
         hasher.update(signature);
         let result = hasher.finalize();
 
         result.to_vec()
+    }
+
+    /// Derive an authenticated encryption key from a raw seed using the legacy
+    /// SHA3-512 KDF.
+    ///
+    /// See [`AeKey::new_from_signer_legacy`] for context.
+    #[deprecated(
+        note = "Non-standard SHA3-512 KDF; new code should use `AeKey::from_seed`. \
+                Retained for backward compatibility. \
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35."
+    )]
+    pub fn from_seed_legacy(seed: &[u8]) -> Result<Self, Box<dyn error::Error>> {
+        const MINIMUM_SEED_LEN: usize = AE_KEY_LEN;
+        const MAXIMUM_SEED_LEN: usize = 65535;
+
+        if seed.len() < MINIMUM_SEED_LEN {
+            return Err(AuthenticatedEncryptionError::SeedLengthTooShort.into());
+        }
+        if seed.len() > MAXIMUM_SEED_LEN {
+            return Err(AuthenticatedEncryptionError::SeedLengthTooLong.into());
+        }
+
+        let mut hasher = Sha3_512::new();
+        hasher.update(seed);
+        let result = hasher.finalize();
+
+        Ok(Self(result[..AE_KEY_LEN].try_into()?))
+    }
+
+    /// Derive an authenticated encryption key from a BIP39 mnemonic and
+    /// passphrase using the legacy SHA3-512 KDF.
+    ///
+    /// See [`AeKey::new_from_signer_legacy`] for context.
+    #[deprecated(
+        note = "Non-standard SHA3-512 KDF; new code should use `<AeKey as SeedDerivable>::\
+                from_seed_phrase_and_passphrase`. Retained for backward compatibility. \
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35."
+    )]
+    #[allow(deprecated)]
+    pub fn from_seed_phrase_and_passphrase_legacy(
+        seed_phrase: &str,
+        passphrase: &str,
+    ) -> Result<Self, Box<dyn error::Error>> {
+        Self::from_seed_legacy(&generate_seed_from_seed_phrase_and_passphrase(
+            seed_phrase,
+            passphrase,
+        ))
     }
 
     /// Generates a random authenticated encryption key.
@@ -188,11 +327,12 @@ impl SeedDerivable for AeKey {
             return Err(AuthenticatedEncryptionError::SeedLengthTooLong.into());
         }
 
-        let mut hasher = Sha3_512::new();
-        hasher.update(seed);
-        let result = hasher.finalize();
+        let hkdf = Hkdf::<Sha512>::new(Some(AE_HKDF_SALT), seed);
+        let mut okm = [0u8; AE_KEY_LEN];
+        hkdf.expand(AE_HKDF_INFO, &mut okm)
+            .map_err(|_| AuthenticatedEncryptionError::Deserialization)?;
 
-        Ok(Self(result[..AE_KEY_LEN].try_into()?))
+        Ok(Self(okm))
     }
 
     fn from_seed_and_derivation_path(
@@ -221,6 +361,12 @@ impl From<[u8; AE_KEY_LEN]> for AeKey {
 
 impl From<AeKey> for [u8; AE_KEY_LEN] {
     fn from(key: AeKey) -> Self {
+        key.0
+    }
+}
+
+impl From<&AeKey> for [u8; AE_KEY_LEN] {
+    fn from(key: &AeKey) -> Self {
         key.0
     }
 }
@@ -394,6 +540,105 @@ mod tests {
 
         let tampered_ciphertext = AeCiphertext::from_bytes(&tampered_bytes).unwrap();
         assert!(tampered_ciphertext.decrypt(&key).is_none());
+    }
+
+    #[test]
+    fn test_aes_key_from_into_ref() {
+        // Verify `From<&AeKey> for [u8; AE_KEY_LEN]` returns the same bytes as
+        // the owning version. This is what backs the wasm-js `to_bytes()`
+        // no-clone path.
+        let key = AeKey::from_seed(&[7; 32]).unwrap();
+        let owned: [u8; AE_KEY_LEN] = key.clone().into();
+        let borrowed: [u8; AE_KEY_LEN] = (&key).into();
+        assert_eq!(owned, borrowed);
+    }
+
+    #[test]
+    fn test_aekey_hkdf_determinism_from_signature() {
+        let sig = Signature::from([0x42u8; 64]);
+        let key_a = AeKey::new_from_signature(&sig).unwrap();
+        let key_b = AeKey::new_from_signature(&sig).unwrap();
+        assert_eq!(
+            <[u8; AE_KEY_LEN]>::from(&key_a),
+            <[u8; AE_KEY_LEN]>::from(&key_b),
+        );
+    }
+
+    #[test]
+    fn test_aekey_hkdf_differs_from_legacy() {
+        // The HKDF and legacy SHA3-512 paths must produce different keys for
+        // the same input — otherwise the legacy fallback would silently match
+        // the new derivation and accounts could be mis-claimed as migrated.
+        let sig = Signature::from([0x42u8; 64]);
+        let new_key = AeKey::new_from_signature(&sig).unwrap();
+        #[allow(deprecated)]
+        let old_key = AeKey::new_from_signature_legacy(&sig).unwrap();
+        assert_ne!(
+            <[u8; AE_KEY_LEN]>::from(&new_key),
+            <[u8; AE_KEY_LEN]>::from(&old_key),
+        );
+    }
+
+    #[test]
+    fn test_aekey_hkdf_known_vector_from_signature() {
+        // Canonical test vector for the HKDF-SHA512 AeKey derivation.
+        //
+        // Inputs:
+        //   signature = [0x42; 64]
+        //   salt      = b"solana-zk-sdk:AeKey:v1:hkdf-sha512"
+        //   info      = b"AeKey"
+        //   L         = 16
+        let sig = Signature::from([0x42u8; 64]);
+        let key = AeKey::new_from_signature(&sig).unwrap();
+        let bytes: [u8; AE_KEY_LEN] = (&key).into();
+        let expected: [u8; AE_KEY_LEN] = [
+            0xe7, 0x04, 0x81, 0x8f, 0x1c, 0x01, 0xb9, 0xbe, 0x2d, 0xb3, 0x99, 0x67, 0x7b, 0x7a,
+            0x91, 0x53,
+        ];
+        assert_eq!(
+            bytes, expected,
+            "HKDF AeKey vector drift; computed {:02x?}",
+            bytes
+        );
+    }
+
+    #[test]
+    fn test_aekey_legacy_known_vector_from_signature() {
+        // Pinned canonical bytes for the SHA3-512 legacy derivation.
+        // Inputs:
+        //   signature = [0x42; 64]
+        //   key       = Truncate-128(SHA3-512(SHA3-512(signature)))
+        let sig = Signature::from([0x42u8; 64]);
+        #[allow(deprecated)]
+        let key = AeKey::new_from_signature_legacy(&sig).unwrap();
+        let bytes: [u8; AE_KEY_LEN] = (&key).into();
+        let expected: [u8; AE_KEY_LEN] = [
+            0x06, 0x6b, 0x8d, 0xa6, 0x7e, 0x6f, 0x30, 0x1c, 0xab, 0x63, 0x4b, 0x60, 0x93, 0xca,
+            0x8c, 0x35,
+        ];
+        assert_eq!(
+            bytes, expected,
+            "Legacy AeKey vector drift; computed {:02x?}",
+            bytes
+        );
+    }
+
+    #[test]
+    fn test_aekey_hkdf_signer_matches_signature_path() {
+        // `new_from_signer` should match `new_from_signature` applied to the
+        // signature the signer would produce for the same message.
+        let keypair = Keypair::new();
+        let public_seed = [0x11u8; 32];
+        let key_from_signer = AeKey::new_from_signer(&keypair, &public_seed).unwrap();
+
+        let message = [b"AeKey", public_seed.as_ref()].concat();
+        let sig = keypair.sign_message(&message);
+        let key_from_sig = AeKey::new_from_signature(&sig).unwrap();
+
+        assert_eq!(
+            <[u8; AE_KEY_LEN]>::from(&key_from_signer),
+            <[u8; AE_KEY_LEN]>::from(&key_from_sig),
+        );
     }
 
     #[test]

--- a/zk-sdk/src/encryption/auth_encryption.rs
+++ b/zk-sdk/src/encryption/auth_encryption.rs
@@ -328,11 +328,11 @@ impl SeedDerivable for AeKey {
         }
 
         let hkdf = Hkdf::<Sha512>::new(Some(AE_HKDF_SALT), seed);
-        let mut okm = [0u8; AE_KEY_LEN];
-        hkdf.expand(AE_HKDF_INFO, &mut okm)
+        let mut okm = Zeroizing::new([0u8; AE_KEY_LEN]);
+        hkdf.expand(AE_HKDF_INFO, okm.as_mut_slice())
             .map_err(|_| AuthenticatedEncryptionError::Deserialization)?;
 
-        Ok(Self(okm))
+        Ok(Self(*okm))
     }
 
     fn from_seed_and_derivation_path(

--- a/zk-sdk/src/encryption/auth_encryption.rs
+++ b/zk-sdk/src/encryption/auth_encryption.rs
@@ -143,16 +143,16 @@ impl AeKey {
         Self::from_seed(&seed)
     }
 
-    /// Derive a seed from a signature used to generate an authenticated
-    /// encryption key.
+    /// Returns the input key material derived from a signature, suitable for
+    /// feeding into [`AeKey::from_seed`].
     ///
-    /// The signature is treated as input key material for HKDF-Extract
-    /// (HKDF-SHA512, RFC 5869) using a versioned, domain-separated salt. The
-    /// returned 64-byte pseudorandom key is then fed into [`AeKey::from_seed`]
-    /// which performs the corresponding HKDF-Expand step.
+    /// The signature bytes themselves are returned unmodified so that the
+    /// full HKDF-SHA512 chain (Extract + Expand) runs exactly once inside
+    /// [`AeKey::from_seed`]. A wallet that prefers to call HKDF directly via
+    /// its platform crypto can therefore reproduce the SDK output via
+    /// `HKDF-SHA512(salt = AE_HKDF_SALT, ikm = signature, info = b"AeKey", L = 16)`.
     pub fn seed_from_signature(signature: &Signature) -> Vec<u8> {
-        let (prk, _) = Hkdf::<Sha512>::extract(Some(AE_HKDF_SALT), signature.as_ref());
-        prk.to_vec()
+        signature.as_ref().to_vec()
     }
 
     /// Derive an authenticated encryption key from a Solana signer using the
@@ -592,8 +592,8 @@ mod tests {
         let key = AeKey::new_from_signature(&sig).unwrap();
         let bytes: [u8; AE_KEY_LEN] = (&key).into();
         let expected: [u8; AE_KEY_LEN] = [
-            0xe7, 0x04, 0x81, 0x8f, 0x1c, 0x01, 0xb9, 0xbe, 0x2d, 0xb3, 0x99, 0x67, 0x7b, 0x7a,
-            0x91, 0x53,
+            0x48, 0x6d, 0x45, 0x79, 0x6d, 0xf2, 0xdc, 0xa5, 0xeb, 0x5e, 0x1e, 0xaf, 0x47, 0xb0,
+            0x74, 0x65,
         ];
         assert_eq!(
             bytes, expected,
@@ -621,6 +621,24 @@ mod tests {
             "Legacy AeKey vector drift; computed {:02x?}",
             bytes
         );
+    }
+
+    #[test]
+    fn test_aekey_matches_single_hkdf_over_signature() {
+        // The documented interop contract is: an external implementation
+        // (e.g. Web Crypto subtle.deriveBits, Apple CryptoKit HKDF<SHA512>)
+        // computing `HKDF-SHA512(salt = AE_HKDF_SALT, ikm = signature,
+        // info = b"AeKey", L = 16)` MUST produce the same bytes as the SDK.
+        // Regression guard for the double-HKDF-Extract bug.
+        let sig = Signature::from([0x42u8; 64]);
+        let sdk_key = AeKey::new_from_signature(&sig).unwrap();
+        let sdk_bytes: [u8; AE_KEY_LEN] = (&sdk_key).into();
+
+        let direct = Hkdf::<Sha512>::new(Some(AE_HKDF_SALT), sig.as_ref());
+        let mut external_bytes = [0u8; AE_KEY_LEN];
+        direct.expand(AE_HKDF_INFO, &mut external_bytes).unwrap();
+
+        assert_eq!(sdk_bytes, external_bytes);
     }
 
     #[test]

--- a/zk-sdk/src/encryption/auth_encryption.rs
+++ b/zk-sdk/src/encryption/auth_encryption.rs
@@ -147,7 +147,7 @@ impl AeKey {
     /// feeding into [`AeKey::from_seed`].
     ///
     /// The signature bytes themselves are returned unmodified so that the
-    /// full HKDF-SHA512 chain (Extract + Expand) runs exactly once inside
+    /// full HKDF-SHA512 chain (Extract and Expand) runs exactly once inside
     /// [`AeKey::from_seed`]. A wallet that prefers to call HKDF directly via
     /// its platform crypto can therefore reproduce the SDK output via
     /// `HKDF-SHA512(salt = AE_HKDF_SALT, ikm = signature, info = b"AeKey", L = 16)`.

--- a/zk-sdk/src/encryption/elgamal.rs
+++ b/zk-sdk/src/encryption/elgamal.rs
@@ -569,8 +569,8 @@ impl ElGamalSecretKey {
         }
 
         let hkdf = Hkdf::<Sha512>::new(Some(ELGAMAL_HKDF_SALT), seed);
-        let mut wide = [0u8; 64];
-        hkdf.expand(ELGAMAL_HKDF_INFO, &mut wide)
+        let mut wide = Zeroizing::new([0u8; 64]);
+        hkdf.expand(ELGAMAL_HKDF_INFO, wide.as_mut_slice())
             .map_err(|_| ElGamalError::SecretKeyDeserialization)?;
 
         Ok(ElGamalSecretKey(Scalar::from_bytes_mod_order_wide(&wide)))

--- a/zk-sdk/src/encryption/elgamal.rs
+++ b/zk-sdk/src/encryption/elgamal.rs
@@ -30,8 +30,10 @@ use {
         ristretto::{CompressedRistretto, RistrettoPoint},
         scalar::Scalar,
     },
+    hkdf::Hkdf,
     rand::rngs::OsRng,
     serde::{Deserialize, Serialize},
+    sha2::Sha512,
     sha3::{Digest, Sha3_512},
     solana_derivation_path::DerivationPath,
     solana_seed_derivable::SeedDerivable,
@@ -52,6 +54,16 @@ use {
     subtle::{Choice, ConstantTimeEq},
     zeroize::{Zeroize, Zeroizing},
 };
+
+/// HKDF salt used when deriving an `ElGamalSecretKey`. Versioned so that future
+/// revisions of the key derivation scheme can coexist with the current one by
+/// bumping the `:vN` suffix.
+const ELGAMAL_HKDF_SALT: &[u8] = b"solana-zk-sdk:ElGamalSecretKey:v1:hkdf-sha512";
+
+/// HKDF info string used to bind the expanded output to the `ElGamalSecretKey`
+/// key type. Combined with the salt this provides domain separation against
+/// `AeKey` derivation even when both share the same input key material.
+const ELGAMAL_HKDF_INFO: &[u8] = b"ElGamalSecretKey";
 
 /// Algorithm handle for the twisted ElGamal encryption scheme
 pub struct ElGamal;
@@ -217,6 +229,70 @@ impl ElGamalKeypair {
     pub fn new_from_signature(signature: &Signature) -> Result<Self, Box<dyn error::Error>> {
         let secret = ElGamalSecretKey::new_from_signature(signature)?;
         Ok(Self::new(secret))
+    }
+
+    /// Derive an ElGamal keypair from a Solana signer using the legacy
+    /// SHA3-512 KDF.
+    ///
+    /// See [`ElGamalSecretKey::new_from_signer_legacy`] for context.
+    #[deprecated(note = "Non-standard SHA3-512 KDF; new code should use \
+                `ElGamalKeypair::new_from_signer`. Retained for backward compatibility. \
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
+    #[allow(deprecated)]
+    pub fn new_from_signer_legacy(
+        signer: &dyn Signer,
+        public_seed: &[u8],
+    ) -> Result<Self, Box<dyn error::Error>> {
+        let secret = ElGamalSecretKey::new_from_signer_legacy(signer, public_seed)?;
+        Ok(Self::new(secret))
+    }
+
+    /// Derive an ElGamal keypair from a raw signature using the legacy
+    /// SHA3-512 KDF.
+    ///
+    /// See [`ElGamalSecretKey::new_from_signer_legacy`] for context.
+    #[deprecated(note = "Non-standard SHA3-512 KDF; new code should use \
+                `ElGamalKeypair::new_from_signature`. Retained for backward compatibility. \
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
+    #[allow(deprecated)]
+    pub fn new_from_signature_legacy(signature: &Signature) -> Result<Self, Box<dyn error::Error>> {
+        let secret = ElGamalSecretKey::new_from_signature_legacy(signature)?;
+        Ok(Self::new(secret))
+    }
+
+    /// Derive an ElGamal keypair from a raw seed using the legacy SHA3-512
+    /// KDF.
+    ///
+    /// See [`ElGamalSecretKey::new_from_signer_legacy`] for context.
+    #[deprecated(
+        note = "Non-standard SHA3-512 KDF; new code should use `ElGamalKeypair::from_seed`. \
+                Retained for backward compatibility. \
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35."
+    )]
+    #[allow(deprecated)]
+    pub fn from_seed_legacy(seed: &[u8]) -> Result<Self, Box<dyn error::Error>> {
+        let secret = ElGamalSecretKey::from_seed_legacy(seed)?;
+        let public = ElGamalPubkey::new(&secret);
+        Ok(ElGamalKeypair { public, secret })
+    }
+
+    /// Derive an ElGamal keypair from a BIP39 mnemonic and passphrase using
+    /// the legacy SHA3-512 KDF.
+    ///
+    /// See [`ElGamalSecretKey::new_from_signer_legacy`] for context.
+    #[deprecated(note = "Non-standard SHA3-512 KDF; new code should use \
+                `<ElGamalKeypair as SeedDerivable>::from_seed_phrase_and_passphrase`. \
+                Retained for backward compatibility. \
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
+    #[allow(deprecated)]
+    pub fn from_seed_phrase_and_passphrase_legacy(
+        seed_phrase: &str,
+        passphrase: &str,
+    ) -> Result<Self, Box<dyn error::Error>> {
+        Self::from_seed_legacy(&generate_seed_from_seed_phrase_and_passphrase(
+            seed_phrase,
+            passphrase,
+        ))
     }
 
     /// Reads a JSON-encoded keypair from a `Reader` implementer
@@ -476,6 +552,11 @@ impl ElGamalSecretKey {
     }
 
     /// Derive an ElGamal secret key from an entropy seed.
+    ///
+    /// The seed is treated as input key material for HKDF-SHA512 (RFC 5869).
+    /// HKDF-Extract uses a versioned, domain-separated salt; HKDF-Expand
+    /// produces 64 bytes which are reduced to a uniformly distributed
+    /// Ristretto scalar via `Scalar::from_bytes_mod_order_wide`.
     pub fn from_seed(seed: &[u8]) -> Result<Self, ElGamalError> {
         const MINIMUM_SEED_LEN: usize = ELGAMAL_SECRET_KEY_LEN;
         const MAXIMUM_SEED_LEN: usize = 65535;
@@ -486,7 +567,13 @@ impl ElGamalSecretKey {
         if seed.len() > MAXIMUM_SEED_LEN {
             return Err(ElGamalError::SeedLengthTooLong);
         }
-        Ok(ElGamalSecretKey(Scalar::hash_from_bytes::<Sha3_512>(seed)))
+
+        let hkdf = Hkdf::<Sha512>::new(Some(ELGAMAL_HKDF_SALT), seed);
+        let mut wide = [0u8; 64];
+        hkdf.expand(ELGAMAL_HKDF_INFO, &mut wide)
+            .map_err(|_| ElGamalError::SecretKeyDeserialization)?;
+
+        Ok(ElGamalSecretKey(Scalar::from_bytes_mod_order_wide(&wide)))
     }
 
     pub fn get_scalar(&self) -> &Scalar {
@@ -552,16 +639,127 @@ impl ElGamalSecretKey {
         Ok(key)
     }
 
-    /// Derive an ElGamal secret key from a signature.
+    /// Derive a seed from a signature used to generate an ElGamal secret key.
     ///
-    /// TODO: This function uses a non-standard KDF and should be refactored.
-    /// See: <https://github.com/solana-program/zk-elgamal-proof/issues/35>
+    /// The signature is treated as input key material for HKDF-Extract
+    /// (HKDF-SHA512, RFC 5869) using a versioned, domain-separated salt. The
+    /// returned 64-byte pseudorandom key is then fed into
+    /// [`ElGamalSecretKey::from_seed`] which performs the corresponding
+    /// HKDF-Expand step.
     pub fn seed_from_signature(signature: &Signature) -> Vec<u8> {
+        let (prk, _) = Hkdf::<Sha512>::extract(Some(ELGAMAL_HKDF_SALT), signature.as_ref());
+        prk.to_vec()
+    }
+
+    /// Derive an ElGamal secret key from a Solana signer using the legacy
+    /// SHA3-512-based KDF.
+    ///
+    /// Retained only so wallets can recover keys for accounts that were
+    /// provisioned under `solana-zk-sdk` versions that shipped the
+    /// non-standard `Scalar::hash_from_bytes::<Sha3_512>(...)` derivation. New
+    /// code should use [`ElGamalSecretKey::new_from_signer`].
+    #[deprecated(note = "Non-standard SHA3-512 KDF; new code should use \
+                `ElGamalSecretKey::new_from_signer`. Retained for backward \
+                compatibility with accounts provisioned under solana-zk-sdk versions \
+                prior to the HKDF-SHA512 migration. \
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
+    #[allow(deprecated)]
+    pub fn new_from_signer_legacy(
+        signer: &dyn Signer,
+        public_seed: &[u8],
+    ) -> Result<Self, Box<dyn error::Error>> {
+        let seed = Self::seed_from_signer_legacy(signer, public_seed)?;
+        let key = Self::from_seed_legacy(&seed)?;
+        Ok(key)
+    }
+
+    /// Derive a seed from a Solana signer using the legacy SHA3-512 KDF.
+    ///
+    /// See [`ElGamalSecretKey::new_from_signer_legacy`] for context.
+    #[deprecated(note = "Non-standard SHA3-512 KDF; new code should use \
+                `ElGamalSecretKey::seed_from_signer`. Retained for backward compatibility. \
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
+    #[allow(deprecated)]
+    pub fn seed_from_signer_legacy(
+        signer: &dyn Signer,
+        public_seed: &[u8],
+    ) -> Result<Vec<u8>, SignerError> {
+        let message = [b"ElGamalSecretKey", public_seed].concat();
+        let signature = signer.try_sign_message(&message)?;
+
+        if bool::from(signature.as_ref().ct_eq(Signature::default().as_ref())) {
+            return Err(SignerError::Custom("Rejecting default signatures".into()));
+        }
+
+        Ok(Self::seed_from_signature_legacy(&signature))
+    }
+
+    /// Derive an ElGamal secret key from a raw signature using the legacy
+    /// SHA3-512 KDF.
+    ///
+    /// See [`ElGamalSecretKey::new_from_signer_legacy`] for context.
+    #[deprecated(note = "Non-standard SHA3-512 KDF; new code should use \
+                `ElGamalSecretKey::new_from_signature`. Retained for backward compatibility. \
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
+    #[allow(deprecated)]
+    pub fn new_from_signature_legacy(signature: &Signature) -> Result<Self, Box<dyn error::Error>> {
+        let seed = Self::seed_from_signature_legacy(signature);
+        let key = Self::from_seed_legacy(&seed)?;
+        Ok(key)
+    }
+
+    /// Derive a seed from a signature using the legacy SHA3-512 KDF.
+    ///
+    /// See [`ElGamalSecretKey::new_from_signer_legacy`] for context.
+    #[deprecated(note = "Non-standard SHA3-512 KDF; new code should use \
+                `ElGamalSecretKey::seed_from_signature`. Retained for backward compatibility. \
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
+    pub fn seed_from_signature_legacy(signature: &Signature) -> Vec<u8> {
         let mut hasher = Sha3_512::new();
         hasher.update(signature.as_ref());
         let result = hasher.finalize();
 
         result.to_vec()
+    }
+
+    /// Derive an ElGamal secret key from a raw seed using the legacy SHA3-512
+    /// KDF.
+    ///
+    /// See [`ElGamalSecretKey::new_from_signer_legacy`] for context.
+    #[deprecated(note = "Non-standard SHA3-512 KDF; new code should use \
+                `ElGamalSecretKey::from_seed`. Retained for backward compatibility. \
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
+    pub fn from_seed_legacy(seed: &[u8]) -> Result<Self, ElGamalError> {
+        const MINIMUM_SEED_LEN: usize = ELGAMAL_SECRET_KEY_LEN;
+        const MAXIMUM_SEED_LEN: usize = 65535;
+
+        if seed.len() < MINIMUM_SEED_LEN {
+            return Err(ElGamalError::SeedLengthTooShort);
+        }
+        if seed.len() > MAXIMUM_SEED_LEN {
+            return Err(ElGamalError::SeedLengthTooLong);
+        }
+        Ok(ElGamalSecretKey(Scalar::hash_from_bytes::<Sha3_512>(seed)))
+    }
+
+    /// Derive an ElGamal secret key from a BIP39 mnemonic and passphrase using
+    /// the legacy SHA3-512 KDF.
+    ///
+    /// See [`ElGamalSecretKey::new_from_signer_legacy`] for context.
+    #[deprecated(note = "Non-standard SHA3-512 KDF; new code should use \
+                `<ElGamalSecretKey as SeedDerivable>::from_seed_phrase_and_passphrase`. \
+                Retained for backward compatibility. \
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
+    #[allow(deprecated)]
+    pub fn from_seed_phrase_and_passphrase_legacy(
+        seed_phrase: &str,
+        passphrase: &str,
+    ) -> Result<Self, Box<dyn error::Error>> {
+        let key = Self::from_seed_legacy(&generate_seed_from_seed_phrase_and_passphrase(
+            seed_phrase,
+            passphrase,
+        ))?;
+        Ok(key)
     }
 }
 
@@ -1221,6 +1419,97 @@ mod tests {
         assert!(
             ElGamalSecretKey::new_from_signer(&null_signer, Address::default().as_ref()).is_err()
         );
+    }
+
+    #[test]
+    fn test_elgamal_hkdf_determinism_from_signature() {
+        let sig = Signature::from([0x42u8; 64]);
+        let key_a = ElGamalSecretKey::new_from_signature(&sig).unwrap();
+        let key_b = ElGamalSecretKey::new_from_signature(&sig).unwrap();
+        assert_eq!(key_a.as_bytes(), key_b.as_bytes());
+    }
+
+    #[test]
+    fn test_elgamal_hkdf_differs_from_legacy() {
+        // The HKDF and legacy SHA3-512 paths must produce different secret
+        // keys for the same input — otherwise the legacy fallback would
+        // silently match the new derivation and accounts could be mis-claimed
+        // as migrated.
+        let sig = Signature::from([0x42u8; 64]);
+        let new_key = ElGamalSecretKey::new_from_signature(&sig).unwrap();
+        #[allow(deprecated)]
+        let old_key = ElGamalSecretKey::new_from_signature_legacy(&sig).unwrap();
+        assert_ne!(new_key.as_bytes(), old_key.as_bytes());
+    }
+
+    #[test]
+    fn test_elgamal_hkdf_known_vector_from_signature() {
+        // Canonical test vector for the HKDF-SHA512 ElGamalSecretKey
+        // derivation.
+        //
+        // Inputs:
+        //   signature = [0x42; 64]
+        //   salt      = b"solana-zk-sdk:ElGamalSecretKey:v1:hkdf-sha512"
+        //   info      = b"ElGamalSecretKey"
+        //   L         = 64 (reduced via Scalar::from_bytes_mod_order_wide)
+        let sig = Signature::from([0x42u8; 64]);
+        let key = ElGamalSecretKey::new_from_signature(&sig).unwrap();
+        let expected: [u8; ELGAMAL_SECRET_KEY_LEN] = [
+            0xa6, 0x5a, 0xb9, 0xa5, 0x97, 0x56, 0xd8, 0x68, 0xc5, 0xdc, 0x1d, 0xbe, 0xbf, 0xfe,
+            0x52, 0xa0, 0x9e, 0xb7, 0xeb, 0x6a, 0xe2, 0x90, 0x6c, 0x13, 0x4e, 0x3c, 0x74, 0x5d,
+            0xb7, 0x9c, 0x02, 0x00,
+        ];
+        assert_eq!(
+            key.as_bytes(),
+            &expected,
+            "HKDF ElGamalSecretKey vector drift; computed {:02x?}",
+            key.as_bytes()
+        );
+    }
+
+    #[test]
+    fn test_elgamal_legacy_known_vector_from_signature() {
+        // Pinned canonical bytes for the SHA3-512 legacy derivation.
+        let sig = Signature::from([0x42u8; 64]);
+        #[allow(deprecated)]
+        let key = ElGamalSecretKey::new_from_signature_legacy(&sig).unwrap();
+        let expected: [u8; ELGAMAL_SECRET_KEY_LEN] = [
+            0x66, 0x85, 0xc3, 0x9b, 0x2b, 0x75, 0xff, 0x56, 0x28, 0x4a, 0xb0, 0x61, 0xa5, 0xb9,
+            0xf8, 0xbf, 0xff, 0x48, 0x7b, 0x69, 0xc2, 0x9f, 0x5e, 0xd1, 0x48, 0x79, 0xad, 0xf3,
+            0xe6, 0x95, 0x8c, 0x0c,
+        ];
+        assert_eq!(
+            key.as_bytes(),
+            &expected,
+            "Legacy ElGamalSecretKey vector drift; computed {:02x?}",
+            key.as_bytes()
+        );
+    }
+
+    #[test]
+    fn test_elgamal_hkdf_signer_matches_signature_path() {
+        // `new_from_signer` should match `new_from_signature` over the
+        // signature the signer would produce for the same message.
+        let keypair = Keypair::new();
+        let public_seed = [0x11u8; 32];
+        let key_from_signer = ElGamalSecretKey::new_from_signer(&keypair, &public_seed).unwrap();
+
+        let message = [b"ElGamalSecretKey", public_seed.as_ref()].concat();
+        let sig = keypair.sign_message(&message);
+        let key_from_sig = ElGamalSecretKey::new_from_signature(&sig).unwrap();
+
+        assert_eq!(key_from_signer.as_bytes(), key_from_sig.as_bytes());
+    }
+
+    #[test]
+    fn test_elgamal_aekey_domain_separation_from_signature() {
+        // ElGamal and AeKey derivations over the same signature must produce
+        // unrelated key material. This is enforced by salt + info domain
+        // separation in the HKDF construction.
+        let sig = Signature::from([0x42u8; 64]);
+        let elgamal_seed = ElGamalSecretKey::seed_from_signature(&sig);
+        let ae_seed = crate::encryption::auth_encryption::AeKey::seed_from_signature(&sig);
+        assert_ne!(elgamal_seed, ae_seed);
     }
 
     #[test]

--- a/zk-sdk/src/encryption/elgamal.rs
+++ b/zk-sdk/src/encryption/elgamal.rs
@@ -643,7 +643,7 @@ impl ElGamalSecretKey {
     /// feeding into [`ElGamalSecretKey::from_seed`].
     ///
     /// The signature bytes themselves are returned unmodified so that the
-    /// full HKDF-SHA512 chain (Extract + Expand) runs exactly once inside
+    /// full HKDF-SHA512 chain (Extract and Expand) runs exactly once inside
     /// [`ElGamalSecretKey::from_seed`]. A wallet that prefers to call HKDF
     /// directly via its platform crypto can therefore reproduce the SDK
     /// output via

--- a/zk-sdk/src/encryption/elgamal.rs
+++ b/zk-sdk/src/encryption/elgamal.rs
@@ -639,16 +639,18 @@ impl ElGamalSecretKey {
         Ok(key)
     }
 
-    /// Derive a seed from a signature used to generate an ElGamal secret key.
+    /// Returns the input key material derived from a signature, suitable for
+    /// feeding into [`ElGamalSecretKey::from_seed`].
     ///
-    /// The signature is treated as input key material for HKDF-Extract
-    /// (HKDF-SHA512, RFC 5869) using a versioned, domain-separated salt. The
-    /// returned 64-byte pseudorandom key is then fed into
-    /// [`ElGamalSecretKey::from_seed`] which performs the corresponding
-    /// HKDF-Expand step.
+    /// The signature bytes themselves are returned unmodified so that the
+    /// full HKDF-SHA512 chain (Extract + Expand) runs exactly once inside
+    /// [`ElGamalSecretKey::from_seed`]. A wallet that prefers to call HKDF
+    /// directly via its platform crypto can therefore reproduce the SDK
+    /// output via
+    /// `HKDF-SHA512(salt = ELGAMAL_HKDF_SALT, ikm = signature, info = b"ElGamalSecretKey", L = 64)`
+    /// and then reduce the 64 bytes via `Scalar::from_bytes_mod_order_wide`.
     pub fn seed_from_signature(signature: &Signature) -> Vec<u8> {
-        let (prk, _) = Hkdf::<Sha512>::extract(Some(ELGAMAL_HKDF_SALT), signature.as_ref());
-        prk.to_vec()
+        signature.as_ref().to_vec()
     }
 
     /// Derive an ElGamal secret key from a Solana signer using the legacy
@@ -1455,9 +1457,9 @@ mod tests {
         let sig = Signature::from([0x42u8; 64]);
         let key = ElGamalSecretKey::new_from_signature(&sig).unwrap();
         let expected: [u8; ELGAMAL_SECRET_KEY_LEN] = [
-            0xa6, 0x5a, 0xb9, 0xa5, 0x97, 0x56, 0xd8, 0x68, 0xc5, 0xdc, 0x1d, 0xbe, 0xbf, 0xfe,
-            0x52, 0xa0, 0x9e, 0xb7, 0xeb, 0x6a, 0xe2, 0x90, 0x6c, 0x13, 0x4e, 0x3c, 0x74, 0x5d,
-            0xb7, 0x9c, 0x02, 0x00,
+            0xe7, 0x03, 0x51, 0xd6, 0x6a, 0x1a, 0x3f, 0x88, 0x3c, 0xd8, 0x53, 0x64, 0x8b, 0xa2,
+            0x18, 0xfa, 0x39, 0x0a, 0x67, 0xdf, 0x61, 0x1d, 0x59, 0x7a, 0x0c, 0xf6, 0xd7, 0x7d,
+            0x92, 0x67, 0x45, 0x03,
         ];
         assert_eq!(
             key.as_bytes(),
@@ -1487,6 +1489,23 @@ mod tests {
     }
 
     #[test]
+    fn test_elgamal_matches_single_hkdf_over_signature() {
+        // External-implementation interop contract: HKDF-SHA512 over the
+        // signature with the documented salt/info, expanded to 64 bytes, then
+        // reduced via `Scalar::from_bytes_mod_order_wide`, MUST equal the SDK
+        // scalar. Regression guard for the double-HKDF-Extract bug.
+        let sig = Signature::from([0x42u8; 64]);
+        let sdk_secret = ElGamalSecretKey::new_from_signature(&sig).unwrap();
+
+        let direct = Hkdf::<Sha512>::new(Some(ELGAMAL_HKDF_SALT), sig.as_ref());
+        let mut wide = [0u8; 64];
+        direct.expand(ELGAMAL_HKDF_INFO, &mut wide).unwrap();
+        let external_scalar = Scalar::from_bytes_mod_order_wide(&wide);
+
+        assert_eq!(sdk_secret.as_bytes(), external_scalar.as_bytes());
+    }
+
+    #[test]
     fn test_elgamal_hkdf_signer_matches_signature_path() {
         // `new_from_signer` should match `new_from_signature` over the
         // signature the signer would produce for the same message.
@@ -1505,11 +1524,16 @@ mod tests {
     fn test_elgamal_aekey_domain_separation_from_signature() {
         // ElGamal and AeKey derivations over the same signature must produce
         // unrelated key material. This is enforced by salt + info domain
-        // separation in the HKDF construction.
+        // separation in the HKDF construction inside `from_seed`.
         let sig = Signature::from([0x42u8; 64]);
-        let elgamal_seed = ElGamalSecretKey::seed_from_signature(&sig);
-        let ae_seed = crate::encryption::auth_encryption::AeKey::seed_from_signature(&sig);
-        assert_ne!(elgamal_seed, ae_seed);
+        let elgamal_secret = ElGamalSecretKey::new_from_signature(&sig).unwrap();
+        let ae_key = crate::encryption::auth_encryption::AeKey::new_from_signature(&sig).unwrap();
+
+        // The first 16 bytes of the ElGamal scalar and the AeKey would only
+        // collide if the salt+info domain separation were broken.
+        let elgamal_bytes = elgamal_secret.as_bytes();
+        let ae_bytes: [u8; 16] = (&ae_key).into();
+        assert_ne!(&elgamal_bytes[..16], &ae_bytes[..]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #35.

Swaps the non-standard SHA3-512 truncate / `Scalar::hash_from_bytes::<Sha3_512>` constructions used for `AeKey` and `ElGamalSecretKey` derivation over to HKDF-SHA512 (RFC 5869) with versioned, domain-separated salt and info strings:

- `AeKey`: salt `b"solana-zk-sdk:AeKey:v1:hkdf-sha512"`, info `b"AeKey"`, 16 bytes
- `ElGamalSecretKey`: salt `b"solana-zk-sdk:ElGamalSecretKey:v1:hkdf-sha512"`, info `b"ElGamalSecretKey"`, 64 bytes reduced via `Scalar::from_bytes_mod_order_wide`

The legacy SHA3-512 paths are preserved under `*_legacy` methods marked `#[deprecated]`, with note text pointing at this issue, so any account provisioned under the previous scheme can still be recovered through the explicit legacy API.

## Notes

Behavior change: same signer + same `public_seed` will now produce different `AeKey` / `ElGamal` bytes than before. The public API surface is purely additive (new methods, new `From<&AeKey>` impl), but the meaning of `new_from_signer` / `new_from_signature` / `from_seed` / `from_seed_phrase_and_passphrase` shifts. This is the intent of issue #35 and likely warrants a major-version bump at release time.

Drive-by: adds `From<&AeKey> for [u8; AE_KEY_LEN]` (mirroring the existing `&ElGamalKeypair` and `&ElGamalPubkey` impls) and uses it in `zk-sdk-wasm-js` to drop the `.clone()` workaround in `AeKey::toBytes`. Closes the third remaining TODO in the encryption module.

New tests:
- pinned HKDF canonical vectors for `AeKey` and `ElGamalSecretKey` over `signature = [0x42; 64]`
- pinned legacy vectors over the same input to guard against silent regressions in the recovery path
- HKDF and legacy outputs differ for the same input
- signer-message path matches the signature-only path
- `AeKey` and `ElGamal` HKDF seeds derived from the same signature are unrelated

## Why HKDF-SHA512 and not HKDF-SHA3-512

Worth calling out since the crate already uses SHA3-512 elsewhere (Merlin transcripts, `Scalar::hash_from_bytes`, the legacy KDF). Cryptographically the two are equivalent for HKDF purposes (both 256-bit secure, both 64-byte output, NIST-approved, no known practical attacks). The deciding factor is interop with platform crypto on the wallet integration side:

- **Web Crypto** (`subtle.deriveBits` with HKDF) supports SHA-1/256/384/512 only. No SHA-3. Browser wallets (Phantom, Backpack, Solflare) hitting this path would need a SHA-3 polyfill instead of native `crypto.subtle`.
- **iOS / macOS CryptoKit** ships `HKDF<SHA512>` natively. No SHA-3 path, third-party deps required.
- **Rust `ring`** (rustls, many production backends) deliberately excludes SHA-3.
- **Standards alignment**: TLS 1.3, HPKE (RFC 9180), Signal, Noise, WebAuthn PRF, BIP-32 / SLIP-10 all use HMAC/HKDF over SHA-2. There is effectively no production protocol shipping HKDF-SHA3.

Inside this crate, `sha2` is already in the build graph transitively (via `solana-signature`, `solana-keypair`, `ed25519-dalek`, `tiny-bip39`, `pbkdf2`), so declaring it at workspace level doesn't add anything new to the dep closure. `sha3` stays in use for the curve25519-dalek hash-to-scalar and Merlin transcripts: that's an algebraic requirement of those constructions, not a hash-of-convenience.

## Background

The wallet-side framework around confidential balance key derivation distinguishes two regimes: HKDF-direct (preferred when the wallet exposes an HMAC primitive, e.g. passkey PRF, Secure Enclave HMAC, KMS HMAC, the eventual Wallet Standard `solana:deriveSubkey`) and an Ed25519 sig-based fallback for wallets that expose only `signMessage`. This PR keeps the sig-based fallback shape (two domain-separated messages, deterministic Ed25519, per-account `public_seed`) and only swaps the internal hash for HKDF-SHA512.

## Open items

- Long-term, a unified `DerivationAdapter` trait + shared HKDF spine that covers passkey PRF, Secure Enclave, KMS, deterministic ECDSA, and the future `deriveSubkey` extension is the natural follow-up. The salt strings introduced here are versioned (`v1`) so a future framework can iterate without colliding.
- Canonical cross-language vectors (Rust ↔ wasm-js) are a sensible follow-up; the Rust-side vectors land here.
