### PR TITLE
refactor: unify confidential-balances key derivation under solana-conf-bal/v1 HKDF spine

### DIFF
--- a/scripts/solana.dic
+++ b/scripts/solana.dic
@@ -79,9 +79,15 @@ multiscalar
 representable
 KDF
 HKDF
+HMAC
+IKM
+KMS
+PRF
 SHA512
+WebAuthn
 crypto
 pseudorandom
+reimplementations
 SDK
 Curve25519
 hashable

--- a/zk-sdk-wasm-js/src/encryption/auth_encryption.rs
+++ b/zk-sdk-wasm-js/src/encryption/auth_encryption.rs
@@ -1,14 +1,10 @@
 use {
     js_sys::Uint8Array,
     solana_seed_derivable::SeedDerivable,
-    solana_signature::Signature,
     solana_zk_sdk::encryption::auth_encryption,
     solana_zk_sdk_pod::encryption::{AE_CIPHERTEXT_LEN, AE_KEY_LEN},
     wasm_bindgen::prelude::{wasm_bindgen, JsValue},
 };
-
-/// Byte length of an ed25519 signature.
-const SIGNATURE_LEN: usize = 64;
 
 #[wasm_bindgen]
 pub struct AeKey {
@@ -25,43 +21,6 @@ impl AeKey {
         Self {
             inner: auth_encryption::AeKey::new_rand(),
         }
-    }
-
-    /// Returns the message that a Solana signer must sign in order to
-    /// deterministically derive an `AeKey` via `fromSignature`.
-    ///
-    /// The message is `b"AeKey" || public_seed`. For the spl-token-2022
-    /// confidential extension, the `public_seed` is the 32-byte token
-    /// account address.
-    #[wasm_bindgen(js_name = "signerMessage")]
-    pub fn signer_message(public_seed: Uint8Array) -> Vec<u8> {
-        let mut seed = vec![0u8; public_seed.length() as usize];
-        public_seed.copy_to(&mut seed);
-        [b"AeKey".as_ref(), seed.as_ref()].concat()
-    }
-
-    /// Derives an `AeKey` from a 64-byte ed25519 signature over the
-    /// message returned by `signerMessage`.
-    #[wasm_bindgen(js_name = "fromSignature")]
-    pub fn from_signature(signature: Uint8Array) -> Result<AeKey, JsValue> {
-        let mut bytes = [0u8; SIGNATURE_LEN];
-        if signature.length() as usize != SIGNATURE_LEN {
-            return Err(JsValue::from_str(&format!(
-                "Invalid signature length: expected {}, got {}",
-                SIGNATURE_LEN,
-                signature.length()
-            )));
-        }
-        signature.copy_to(&mut bytes);
-        let signature = Signature::from(bytes);
-
-        if signature == Signature::default() {
-            return Err(JsValue::from_str("Rejecting default signature"));
-        }
-
-        auth_encryption::AeKey::new_from_signature(&signature)
-            .map(|inner| Self { inner })
-            .map_err(|e| JsValue::from_str(&e.to_string()))
     }
 
     /// Deterministically derives an `AeKey` from a seed.
@@ -226,48 +185,6 @@ mod tests {
         // Attempt to decrypt with wrong key
         let result = key2.decrypt(&ciphertext);
         assert!(!result.is_ok());
-    }
-
-    #[wasm_bindgen_test]
-    fn test_signer_message_format() {
-        let seed = [7u8; 32];
-        let expected = [b"AeKey".as_ref(), seed.as_ref()].concat();
-        let msg = AeKey::signer_message(Uint8Array::from(seed.as_ref()));
-        assert_eq!(msg, expected);
-    }
-
-    #[wasm_bindgen_test]
-    fn test_signer_message_domain_separated_from_elgamal() {
-        // The AeKey and ElGamalSecretKey domain separators must differ so that
-        // signing the same public seed for both keys yields different signatures.
-        let seed = Uint8Array::from([0u8; 32].as_ref());
-        let ae_msg = AeKey::signer_message(seed.clone());
-        let elgamal_msg = crate::encryption::elgamal::ElGamalSecretKey::signer_message(seed);
-        assert_ne!(ae_msg, elgamal_msg);
-    }
-
-    #[wasm_bindgen_test]
-    fn test_from_signature_determinism() {
-        let signature_bytes = [3u8; 64];
-        let sig = Uint8Array::from(signature_bytes.as_ref());
-
-        let key_a = AeKey::from_signature(sig.clone()).unwrap();
-        let key_b = AeKey::from_signature(sig).unwrap();
-        assert_eq!(key_a.to_bytes(), key_b.to_bytes());
-    }
-
-    #[wasm_bindgen_test]
-    fn test_from_signature_rejects_wrong_length() {
-        let short = vec![0u8; 63];
-        assert!(AeKey::from_signature(Uint8Array::from(short.as_slice())).is_err());
-        let long = vec![0u8; 65];
-        assert!(AeKey::from_signature(Uint8Array::from(long.as_slice())).is_err());
-    }
-
-    #[wasm_bindgen_test]
-    fn test_from_signature_rejects_default_signature() {
-        let default = vec![0u8; 64];
-        assert!(AeKey::from_signature(Uint8Array::from(default.as_slice())).is_err());
     }
 
     #[wasm_bindgen_test]

--- a/zk-sdk-wasm-js/src/encryption/derivation.rs
+++ b/zk-sdk-wasm-js/src/encryption/derivation.rs
@@ -68,9 +68,10 @@ impl ConfidentialKeys {
 
     /// Derives a `ConfidentialKeys` pair from raw input key material.
     ///
-    /// Use this when the caller already produced 32+ bytes of IKM via a
-    /// non-`Signer` path: WebAuthn PRF output, Secure Enclave HMAC output,
-    /// KMS `GenerateMac` output, HKDF over an Ed25519 seed, or a BIP39 seed.
+    /// Use this when the caller already produced 32 or more bytes of IKM
+    /// via a non-`Signer` path: WebAuthn PRF output, Secure Enclave HMAC
+    /// output, KMS `GenerateMac` output, HKDF over an Ed25519 seed, or a
+    /// BIP39 seed.
     #[wasm_bindgen(js_name = "fromIkm")]
     pub fn from_ikm(ikm: Uint8Array) -> Result<ConfidentialKeys, JsValue> {
         let mut bytes = vec![0u8; ikm.length() as usize];

--- a/zk-sdk-wasm-js/src/encryption/derivation.rs
+++ b/zk-sdk-wasm-js/src/encryption/derivation.rs
@@ -1,0 +1,174 @@
+use {
+    crate::encryption::{auth_encryption::AeKey, elgamal::ElGamalKeypair},
+    js_sys::Uint8Array,
+    solana_signature::Signature,
+    solana_zk_sdk::encryption::derivation::{
+        derive_confidential_keys_from_ikm, derive_confidential_keys_from_signature, HKDF_SALT,
+    },
+    wasm_bindgen::prelude::{wasm_bindgen, JsValue},
+};
+
+/// Byte length of an ed25519 signature.
+const SIGNATURE_LEN: usize = 64;
+
+/// Container returned by the unified confidential-balances key derivation.
+///
+/// Both the ElGamal keypair and the AES (`decryptable_available_balance`
+/// fast-path) key are derived from a single source of input key material
+/// via a shared HKDF-SHA512 chain.
+#[wasm_bindgen]
+pub struct ConfidentialKeys {
+    pub(crate) elgamal: ElGamalKeypair,
+    pub(crate) ae: AeKey,
+}
+
+#[wasm_bindgen]
+impl ConfidentialKeys {
+    /// Returns the canonical derivation message a Solana signer must sign
+    /// in order to deterministically derive a `ConfidentialKeys` pair via
+    /// `fromSignature`.
+    ///
+    /// The message is `b"solana-conf-bal/v1" || public_seed`. `public_seed`
+    /// is caller-controlled and granularity-agnostic; pass a wallet pubkey
+    /// for per-wallet keying or a token-account pubkey for per-account
+    /// keying.
+    #[wasm_bindgen(js_name = "signerMessage")]
+    pub fn signer_message(public_seed: Uint8Array) -> Vec<u8> {
+        let mut seed = vec![0u8; public_seed.length() as usize];
+        public_seed.copy_to(&mut seed);
+        [HKDF_SALT, seed.as_ref()].concat()
+    }
+
+    /// Derives a `ConfidentialKeys` pair from a 64-byte ed25519 signature
+    /// over the message returned by `signerMessage`.
+    #[wasm_bindgen(js_name = "fromSignature")]
+    pub fn from_signature(signature: Uint8Array) -> Result<ConfidentialKeys, JsValue> {
+        if signature.length() as usize != SIGNATURE_LEN {
+            return Err(JsValue::from_str(&format!(
+                "Invalid signature length: expected {}, got {}",
+                SIGNATURE_LEN,
+                signature.length()
+            )));
+        }
+        let mut bytes = [0u8; SIGNATURE_LEN];
+        signature.copy_to(&mut bytes);
+        let signature = Signature::from(bytes);
+
+        if signature == Signature::default() {
+            return Err(JsValue::from_str("Rejecting default signature"));
+        }
+
+        derive_confidential_keys_from_signature(&signature)
+            .map(|(elgamal, ae)| Self {
+                elgamal: elgamal.into(),
+                ae: ae.into(),
+            })
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Derives a `ConfidentialKeys` pair from raw input key material.
+    ///
+    /// Use this when the caller already produced 32+ bytes of IKM via a
+    /// non-`Signer` path: WebAuthn PRF output, Secure Enclave HMAC output,
+    /// KMS `GenerateMac` output, HKDF over an Ed25519 seed, or a BIP39 seed.
+    #[wasm_bindgen(js_name = "fromIkm")]
+    pub fn from_ikm(ikm: Uint8Array) -> Result<ConfidentialKeys, JsValue> {
+        let mut bytes = vec![0u8; ikm.length() as usize];
+        ikm.copy_to(&mut bytes);
+
+        derive_confidential_keys_from_ikm(&bytes)
+            .map(|(elgamal, ae)| Self {
+                elgamal: elgamal.into(),
+                ae: ae.into(),
+            })
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Returns the ElGamal keypair component.
+    pub fn elgamal(&self) -> ElGamalKeypair {
+        ElGamalKeypair {
+            inner: self.elgamal.inner.clone(),
+        }
+    }
+
+    /// Returns the AES key component.
+    pub fn ae(&self) -> AeKey {
+        AeKey {
+            inner: self.ae.inner.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, wasm_bindgen_test::*};
+
+    #[wasm_bindgen_test]
+    fn test_signer_message_format() {
+        let seed = [7u8; 32];
+        let expected = [HKDF_SALT, seed.as_ref()].concat();
+        let msg = ConfidentialKeys::signer_message(Uint8Array::from(seed.as_ref()));
+        assert_eq!(msg, expected);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_signer_message_uses_unified_context() {
+        // Sanity-check that the message uses the SRFC-aligned protocol
+        // identifier rather than a per-key magic string.
+        let seed = [0u8; 32];
+        let msg = ConfidentialKeys::signer_message(Uint8Array::from(seed.as_ref()));
+        assert!(msg.starts_with(b"solana-conf-bal/v1"));
+        assert!(!msg.starts_with(b"AeKey"));
+        assert!(!msg.starts_with(b"ElGamalSecretKey"));
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_signature_determinism() {
+        let signature_bytes = [3u8; 64];
+        let sig = Uint8Array::from(signature_bytes.as_ref());
+
+        let keys_a = ConfidentialKeys::from_signature(sig.clone()).unwrap();
+        let keys_b = ConfidentialKeys::from_signature(sig).unwrap();
+        assert_eq!(
+            keys_a.elgamal().secret().to_bytes(),
+            keys_b.elgamal().secret().to_bytes()
+        );
+        assert_eq!(keys_a.ae().to_bytes(), keys_b.ae().to_bytes());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_signature_rejects_wrong_length() {
+        let short = vec![0u8; 63];
+        assert!(ConfidentialKeys::from_signature(Uint8Array::from(short.as_slice())).is_err());
+        let long = vec![0u8; 65];
+        assert!(ConfidentialKeys::from_signature(Uint8Array::from(long.as_slice())).is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_signature_rejects_default_signature() {
+        let default = vec![0u8; 64];
+        assert!(ConfidentialKeys::from_signature(Uint8Array::from(default.as_slice())).is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_ikm_matches_from_signature_over_same_bytes() {
+        let signature_bytes = [5u8; 64];
+        let sig = Uint8Array::from(signature_bytes.as_ref());
+        let ikm = Uint8Array::from(signature_bytes.as_ref());
+
+        let from_sig = ConfidentialKeys::from_signature(sig).unwrap();
+        let from_ikm = ConfidentialKeys::from_ikm(ikm).unwrap();
+
+        assert_eq!(
+            from_sig.elgamal().secret().to_bytes(),
+            from_ikm.elgamal().secret().to_bytes()
+        );
+        assert_eq!(from_sig.ae().to_bytes(), from_ikm.ae().to_bytes());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_ikm_rejects_short() {
+        let too_short = vec![0u8; 31];
+        assert!(ConfidentialKeys::from_ikm(Uint8Array::from(too_short.as_slice())).is_err());
+    }
+}

--- a/zk-sdk-wasm-js/src/encryption/derivation.rs
+++ b/zk-sdk-wasm-js/src/encryption/derivation.rs
@@ -54,10 +54,6 @@ impl ConfidentialKeys {
         signature.copy_to(&mut bytes);
         let signature = Signature::from(bytes);
 
-        if signature == Signature::default() {
-            return Err(JsValue::from_str("Rejecting default signature"));
-        }
-
         derive_confidential_keys_from_signature(&signature)
             .map(|(elgamal, ae)| Self {
                 elgamal: elgamal.into(),

--- a/zk-sdk-wasm-js/src/encryption/elgamal.rs
+++ b/zk-sdk-wasm-js/src/encryption/elgamal.rs
@@ -2,16 +2,12 @@ use {
     crate::encryption::pedersen::{PedersenCommitment, PedersenOpening},
     js_sys::Uint8Array,
     solana_seed_derivable::SeedDerivable,
-    solana_signature::Signature,
     solana_zk_sdk::encryption::elgamal,
     solana_zk_sdk_pod::encryption::{
         DECRYPT_HANDLE_LEN, ELGAMAL_CIPHERTEXT_LEN, ELGAMAL_PUBKEY_LEN, ELGAMAL_SECRET_KEY_LEN,
     },
     wasm_bindgen::prelude::{wasm_bindgen, JsValue},
 };
-
-/// Byte length of an ed25519 signature.
-const SIGNATURE_LEN: usize = 64;
 
 #[wasm_bindgen]
 pub struct ElGamalPubkey {
@@ -85,43 +81,6 @@ impl ElGamalSecretKey {
         Self {
             inner: elgamal::ElGamalSecretKey::new_rand(),
         }
-    }
-
-    /// Returns the message that a Solana signer must sign in order to
-    /// deterministically derive an `ElGamalSecretKey` via `fromSignature`.
-    ///
-    /// The message is `b"ElGamalSecretKey" || public_seed`. For the
-    /// spl-token-2022 confidential extension, the `public_seed` is the
-    /// 32-byte token account address.
-    #[wasm_bindgen(js_name = "signerMessage")]
-    pub fn signer_message(public_seed: Uint8Array) -> Vec<u8> {
-        let mut seed = vec![0u8; public_seed.length() as usize];
-        public_seed.copy_to(&mut seed);
-        [b"ElGamalSecretKey".as_ref(), seed.as_ref()].concat()
-    }
-
-    /// Derives an `ElGamalSecretKey` from a 64-byte ed25519 signature
-    /// over the message returned by `signerMessage`.
-    #[wasm_bindgen(js_name = "fromSignature")]
-    pub fn from_signature(signature: Uint8Array) -> Result<ElGamalSecretKey, JsValue> {
-        let mut bytes = [0u8; SIGNATURE_LEN];
-        if signature.length() as usize != SIGNATURE_LEN {
-            return Err(JsValue::from_str(&format!(
-                "Invalid signature length: expected {}, got {}",
-                SIGNATURE_LEN,
-                signature.length()
-            )));
-        }
-        signature.copy_to(&mut bytes);
-        let signature = Signature::from(bytes);
-
-        if signature == Signature::default() {
-            return Err(JsValue::from_str("Rejecting default signature"));
-        }
-
-        elgamal::ElGamalSecretKey::new_from_signature(&signature)
-            .map(|inner| Self { inner })
-            .map_err(|e| JsValue::from_str(&e.to_string()))
     }
 
     /// Deterministically derives an `ElGamalSecretKey` from a seed.
@@ -215,24 +174,6 @@ impl ElGamalKeypair {
         Self {
             inner: elgamal::ElGamalKeypair::new(secret_key.inner.clone()),
         }
-    }
-
-    /// Returns the message that a Solana signer must sign in order to
-    /// deterministically derive an `ElGamalKeypair` via `fromSignature`.
-    ///
-    /// Identical to `ElGamalSecretKey.signerMessage` - provided on `ElGamalKeypair`
-    /// for ergonomic access.
-    #[wasm_bindgen(js_name = "signerMessage")]
-    pub fn signer_message(public_seed: Uint8Array) -> Vec<u8> {
-        ElGamalSecretKey::signer_message(public_seed)
-    }
-
-    /// Derives an `ElGamalKeypair` from a 64-byte ed25519 signature
-    /// over the message returned by `signerMessage`.
-    #[wasm_bindgen(js_name = "fromSignature")]
-    pub fn from_signature(signature: Uint8Array) -> Result<ElGamalKeypair, JsValue> {
-        let secret = ElGamalSecretKey::from_signature(signature)?;
-        Ok(Self::from_secret_key(&secret))
     }
 
     /// Deterministically derives an `ElGamalKeypair` from a seed.
@@ -495,47 +436,6 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    fn test_signer_message_format() {
-        let seed = [7u8; 32];
-        let expected = [b"ElGamalSecretKey".as_ref(), seed.as_ref()].concat();
-
-        let from_secret = ElGamalSecretKey::signer_message(Uint8Array::from(seed.as_ref()));
-        assert_eq!(from_secret, expected);
-
-        let from_keypair = ElGamalKeypair::signer_message(Uint8Array::from(seed.as_ref()));
-        assert_eq!(from_keypair, expected);
-    }
-
-    #[wasm_bindgen_test]
-    fn test_from_signature_determinism() {
-        let signature_bytes = [1u8; 64];
-        let sig = Uint8Array::from(signature_bytes.as_ref());
-
-        let secret_a = ElGamalSecretKey::from_signature(sig.clone()).unwrap();
-        let secret_b = ElGamalSecretKey::from_signature(sig.clone()).unwrap();
-        assert_eq!(secret_a.to_bytes(), secret_b.to_bytes());
-
-        // Keypair derivation must yield the same secret as the secret-key path.
-        let keypair = ElGamalKeypair::from_signature(sig).unwrap();
-        assert_eq!(keypair.secret().to_bytes(), secret_a.to_bytes());
-    }
-
-    #[wasm_bindgen_test]
-    fn test_from_signature_rejects_wrong_length() {
-        let short = vec![0u8; 63];
-        assert!(ElGamalSecretKey::from_signature(Uint8Array::from(short.as_slice())).is_err());
-        let long = vec![0u8; 65];
-        assert!(ElGamalKeypair::from_signature(Uint8Array::from(long.as_slice())).is_err());
-    }
-
-    #[wasm_bindgen_test]
-    fn test_from_signature_rejects_default_signature() {
-        let default = vec![0u8; 64];
-        assert!(ElGamalSecretKey::from_signature(Uint8Array::from(default.as_slice())).is_err());
-        assert!(ElGamalKeypair::from_signature(Uint8Array::from(default.as_slice())).is_err());
-    }
-
-    #[wasm_bindgen_test]
     fn test_from_seed_roundtrip() {
         let seed = [9u8; 32];
         let seed_arr = Uint8Array::from(seed.as_ref());
@@ -569,18 +469,5 @@ mod tests {
             ElGamalSecretKey::from_seed_phrase_and_passphrase(phrase, Some("pw".to_string()))
                 .unwrap();
         assert_ne!(different.to_bytes(), a.to_bytes());
-    }
-
-    #[wasm_bindgen_test]
-    fn test_different_public_seeds_produce_different_keys() {
-        // Domain separation across token accounts: different public seeds must
-        // yield different signer messages, and therefore different keys for any
-        // given (hypothetical) signer.
-        let seed_a = Uint8Array::from([1u8; 32].as_ref());
-        let seed_b = Uint8Array::from([2u8; 32].as_ref());
-
-        let msg_a = ElGamalSecretKey::signer_message(seed_a);
-        let msg_b = ElGamalSecretKey::signer_message(seed_b);
-        assert_ne!(msg_a, msg_b);
     }
 }

--- a/zk-sdk-wasm-js/src/encryption/mod.rs
+++ b/zk-sdk-wasm-js/src/encryption/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth_encryption;
+pub mod derivation;
 pub mod elgamal;
 pub mod grouped_elgamal;
 pub mod pedersen;

--- a/zk-sdk/src/encryption/auth_encryption.rs
+++ b/zk-sdk/src/encryption/auth_encryption.rs
@@ -4,7 +4,10 @@
 //! specialized for SPL Token-2022 program where the plaintext is always a `u64`
 //! number.
 use {
-    crate::errors::AuthenticatedEncryptionError,
+    crate::{
+        encryption::derivation::{AE_HKDF_INFO, HKDF_SALT},
+        errors::AuthenticatedEncryptionError,
+    },
     aes_gcm_siv::{
         aead::{Aead, KeyInit},
         Aes128GcmSiv,
@@ -30,16 +33,6 @@ use {
     subtle::ConstantTimeEq,
     zeroize::{Zeroize, Zeroizing},
 };
-
-/// HKDF salt used when deriving an `AeKey`. Versioned so that future revisions
-/// of the key derivation scheme can coexist with the current one by bumping the
-/// `:vN` suffix.
-const AE_HKDF_SALT: &[u8] = b"solana-zk-sdk:AeKey:v1:hkdf-sha512";
-
-/// HKDF info string used to bind the expanded output to the `AeKey` key type.
-/// Combined with the salt this provides domain separation against ElGamal
-/// derivation even when both share the same input key material.
-const AE_HKDF_INFO: &[u8] = b"AeKey";
 
 /// Byte length of an authenticated encryption nonce component
 const NONCE_LEN: usize = 12;
@@ -101,73 +94,18 @@ impl AuthenticatedEncryption {
 pub struct AeKey([u8; AE_KEY_LEN]);
 
 impl AeKey {
-    /// Deterministically derives an authenticated encryption key from a Solana signer and a public
-    /// seed.
-    ///
-    /// This function exists for applications where a user may not wish to maintain a Solana signer
-    /// and an authenticated encryption key separately. Instead, a user can derive the ElGamal
-    /// keypair on-the-fly whenever encryption / decryption is needed.
-    pub fn new_from_signer(
-        signer: &dyn Signer,
-        public_seed: &[u8],
-    ) -> Result<Self, Box<dyn error::Error>> {
-        let seed = Self::seed_from_signer(signer, public_seed)?;
-        Self::from_seed(&seed)
-    }
-
-    /// Derive a seed from a Solana signer used to generate an authenticated encryption key.
-    ///
-    /// The signer is asked to sign the message `b"AeKey" || public_seed`. The
-    /// resulting Ed25519 signature is fed into HKDF-SHA512 (RFC 5869) to
-    /// produce 64 bytes of pseudorandom seed material suitable for
-    /// [`AeKey::from_seed`].
-    pub fn seed_from_signer(
-        signer: &dyn Signer,
-        public_seed: &[u8],
-    ) -> Result<Vec<u8>, SignerError> {
-        let message = [b"AeKey", public_seed].concat();
-        let signature = signer.try_sign_message(&message)?;
-
-        // Some `Signer` implementations return the default signature, which is not suitable for
-        // use as key material
-        if bool::from(signature.as_ref().ct_eq(Signature::default().as_ref())) {
-            return Err(SignerError::Custom("Rejecting default signature".into()));
-        }
-
-        Ok(Self::seed_from_signature(&signature))
-    }
-
-    /// Derive an authenticated encryption key from a signature.
-    pub fn new_from_signature(signature: &Signature) -> Result<Self, Box<dyn error::Error>> {
-        let seed = Self::seed_from_signature(signature);
-        Self::from_seed(&seed)
-    }
-
-    /// Returns the input key material derived from a signature, suitable for
-    /// feeding into [`AeKey::from_seed`].
-    ///
-    /// The signature bytes themselves are returned unmodified so that the
-    /// full HKDF-SHA512 chain (Extract and Expand) runs exactly once inside
-    /// [`AeKey::from_seed`]. A wallet that prefers to call HKDF directly via
-    /// its platform crypto can therefore reproduce the SDK output via
-    /// `HKDF-SHA512(salt = AE_HKDF_SALT, ikm = signature, info = b"AeKey", L = 16)`.
-    pub fn seed_from_signature(signature: &Signature) -> Vec<u8> {
-        signature.as_ref().to_vec()
-    }
-
     /// Derive an authenticated encryption key from a Solana signer using the
     /// legacy SHA3-512-based KDF.
     ///
     /// Retained only so wallets can recover keys for accounts that were
     /// provisioned under `solana-zk-sdk` versions that shipped the
     /// non-standard `Truncate-128(SHA3-512(...))` derivation. New code should
-    /// use [`AeKey::new_from_signer`].
-    #[deprecated(
-        note = "Non-standard SHA3-512 KDF; new code should use `AeKey::new_from_signer`. \
+    /// use [`crate::encryption::derivation::derive_confidential_keys`].
+    #[deprecated(note = "Non-standard SHA3-512 KDF. New code should use \
+                `crate::encryption::derivation::derive_confidential_keys`. \
                 Retained for backward compatibility with accounts provisioned under \
                 solana-zk-sdk versions prior to the HKDF-SHA512 migration. \
-                See https://github.com/solana-program/zk-elgamal-proof/issues/35."
-    )]
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
     #[allow(deprecated)]
     pub fn new_from_signer_legacy(
         signer: &dyn Signer,
@@ -181,8 +119,8 @@ impl AeKey {
     ///
     /// See [`AeKey::new_from_signer_legacy`] for context.
     #[deprecated(
-        note = "Non-standard SHA3-512 KDF; new code should use `AeKey::seed_from_signer`. \
-                Retained for backward compatibility. \
+        note = "Non-standard SHA3-512 KDF. Retained for backward compatibility with accounts \
+                provisioned under solana-zk-sdk versions prior to the HKDF-SHA512 migration. \
                 See https://github.com/solana-program/zk-elgamal-proof/issues/35."
     )]
     #[allow(deprecated)]
@@ -204,11 +142,10 @@ impl AeKey {
     /// legacy SHA3-512 KDF.
     ///
     /// See [`AeKey::new_from_signer_legacy`] for context.
-    #[deprecated(
-        note = "Non-standard SHA3-512 KDF; new code should use `AeKey::new_from_signature`. \
+    #[deprecated(note = "Non-standard SHA3-512 KDF. New code should use \
+                `crate::encryption::derivation::derive_confidential_keys_from_signature`. \
                 Retained for backward compatibility. \
-                See https://github.com/solana-program/zk-elgamal-proof/issues/35."
-    )]
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
     #[allow(deprecated)]
     pub fn new_from_signature_legacy(signature: &Signature) -> Result<Self, Box<dyn error::Error>> {
         let seed = Self::seed_from_signature_legacy(signature);
@@ -219,8 +156,7 @@ impl AeKey {
     ///
     /// See [`AeKey::new_from_signer_legacy`] for context.
     #[deprecated(
-        note = "Non-standard SHA3-512 KDF; new code should use `AeKey::seed_from_signature`. \
-                Retained for backward compatibility. \
+        note = "Non-standard SHA3-512 KDF. Retained for backward compatibility. \
                 See https://github.com/solana-program/zk-elgamal-proof/issues/35."
     )]
     pub fn seed_from_signature_legacy(signature: &Signature) -> Vec<u8> {
@@ -235,11 +171,10 @@ impl AeKey {
     /// SHA3-512 KDF.
     ///
     /// See [`AeKey::new_from_signer_legacy`] for context.
-    #[deprecated(
-        note = "Non-standard SHA3-512 KDF; new code should use `AeKey::from_seed`. \
+    #[deprecated(note = "Non-standard SHA3-512 KDF. New code should use \
+                `<AeKey as SeedDerivable>::from_seed` (which now uses the unified HKDF spine). \
                 Retained for backward compatibility. \
-                See https://github.com/solana-program/zk-elgamal-proof/issues/35."
-    )]
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
     pub fn from_seed_legacy(seed: &[u8]) -> Result<Self, Box<dyn error::Error>> {
         const MINIMUM_SEED_LEN: usize = AE_KEY_LEN;
         const MAXIMUM_SEED_LEN: usize = 65535;
@@ -316,6 +251,12 @@ impl EncodableKey for AeKey {
 }
 
 impl SeedDerivable for AeKey {
+    /// Derives an `AeKey` from raw input key material via HKDF-SHA512 with the
+    /// shared `HKDF_SALT` and `AE_HKDF_INFO`. Feeding the same IKM into this
+    /// function and into `<ElGamalSecretKey as SeedDerivable>::from_seed`
+    /// produces an independent pair (HKDF info-based separation), and matches
+    /// what [`crate::encryption::derivation::derive_confidential_keys_from_ikm`]
+    /// produces.
     fn from_seed(seed: &[u8]) -> Result<Self, Box<dyn error::Error>> {
         const MINIMUM_SEED_LEN: usize = AE_KEY_LEN;
         const MAXIMUM_SEED_LEN: usize = 65535;
@@ -327,7 +268,7 @@ impl SeedDerivable for AeKey {
             return Err(AuthenticatedEncryptionError::SeedLengthTooLong.into());
         }
 
-        let hkdf = Hkdf::<Sha512>::new(Some(AE_HKDF_SALT), seed);
+        let hkdf = Hkdf::<Sha512>::new(Some(HKDF_SALT), seed);
         let mut okm = Zeroizing::new([0u8; AE_KEY_LEN]);
         hkdf.expand(AE_HKDF_INFO, okm.as_mut_slice())
             .map_err(|_| AuthenticatedEncryptionError::Deserialization)?;
@@ -441,10 +382,7 @@ impl TryFrom<PodAeCiphertext> for AeCiphertext {
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*, solana_address::Address, solana_keypair::Keypair,
-        solana_signer::null_signer::NullSigner,
-    };
+    use super::*;
 
     #[test]
     fn test_aes_encrypt_decrypt_correctness() {
@@ -455,24 +393,6 @@ mod tests {
         let decrypted_amount = ciphertext.decrypt(&key).unwrap();
 
         assert_eq!(amount, decrypted_amount);
-    }
-
-    #[test]
-    fn test_aes_new() {
-        let keypair1 = Keypair::new();
-        let keypair2 = Keypair::new();
-
-        assert_ne!(
-            AeKey::new_from_signer(&keypair1, Address::default().as_ref())
-                .unwrap()
-                .0,
-            AeKey::new_from_signer(&keypair2, Address::default().as_ref())
-                .unwrap()
-                .0,
-        );
-
-        let null_signer = NullSigner::new(&Address::default());
-        assert!(AeKey::new_from_signer(&null_signer, Address::default().as_ref()).is_err());
     }
 
     #[test]
@@ -554,55 +474,6 @@ mod tests {
     }
 
     #[test]
-    fn test_aekey_hkdf_determinism_from_signature() {
-        let sig = Signature::from([0x42u8; 64]);
-        let key_a = AeKey::new_from_signature(&sig).unwrap();
-        let key_b = AeKey::new_from_signature(&sig).unwrap();
-        assert_eq!(
-            <[u8; AE_KEY_LEN]>::from(&key_a),
-            <[u8; AE_KEY_LEN]>::from(&key_b),
-        );
-    }
-
-    #[test]
-    fn test_aekey_hkdf_differs_from_legacy() {
-        // The HKDF and legacy SHA3-512 paths must produce different keys for
-        // the same input — otherwise the legacy fallback would silently match
-        // the new derivation and accounts could be mis-claimed as migrated.
-        let sig = Signature::from([0x42u8; 64]);
-        let new_key = AeKey::new_from_signature(&sig).unwrap();
-        #[allow(deprecated)]
-        let old_key = AeKey::new_from_signature_legacy(&sig).unwrap();
-        assert_ne!(
-            <[u8; AE_KEY_LEN]>::from(&new_key),
-            <[u8; AE_KEY_LEN]>::from(&old_key),
-        );
-    }
-
-    #[test]
-    fn test_aekey_hkdf_known_vector_from_signature() {
-        // Canonical test vector for the HKDF-SHA512 AeKey derivation.
-        //
-        // Inputs:
-        //   signature = [0x42; 64]
-        //   salt      = b"solana-zk-sdk:AeKey:v1:hkdf-sha512"
-        //   info      = b"AeKey"
-        //   L         = 16
-        let sig = Signature::from([0x42u8; 64]);
-        let key = AeKey::new_from_signature(&sig).unwrap();
-        let bytes: [u8; AE_KEY_LEN] = (&key).into();
-        let expected: [u8; AE_KEY_LEN] = [
-            0x48, 0x6d, 0x45, 0x79, 0x6d, 0xf2, 0xdc, 0xa5, 0xeb, 0x5e, 0x1e, 0xaf, 0x47, 0xb0,
-            0x74, 0x65,
-        ];
-        assert_eq!(
-            bytes, expected,
-            "HKDF AeKey vector drift; computed {:02x?}",
-            bytes
-        );
-    }
-
-    #[test]
     fn test_aekey_legacy_known_vector_from_signature() {
         // Pinned canonical bytes for the SHA3-512 legacy derivation.
         // Inputs:
@@ -620,42 +491,6 @@ mod tests {
             bytes, expected,
             "Legacy AeKey vector drift; computed {:02x?}",
             bytes
-        );
-    }
-
-    #[test]
-    fn test_aekey_matches_single_hkdf_over_signature() {
-        // The documented interop contract is: an external implementation
-        // (e.g. Web Crypto subtle.deriveBits, Apple CryptoKit HKDF<SHA512>)
-        // computing `HKDF-SHA512(salt = AE_HKDF_SALT, ikm = signature,
-        // info = b"AeKey", L = 16)` MUST produce the same bytes as the SDK.
-        // Regression guard for the double-HKDF-Extract bug.
-        let sig = Signature::from([0x42u8; 64]);
-        let sdk_key = AeKey::new_from_signature(&sig).unwrap();
-        let sdk_bytes: [u8; AE_KEY_LEN] = (&sdk_key).into();
-
-        let direct = Hkdf::<Sha512>::new(Some(AE_HKDF_SALT), sig.as_ref());
-        let mut external_bytes = [0u8; AE_KEY_LEN];
-        direct.expand(AE_HKDF_INFO, &mut external_bytes).unwrap();
-
-        assert_eq!(sdk_bytes, external_bytes);
-    }
-
-    #[test]
-    fn test_aekey_hkdf_signer_matches_signature_path() {
-        // `new_from_signer` should match `new_from_signature` applied to the
-        // signature the signer would produce for the same message.
-        let keypair = Keypair::new();
-        let public_seed = [0x11u8; 32];
-        let key_from_signer = AeKey::new_from_signer(&keypair, &public_seed).unwrap();
-
-        let message = [b"AeKey", public_seed.as_ref()].concat();
-        let sig = keypair.sign_message(&message);
-        let key_from_sig = AeKey::new_from_signature(&sig).unwrap();
-
-        assert_eq!(
-            <[u8; AE_KEY_LEN]>::from(&key_from_signer),
-            <[u8; AE_KEY_LEN]>::from(&key_from_sig),
         );
     }
 

--- a/zk-sdk/src/encryption/derivation.rs
+++ b/zk-sdk/src/encryption/derivation.rs
@@ -92,7 +92,7 @@ pub fn derive_confidential_keys(
 /// over the canonical derivation message.
 ///
 /// Rejects the default (all-zero) signature: some `Signer` implementations
-/// return it instead of erroring, and the resulting keys would be predictable.
+/// return it instead of raising an error, and the resulting keys would be predictable.
 pub fn derive_confidential_keys_from_signature(
     signature: &Signature,
 ) -> Result<(ElGamalKeypair, AeKey), ElGamalError> {

--- a/zk-sdk/src/encryption/derivation.rs
+++ b/zk-sdk/src/encryption/derivation.rs
@@ -8,12 +8,12 @@
 //!
 //! Callers have three entry points:
 //!
-//! - [`derive_confidential_keys`] — sign once with a Solana `Signer`, derive
+//! - [`derive_confidential_keys`]: sign once with a Solana `Signer`, derive
 //!   both keys.
-//! - [`derive_confidential_keys_from_signature`] — when the caller already
+//! - [`derive_confidential_keys_from_signature`]: when the caller already
 //!   holds a signature over the canonical message (e.g. produced via a
 //!   wallet-adapter signing flow or a KMS deterministic-sign call).
-//! - [`derive_confidential_keys_from_ikm`] — when the caller has raw input
+//! - [`derive_confidential_keys_from_ikm`]: when the caller has raw input
 //!   key material from any other source (WebAuthn PRF output, Secure Enclave
 //!   HMAC output, KMS `GenerateMac` output, a BIP39 seed, or HKDF over an
 //!   Ed25519 seed).

--- a/zk-sdk/src/encryption/derivation.rs
+++ b/zk-sdk/src/encryption/derivation.rs
@@ -45,7 +45,7 @@ use {
     hkdf::Hkdf,
     sha2::Sha512,
     solana_signature::Signature,
-    solana_signer::{Signer, SignerError},
+    solana_signer::Signer,
     solana_zk_sdk_pod::encryption::AE_KEY_LEN,
     std::error,
     subtle::ConstantTimeEq,
@@ -85,22 +85,21 @@ pub fn derive_confidential_keys(
 ) -> Result<(ElGamalKeypair, AeKey), Box<dyn error::Error>> {
     let message = [HKDF_SALT, public_seed].concat();
     let signature = signer.try_sign_message(&message)?;
-
-    // Some `Signer` implementations return the default signature, which is not
-    // suitable for use as key material.
-    if bool::from(signature.as_ref().ct_eq(Signature::default().as_ref())) {
-        return Err(SignerError::Custom("Rejecting default signature".into()).into());
-    }
-
-    derive_confidential_keys_from_signature(&signature)
+    derive_confidential_keys_from_signature(&signature).map_err(Into::into)
 }
 
 /// Derives the confidential-balances key pair from a precomputed signature
 /// over the canonical derivation message.
+///
+/// Rejects the default (all-zero) signature: some `Signer` implementations
+/// return it instead of erroring, and the resulting keys would be predictable.
 pub fn derive_confidential_keys_from_signature(
     signature: &Signature,
-) -> Result<(ElGamalKeypair, AeKey), Box<dyn error::Error>> {
-    derive_confidential_keys_from_ikm(signature.as_ref()).map_err(Into::into)
+) -> Result<(ElGamalKeypair, AeKey), ElGamalError> {
+    if bool::from(signature.as_ref().ct_eq(Signature::default().as_ref())) {
+        return Err(ElGamalError::DefaultSignatureRejected);
+    }
+    derive_confidential_keys_from_ikm(signature.as_ref())
 }
 
 /// Derives the confidential-balances key pair from raw input key material.
@@ -251,5 +250,48 @@ mod tests {
         let ikm = [0x33u8; 64];
         let (kp, _ae) = derive_confidential_keys_from_ikm(&ikm).unwrap();
         assert_eq!(*kp.pubkey(), ElGamalPubkey::new(kp.secret()));
+    }
+
+    #[test]
+    fn test_external_hkdf_matches_sdk_output() {
+        // The documented interop contract: an external implementation
+        // (Web Crypto subtle.deriveBits, Apple CryptoKit HKDF<SHA512>, Go
+        // x/crypto/hkdf, ...) running HKDF-SHA512 with the published salt
+        // and info strings MUST produce the same bytes as the SDK. This
+        // test reproduces the spec from scratch and asserts byte-equality
+        // with the SDK output. Regression guard for any future drift in
+        // the HKDF chain shape (e.g., re-introducing a double-Extract or
+        // changing the info strings).
+        let ikm = [0x55u8; 64];
+        let (sdk_kp, sdk_ae) = derive_confidential_keys_from_ikm(&ikm).unwrap();
+
+        let hkdf = Hkdf::<Sha512>::new(Some(HKDF_SALT), &ikm);
+
+        let mut external_ae = [0u8; AE_KEY_LEN];
+        hkdf.expand(AE_HKDF_INFO, &mut external_ae).unwrap();
+
+        let mut external_wide = [0u8; 64];
+        hkdf.expand(ELGAMAL_HKDF_INFO, &mut external_wide).unwrap();
+        let external_scalar = Scalar::from_bytes_mod_order_wide(&external_wide);
+
+        assert_eq!(<[u8; AE_KEY_LEN]>::from(&sdk_ae), external_ae);
+        assert_eq!(sdk_kp.secret().as_bytes(), external_scalar.as_bytes());
+    }
+
+    #[test]
+    fn test_derive_confidential_keys_from_signature_rejects_default() {
+        let sig = Signature::default();
+        let err = derive_confidential_keys_from_signature(&sig).unwrap_err();
+        assert!(matches!(err, ElGamalError::DefaultSignatureRejected));
+    }
+
+    #[test]
+    fn test_derive_confidential_keys_rejects_null_signer() {
+        use solana_signer::null_signer::NullSigner;
+        // `NullSigner` returns the default signature for any message, so
+        // the signer-side path must surface a rejection rather than
+        // silently producing predictable keys.
+        let null_signer = NullSigner::new(&solana_address::Address::default());
+        assert!(derive_confidential_keys(&null_signer, &[0x11u8; 32]).is_err());
     }
 }

--- a/zk-sdk/src/encryption/derivation.rs
+++ b/zk-sdk/src/encryption/derivation.rs
@@ -1,0 +1,255 @@
+//! Confidential balances key derivation.
+//!
+//! Derives the `(ElGamalKeypair, AeKey)` pair used by the Token-2022
+//! confidential-balances extension from a single source of input key material
+//! via a unified HKDF-SHA512 (RFC 5869) chain. The salt, info strings, and
+//! signing message are protocol-identified (`solana-conf-bal/v1`) so that
+//! independent reimplementations on any platform derive byte-identical keys.
+//!
+//! Callers have three entry points:
+//!
+//! - [`derive_confidential_keys`] — sign once with a Solana `Signer`, derive
+//!   both keys.
+//! - [`derive_confidential_keys_from_signature`] — when the caller already
+//!   holds a signature over the canonical message (e.g. produced via a
+//!   wallet-adapter signing flow or a KMS deterministic-sign call).
+//! - [`derive_confidential_keys_from_ikm`] — when the caller has raw input
+//!   key material from any other source (WebAuthn PRF output, Secure Enclave
+//!   HMAC output, KMS `GenerateMac` output, a BIP39 seed, or HKDF over an
+//!   Ed25519 seed).
+//!
+//! The shared HKDF chain is:
+//!
+//! ```text
+//! prk         = HKDF-SHA512-Extract(salt = HKDF_SALT, ikm = adapter_output)
+//! ae_key      = HKDF-Expand(prk, info = AE_HKDF_INFO,      L = 16)
+//! elgamal_sk  = Scalar::from_bytes_mod_order_wide(
+//!                   HKDF-Expand(prk, info = ELGAMAL_HKDF_INFO, L = 64)
+//!               )
+//! ```
+//!
+//! `public_seed` in the signing path is caller-controlled and granularity-
+//! agnostic: pass a wallet pubkey for registry-aligned per-wallet keying, or
+//! a token-account pubkey for per-account keying. The SDK does not enforce
+//! either convention.
+
+use {
+    crate::{
+        encryption::{
+            auth_encryption::AeKey,
+            elgamal::{ElGamalKeypair, ElGamalSecretKey},
+        },
+        errors::ElGamalError,
+    },
+    curve25519_dalek::scalar::Scalar,
+    hkdf::Hkdf,
+    sha2::Sha512,
+    solana_signature::Signature,
+    solana_signer::{Signer, SignerError},
+    solana_zk_sdk_pod::encryption::AE_KEY_LEN,
+    std::error,
+    subtle::ConstantTimeEq,
+    zeroize::Zeroizing,
+};
+
+/// HKDF salt for the confidential-balances key derivation. Identifies the
+/// protocol, not the implementation: independent reimplementations on any
+/// platform derive byte-identical keys from this constant.
+pub const HKDF_SALT: &[u8] = b"solana-conf-bal/v1";
+
+/// HKDF info string for the AES (`decryptable_available_balance` fast-path)
+/// key.
+pub const AE_HKDF_INFO: &[u8] = b"ae";
+
+/// HKDF info string for the ElGamal secret scalar.
+pub const ELGAMAL_HKDF_INFO: &[u8] = b"elgamal";
+
+/// Minimum acceptable IKM length when calling
+/// [`derive_confidential_keys_from_ikm`] directly. Matches the
+/// `ELGAMAL_SECRET_KEY_LEN` floor used elsewhere in the SDK.
+const MINIMUM_IKM_LEN: usize = 32;
+
+/// Maximum acceptable IKM length when calling
+/// [`derive_confidential_keys_from_ikm`] directly.
+const MAXIMUM_IKM_LEN: usize = 65535;
+
+/// Signs the canonical derivation message with `signer` and derives the
+/// confidential-balances key pair.
+///
+/// The signed message is `HKDF_SALT || public_seed`. `public_seed` is
+/// caller-controlled and granularity-agnostic; pass a wallet pubkey for
+/// per-wallet keying or a token-account pubkey for per-account keying.
+pub fn derive_confidential_keys(
+    signer: &dyn Signer,
+    public_seed: &[u8],
+) -> Result<(ElGamalKeypair, AeKey), Box<dyn error::Error>> {
+    let message = [HKDF_SALT, public_seed].concat();
+    let signature = signer.try_sign_message(&message)?;
+
+    // Some `Signer` implementations return the default signature, which is not
+    // suitable for use as key material.
+    if bool::from(signature.as_ref().ct_eq(Signature::default().as_ref())) {
+        return Err(SignerError::Custom("Rejecting default signature".into()).into());
+    }
+
+    derive_confidential_keys_from_signature(&signature)
+}
+
+/// Derives the confidential-balances key pair from a precomputed signature
+/// over the canonical derivation message.
+pub fn derive_confidential_keys_from_signature(
+    signature: &Signature,
+) -> Result<(ElGamalKeypair, AeKey), Box<dyn error::Error>> {
+    derive_confidential_keys_from_ikm(signature.as_ref()).map_err(Into::into)
+}
+
+/// Derives the confidential-balances key pair from raw input key material.
+///
+/// This is the universal entry point used by non-`Signer` adapters (WebAuthn
+/// PRF, Secure Enclave HMAC, KMS HMAC, direct HKDF over an Ed25519 seed,
+/// BIP39 mnemonic seed, etc.).
+pub fn derive_confidential_keys_from_ikm(
+    ikm: &[u8],
+) -> Result<(ElGamalKeypair, AeKey), ElGamalError> {
+    if ikm.len() < MINIMUM_IKM_LEN {
+        return Err(ElGamalError::SeedLengthTooShort);
+    }
+    if ikm.len() > MAXIMUM_IKM_LEN {
+        return Err(ElGamalError::SeedLengthTooLong);
+    }
+
+    let hkdf = Hkdf::<Sha512>::new(Some(HKDF_SALT), ikm);
+
+    let mut ae_bytes = Zeroizing::new([0u8; AE_KEY_LEN]);
+    hkdf.expand(AE_HKDF_INFO, ae_bytes.as_mut_slice())
+        .map_err(|_| ElGamalError::SecretKeyDeserialization)?;
+    let ae_key = AeKey::from(*ae_bytes);
+
+    let mut elgamal_wide = Zeroizing::new([0u8; 64]);
+    hkdf.expand(ELGAMAL_HKDF_INFO, elgamal_wide.as_mut_slice())
+        .map_err(|_| ElGamalError::SecretKeyDeserialization)?;
+    let elgamal_secret = ElGamalSecretKey::from(Scalar::from_bytes_mod_order_wide(&elgamal_wide));
+
+    Ok((ElGamalKeypair::new(elgamal_secret), ae_key))
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*, crate::encryption::elgamal::ElGamalPubkey, solana_address::Address,
+        solana_keypair::Keypair,
+    };
+
+    #[test]
+    fn test_derive_confidential_keys_determinism() {
+        let keypair = Keypair::new();
+        let public_seed = [0x11u8; 32];
+
+        let (kp_a, ae_a) = derive_confidential_keys(&keypair, &public_seed).unwrap();
+        let (kp_b, ae_b) = derive_confidential_keys(&keypair, &public_seed).unwrap();
+
+        assert_eq!(kp_a.secret().as_bytes(), kp_b.secret().as_bytes());
+        assert_eq!(
+            <[u8; AE_KEY_LEN]>::from(&ae_a),
+            <[u8; AE_KEY_LEN]>::from(&ae_b)
+        );
+    }
+
+    #[test]
+    fn test_derive_confidential_keys_distinct_signers() {
+        let kp1 = Keypair::new();
+        let kp2 = Keypair::new();
+
+        let (elgamal1, ae1) = derive_confidential_keys(&kp1, Address::default().as_ref()).unwrap();
+        let (elgamal2, ae2) = derive_confidential_keys(&kp2, Address::default().as_ref()).unwrap();
+
+        assert_ne!(elgamal1.secret().as_bytes(), elgamal2.secret().as_bytes());
+        assert_ne!(
+            <[u8; AE_KEY_LEN]>::from(&ae1),
+            <[u8; AE_KEY_LEN]>::from(&ae2)
+        );
+    }
+
+    #[test]
+    fn test_derive_confidential_keys_signer_matches_signature() {
+        // `derive_confidential_keys` and `_from_signature` over the
+        // wallet-produced signature must yield byte-identical keys.
+        let keypair = Keypair::new();
+        let public_seed = [0x22u8; 32];
+
+        let (kp_signer, ae_signer) = derive_confidential_keys(&keypair, &public_seed).unwrap();
+
+        let message = [HKDF_SALT, public_seed.as_ref()].concat();
+        let sig = keypair.sign_message(&message);
+        let (kp_sig, ae_sig) = derive_confidential_keys_from_signature(&sig).unwrap();
+
+        assert_eq!(kp_signer.secret().as_bytes(), kp_sig.secret().as_bytes());
+        assert_eq!(
+            <[u8; AE_KEY_LEN]>::from(&ae_signer),
+            <[u8; AE_KEY_LEN]>::from(&ae_sig)
+        );
+    }
+
+    #[test]
+    fn test_derive_confidential_keys_from_ikm_known_vector() {
+        // Canonical test vector for the unified HKDF-SHA512 spine.
+        //
+        // Inputs:
+        //   ikm  = [0x42; 64]    (e.g. a 64-byte Ed25519 signature filled with 0x42)
+        //   salt = b"solana-conf-bal/v1"
+        //   info = b"ae" (for AeKey) or b"elgamal" (for ElGamal scalar wide)
+        let ikm = [0x42u8; 64];
+        let (kp, ae) = derive_confidential_keys_from_ikm(&ikm).unwrap();
+
+        let expected_ae: [u8; AE_KEY_LEN] = [
+            0x1b, 0x29, 0x77, 0x8a, 0x34, 0x93, 0xda, 0xb2, 0x18, 0xc2, 0x4e, 0x87, 0x14, 0x4b,
+            0xe4, 0x3d,
+        ];
+        let expected_elgamal: [u8; 32] = [
+            0x71, 0x6d, 0x24, 0x31, 0xfa, 0x74, 0xfc, 0x1c, 0x48, 0xff, 0xb9, 0xb9, 0x97, 0x2b,
+            0x0b, 0xe2, 0xf0, 0xb2, 0x9a, 0xb7, 0x55, 0x08, 0x1f, 0x2e, 0xa3, 0x5d, 0x3c, 0x74,
+            0xf4, 0x42, 0x19, 0x0e,
+        ];
+
+        assert_eq!(
+            <[u8; AE_KEY_LEN]>::from(&ae),
+            expected_ae,
+            "AeKey HKDF vector drift; computed {:02x?}",
+            <[u8; AE_KEY_LEN]>::from(&ae)
+        );
+        assert_eq!(
+            kp.secret().as_bytes(),
+            &expected_elgamal,
+            "ElGamal HKDF vector drift; computed {:02x?}",
+            kp.secret().as_bytes()
+        );
+    }
+
+    #[test]
+    fn test_derive_confidential_keys_from_ikm_rejects_short() {
+        let too_short = vec![0u8; MINIMUM_IKM_LEN - 1];
+        assert!(matches!(
+            derive_confidential_keys_from_ikm(&too_short),
+            Err(ElGamalError::SeedLengthTooShort)
+        ));
+    }
+
+    #[test]
+    fn test_derive_confidential_keys_from_ikm_rejects_long() {
+        let too_long = vec![0u8; MAXIMUM_IKM_LEN + 1];
+        assert!(matches!(
+            derive_confidential_keys_from_ikm(&too_long),
+            Err(ElGamalError::SeedLengthTooLong)
+        ));
+    }
+
+    #[test]
+    fn test_derive_confidential_keys_keypair_consistent() {
+        // The returned ElGamal keypair's public key MUST equal
+        // `ElGamalPubkey::new(secret)` so callers can rely on the keypair
+        // invariant.
+        let ikm = [0x33u8; 64];
+        let (kp, _ae) = derive_confidential_keys_from_ikm(&ikm).unwrap();
+        assert_eq!(*kp.pubkey(), ElGamalPubkey::new(kp.secret()));
+    }
+}

--- a/zk-sdk/src/encryption/elgamal.rs
+++ b/zk-sdk/src/encryption/elgamal.rs
@@ -19,6 +19,7 @@ use curve25519_dalek::traits::Identity;
 use {
     crate::{
         encryption::{
+            derivation::{ELGAMAL_HKDF_INFO, HKDF_SALT},
             discrete_log::DiscreteLog,
             pedersen::{Pedersen, PedersenCommitment, PedersenOpening, G, H},
         },
@@ -54,16 +55,6 @@ use {
     subtle::{Choice, ConstantTimeEq},
     zeroize::{Zeroize, Zeroizing},
 };
-
-/// HKDF salt used when deriving an `ElGamalSecretKey`. Versioned so that future
-/// revisions of the key derivation scheme can coexist with the current one by
-/// bumping the `:vN` suffix.
-const ELGAMAL_HKDF_SALT: &[u8] = b"solana-zk-sdk:ElGamalSecretKey:v1:hkdf-sha512";
-
-/// HKDF info string used to bind the expanded output to the `ElGamalSecretKey`
-/// key type. Combined with the salt this provides domain separation against
-/// `AeKey` derivation even when both share the same input key material.
-const ELGAMAL_HKDF_INFO: &[u8] = b"ElGamalSecretKey";
 
 /// Algorithm handle for the twisted ElGamal encryption scheme
 pub struct ElGamal;
@@ -193,7 +184,8 @@ impl ElGamalKeypair {
     /// Create an ElGamal keypair from an ElGamal public key and an ElGamal secret key.
     ///
     /// An ElGamal keypair should never be instantiated manually; `ElGamalKeypair::new`,
-    /// `ElGamalKeypair::new_rand` or `ElGamalKeypair::new_from_signer` should be used instead.
+    /// `ElGamalKeypair::new_rand` or
+    /// [`crate::encryption::derivation::derive_confidential_keys`] should be used instead.
     /// This function exists to create custom ElGamal keypairs for tests.
     pub fn new_for_tests(public: ElGamalPubkey, secret: ElGamalSecretKey) -> Self {
         Self { public, secret }
@@ -205,38 +197,14 @@ impl ElGamalKeypair {
         Self { public, secret }
     }
 
-    /// Deterministically derives an ElGamal keypair from a Solana signer and a public seed.
-    ///
-    /// This function exists for applications where a user may not wish to maintain a Solana signer
-    /// and an ElGamal keypair separately. Instead, a user can derive the ElGamal keypair
-    /// on-the-fly whenever encryption/decryption is needed.
-    ///
-    /// For the spl-token-2022 confidential extension, the ElGamal public key is specified in a
-    /// token account. A natural way to derive an ElGamal keypair is to define it from the hash of
-    /// a Solana keypair and a Solana address as the public seed. However, for general hardware
-    /// wallets, the signing key is not exposed in the API. Therefore, this function uses a signer
-    /// to sign a public seed and the resulting signature is then hashed to derive an ElGamal
-    /// keypair.
-    pub fn new_from_signer(
-        signer: &dyn Signer,
-        public_seed: &[u8],
-    ) -> Result<Self, Box<dyn error::Error>> {
-        let secret = ElGamalSecretKey::new_from_signer(signer, public_seed)?;
-        Ok(Self::new(secret))
-    }
-
-    /// Derive an ElGamal keypair from a signature.
-    pub fn new_from_signature(signature: &Signature) -> Result<Self, Box<dyn error::Error>> {
-        let secret = ElGamalSecretKey::new_from_signature(signature)?;
-        Ok(Self::new(secret))
-    }
-
     /// Derive an ElGamal keypair from a Solana signer using the legacy
     /// SHA3-512 KDF.
     ///
     /// See [`ElGamalSecretKey::new_from_signer_legacy`] for context.
-    #[deprecated(note = "Non-standard SHA3-512 KDF; new code should use \
-                `ElGamalKeypair::new_from_signer`. Retained for backward compatibility. \
+    #[deprecated(note = "Non-standard SHA3-512 KDF. New code should use \
+                `crate::encryption::derivation::derive_confidential_keys`. \
+                Retained for backward compatibility with accounts provisioned under \
+                solana-zk-sdk versions prior to the HKDF-SHA512 migration. \
                 See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
     #[allow(deprecated)]
     pub fn new_from_signer_legacy(
@@ -251,8 +219,9 @@ impl ElGamalKeypair {
     /// SHA3-512 KDF.
     ///
     /// See [`ElGamalSecretKey::new_from_signer_legacy`] for context.
-    #[deprecated(note = "Non-standard SHA3-512 KDF; new code should use \
-                `ElGamalKeypair::new_from_signature`. Retained for backward compatibility. \
+    #[deprecated(note = "Non-standard SHA3-512 KDF. New code should use \
+                `crate::encryption::derivation::derive_confidential_keys_from_signature`. \
+                Retained for backward compatibility. \
                 See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
     #[allow(deprecated)]
     pub fn new_from_signature_legacy(signature: &Signature) -> Result<Self, Box<dyn error::Error>> {
@@ -265,7 +234,8 @@ impl ElGamalKeypair {
     ///
     /// See [`ElGamalSecretKey::new_from_signer_legacy`] for context.
     #[deprecated(
-        note = "Non-standard SHA3-512 KDF; new code should use `ElGamalKeypair::from_seed`. \
+        note = "Non-standard SHA3-512 KDF. New code should use `ElGamalKeypair::from_seed` \
+                (which now uses the unified HKDF spine). \
                 Retained for backward compatibility. \
                 See https://github.com/solana-program/zk-elgamal-proof/issues/35."
     )]
@@ -280,8 +250,9 @@ impl ElGamalKeypair {
     /// the legacy SHA3-512 KDF.
     ///
     /// See [`ElGamalSecretKey::new_from_signer_legacy`] for context.
-    #[deprecated(note = "Non-standard SHA3-512 KDF; new code should use \
-                `<ElGamalKeypair as SeedDerivable>::from_seed_phrase_and_passphrase`. \
+    #[deprecated(note = "Non-standard SHA3-512 KDF. New code should use \
+                `<ElGamalKeypair as SeedDerivable>::from_seed_phrase_and_passphrase` \
+                (which now uses the unified HKDF spine). \
                 Retained for backward compatibility. \
                 See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
     #[allow(deprecated)]
@@ -553,10 +524,13 @@ impl ElGamalSecretKey {
 
     /// Derive an ElGamal secret key from an entropy seed.
     ///
-    /// The seed is treated as input key material for HKDF-SHA512 (RFC 5869).
-    /// HKDF-Extract uses a versioned, domain-separated salt; HKDF-Expand
-    /// produces 64 bytes which are reduced to a uniformly distributed
-    /// Ristretto scalar via `Scalar::from_bytes_mod_order_wide`.
+    /// The seed is treated as input key material for HKDF-SHA512 (RFC 5869)
+    /// using the shared `HKDF_SALT` and `ELGAMAL_HKDF_INFO` from
+    /// [`crate::encryption::derivation`]. HKDF-Expand produces 64 bytes which
+    /// are reduced to a uniformly distributed Ristretto scalar via
+    /// `Scalar::from_bytes_mod_order_wide`. Feeding the same IKM into this
+    /// function and into `<AeKey as SeedDerivable>::from_seed` produces an
+    /// independent pair (HKDF info-based separation).
     pub fn from_seed(seed: &[u8]) -> Result<Self, ElGamalError> {
         const MINIMUM_SEED_LEN: usize = ELGAMAL_SECRET_KEY_LEN;
         const MAXIMUM_SEED_LEN: usize = 65535;
@@ -568,7 +542,7 @@ impl ElGamalSecretKey {
             return Err(ElGamalError::SeedLengthTooLong);
         }
 
-        let hkdf = Hkdf::<Sha512>::new(Some(ELGAMAL_HKDF_SALT), seed);
+        let hkdf = Hkdf::<Sha512>::new(Some(HKDF_SALT), seed);
         let mut wide = Zeroizing::new([0u8; 64]);
         hkdf.expand(ELGAMAL_HKDF_INFO, wide.as_mut_slice())
             .map_err(|_| ElGamalError::SecretKeyDeserialization)?;
@@ -601,67 +575,16 @@ impl ElGamalSecretKey {
 }
 
 impl ElGamalSecretKey {
-    /// Deterministically derives an ElGamal secret key from a Solana signer and a public seed.
-    ///
-    /// See `ElGamalKeypair::new_from_signer` for more context on the key derivation.
-    pub fn new_from_signer(
-        signer: &dyn Signer,
-        public_seed: &[u8],
-    ) -> Result<Self, Box<dyn error::Error>> {
-        let seed = Self::seed_from_signer(signer, public_seed)?;
-        let key = Self::from_seed(&seed)?;
-        Ok(key)
-    }
-
-    /// Derive a seed from a Solana signer used to generate an ElGamal secret key.
-    ///
-    /// The seed is derived as the hash of the signature of a public seed.
-    pub fn seed_from_signer(
-        signer: &dyn Signer,
-        public_seed: &[u8],
-    ) -> Result<Vec<u8>, SignerError> {
-        let message = [b"ElGamalSecretKey", public_seed].concat();
-        let signature = signer.try_sign_message(&message)?;
-
-        // Some `Signer` implementations return the default signature, which is not suitable for
-        // use as key material
-        if bool::from(signature.as_ref().ct_eq(Signature::default().as_ref())) {
-            return Err(SignerError::Custom("Rejecting default signatures".into()));
-        }
-
-        Ok(Self::seed_from_signature(&signature))
-    }
-
-    /// Derive an ElGamal secret key from a signature.
-    pub fn new_from_signature(signature: &Signature) -> Result<Self, Box<dyn error::Error>> {
-        let seed = Self::seed_from_signature(signature);
-        let key = Self::from_seed(&seed)?;
-        Ok(key)
-    }
-
-    /// Returns the input key material derived from a signature, suitable for
-    /// feeding into [`ElGamalSecretKey::from_seed`].
-    ///
-    /// The signature bytes themselves are returned unmodified so that the
-    /// full HKDF-SHA512 chain (Extract and Expand) runs exactly once inside
-    /// [`ElGamalSecretKey::from_seed`]. A wallet that prefers to call HKDF
-    /// directly via its platform crypto can therefore reproduce the SDK
-    /// output via
-    /// `HKDF-SHA512(salt = ELGAMAL_HKDF_SALT, ikm = signature, info = b"ElGamalSecretKey", L = 64)`
-    /// and then reduce the 64 bytes via `Scalar::from_bytes_mod_order_wide`.
-    pub fn seed_from_signature(signature: &Signature) -> Vec<u8> {
-        signature.as_ref().to_vec()
-    }
-
     /// Derive an ElGamal secret key from a Solana signer using the legacy
     /// SHA3-512-based KDF.
     ///
     /// Retained only so wallets can recover keys for accounts that were
     /// provisioned under `solana-zk-sdk` versions that shipped the
     /// non-standard `Scalar::hash_from_bytes::<Sha3_512>(...)` derivation. New
-    /// code should use [`ElGamalSecretKey::new_from_signer`].
-    #[deprecated(note = "Non-standard SHA3-512 KDF; new code should use \
-                `ElGamalSecretKey::new_from_signer`. Retained for backward \
+    /// code should use
+    /// [`crate::encryption::derivation::derive_confidential_keys`].
+    #[deprecated(note = "Non-standard SHA3-512 KDF. New code should use \
+                `crate::encryption::derivation::derive_confidential_keys`. Retained for backward \
                 compatibility with accounts provisioned under solana-zk-sdk versions \
                 prior to the HKDF-SHA512 migration. \
                 See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
@@ -678,9 +601,10 @@ impl ElGamalSecretKey {
     /// Derive a seed from a Solana signer using the legacy SHA3-512 KDF.
     ///
     /// See [`ElGamalSecretKey::new_from_signer_legacy`] for context.
-    #[deprecated(note = "Non-standard SHA3-512 KDF; new code should use \
-                `ElGamalSecretKey::seed_from_signer`. Retained for backward compatibility. \
-                See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
+    #[deprecated(
+        note = "Non-standard SHA3-512 KDF. Retained for backward compatibility. \
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35."
+    )]
     #[allow(deprecated)]
     pub fn seed_from_signer_legacy(
         signer: &dyn Signer,
@@ -700,8 +624,9 @@ impl ElGamalSecretKey {
     /// SHA3-512 KDF.
     ///
     /// See [`ElGamalSecretKey::new_from_signer_legacy`] for context.
-    #[deprecated(note = "Non-standard SHA3-512 KDF; new code should use \
-                `ElGamalSecretKey::new_from_signature`. Retained for backward compatibility. \
+    #[deprecated(note = "Non-standard SHA3-512 KDF. New code should use \
+                `crate::encryption::derivation::derive_confidential_keys_from_signature`. \
+                Retained for backward compatibility. \
                 See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
     #[allow(deprecated)]
     pub fn new_from_signature_legacy(signature: &Signature) -> Result<Self, Box<dyn error::Error>> {
@@ -713,9 +638,10 @@ impl ElGamalSecretKey {
     /// Derive a seed from a signature using the legacy SHA3-512 KDF.
     ///
     /// See [`ElGamalSecretKey::new_from_signer_legacy`] for context.
-    #[deprecated(note = "Non-standard SHA3-512 KDF; new code should use \
-                `ElGamalSecretKey::seed_from_signature`. Retained for backward compatibility. \
-                See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
+    #[deprecated(
+        note = "Non-standard SHA3-512 KDF. Retained for backward compatibility. \
+                See https://github.com/solana-program/zk-elgamal-proof/issues/35."
+    )]
     pub fn seed_from_signature_legacy(signature: &Signature) -> Vec<u8> {
         let mut hasher = Sha3_512::new();
         hasher.update(signature.as_ref());
@@ -728,8 +654,9 @@ impl ElGamalSecretKey {
     /// KDF.
     ///
     /// See [`ElGamalSecretKey::new_from_signer_legacy`] for context.
-    #[deprecated(note = "Non-standard SHA3-512 KDF; new code should use \
-                `ElGamalSecretKey::from_seed`. Retained for backward compatibility. \
+    #[deprecated(note = "Non-standard SHA3-512 KDF. New code should use \
+                `ElGamalSecretKey::from_seed` (which now uses the unified HKDF spine). \
+                Retained for backward compatibility. \
                 See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
     pub fn from_seed_legacy(seed: &[u8]) -> Result<Self, ElGamalError> {
         const MINIMUM_SEED_LEN: usize = ELGAMAL_SECRET_KEY_LEN;
@@ -748,8 +675,9 @@ impl ElGamalSecretKey {
     /// the legacy SHA3-512 KDF.
     ///
     /// See [`ElGamalSecretKey::new_from_signer_legacy`] for context.
-    #[deprecated(note = "Non-standard SHA3-512 KDF; new code should use \
-                `<ElGamalSecretKey as SeedDerivable>::from_seed_phrase_and_passphrase`. \
+    #[deprecated(note = "Non-standard SHA3-512 KDF. New code should use \
+                `<ElGamalSecretKey as SeedDerivable>::from_seed_phrase_and_passphrase` \
+                (which now uses the unified HKDF spine). \
                 Retained for backward compatibility. \
                 See https://github.com/solana-program/zk-elgamal-proof/issues/35.")]
     #[allow(deprecated)]
@@ -1159,9 +1087,6 @@ mod tests {
         super::*,
         crate::encryption::pedersen::Pedersen,
         bip39::{Language, Mnemonic, MnemonicType, Seed},
-        solana_address::Address,
-        solana_keypair::Keypair,
-        solana_signer::null_signer::NullSigner,
         std::fs::{self, File},
     };
 
@@ -1404,72 +1329,6 @@ mod tests {
     }
 
     #[test]
-    fn test_secret_key_new_from_signer() {
-        let keypair1 = Keypair::new();
-        let keypair2 = Keypair::new();
-
-        assert_ne!(
-            ElGamalSecretKey::new_from_signer(&keypair1, Address::default().as_ref())
-                .unwrap()
-                .0,
-            ElGamalSecretKey::new_from_signer(&keypair2, Address::default().as_ref())
-                .unwrap()
-                .0,
-        );
-
-        let null_signer = NullSigner::new(&Address::default());
-        assert!(
-            ElGamalSecretKey::new_from_signer(&null_signer, Address::default().as_ref()).is_err()
-        );
-    }
-
-    #[test]
-    fn test_elgamal_hkdf_determinism_from_signature() {
-        let sig = Signature::from([0x42u8; 64]);
-        let key_a = ElGamalSecretKey::new_from_signature(&sig).unwrap();
-        let key_b = ElGamalSecretKey::new_from_signature(&sig).unwrap();
-        assert_eq!(key_a.as_bytes(), key_b.as_bytes());
-    }
-
-    #[test]
-    fn test_elgamal_hkdf_differs_from_legacy() {
-        // The HKDF and legacy SHA3-512 paths must produce different secret
-        // keys for the same input — otherwise the legacy fallback would
-        // silently match the new derivation and accounts could be mis-claimed
-        // as migrated.
-        let sig = Signature::from([0x42u8; 64]);
-        let new_key = ElGamalSecretKey::new_from_signature(&sig).unwrap();
-        #[allow(deprecated)]
-        let old_key = ElGamalSecretKey::new_from_signature_legacy(&sig).unwrap();
-        assert_ne!(new_key.as_bytes(), old_key.as_bytes());
-    }
-
-    #[test]
-    fn test_elgamal_hkdf_known_vector_from_signature() {
-        // Canonical test vector for the HKDF-SHA512 ElGamalSecretKey
-        // derivation.
-        //
-        // Inputs:
-        //   signature = [0x42; 64]
-        //   salt      = b"solana-zk-sdk:ElGamalSecretKey:v1:hkdf-sha512"
-        //   info      = b"ElGamalSecretKey"
-        //   L         = 64 (reduced via Scalar::from_bytes_mod_order_wide)
-        let sig = Signature::from([0x42u8; 64]);
-        let key = ElGamalSecretKey::new_from_signature(&sig).unwrap();
-        let expected: [u8; ELGAMAL_SECRET_KEY_LEN] = [
-            0xe7, 0x03, 0x51, 0xd6, 0x6a, 0x1a, 0x3f, 0x88, 0x3c, 0xd8, 0x53, 0x64, 0x8b, 0xa2,
-            0x18, 0xfa, 0x39, 0x0a, 0x67, 0xdf, 0x61, 0x1d, 0x59, 0x7a, 0x0c, 0xf6, 0xd7, 0x7d,
-            0x92, 0x67, 0x45, 0x03,
-        ];
-        assert_eq!(
-            key.as_bytes(),
-            &expected,
-            "HKDF ElGamalSecretKey vector drift; computed {:02x?}",
-            key.as_bytes()
-        );
-    }
-
-    #[test]
     fn test_elgamal_legacy_known_vector_from_signature() {
         // Pinned canonical bytes for the SHA3-512 legacy derivation.
         let sig = Signature::from([0x42u8; 64]);
@@ -1489,48 +1348,16 @@ mod tests {
     }
 
     #[test]
-    fn test_elgamal_matches_single_hkdf_over_signature() {
-        // External-implementation interop contract: HKDF-SHA512 over the
-        // signature with the documented salt/info, expanded to 64 bytes, then
-        // reduced via `Scalar::from_bytes_mod_order_wide`, MUST equal the SDK
-        // scalar. Regression guard for the double-HKDF-Extract bug.
-        let sig = Signature::from([0x42u8; 64]);
-        let sdk_secret = ElGamalSecretKey::new_from_signature(&sig).unwrap();
-
-        let direct = Hkdf::<Sha512>::new(Some(ELGAMAL_HKDF_SALT), sig.as_ref());
-        let mut wide = [0u8; 64];
-        direct.expand(ELGAMAL_HKDF_INFO, &mut wide).unwrap();
-        let external_scalar = Scalar::from_bytes_mod_order_wide(&wide);
-
-        assert_eq!(sdk_secret.as_bytes(), external_scalar.as_bytes());
-    }
-
-    #[test]
-    fn test_elgamal_hkdf_signer_matches_signature_path() {
-        // `new_from_signer` should match `new_from_signature` over the
-        // signature the signer would produce for the same message.
-        let keypair = Keypair::new();
-        let public_seed = [0x11u8; 32];
-        let key_from_signer = ElGamalSecretKey::new_from_signer(&keypair, &public_seed).unwrap();
-
-        let message = [b"ElGamalSecretKey", public_seed.as_ref()].concat();
-        let sig = keypair.sign_message(&message);
-        let key_from_sig = ElGamalSecretKey::new_from_signature(&sig).unwrap();
-
-        assert_eq!(key_from_signer.as_bytes(), key_from_sig.as_bytes());
-    }
-
-    #[test]
-    fn test_elgamal_aekey_domain_separation_from_signature() {
-        // ElGamal and AeKey derivations over the same signature must produce
-        // unrelated key material. This is enforced by salt + info domain
-        // separation in the HKDF construction inside `from_seed`.
-        let sig = Signature::from([0x42u8; 64]);
-        let elgamal_secret = ElGamalSecretKey::new_from_signature(&sig).unwrap();
-        let ae_key = crate::encryption::auth_encryption::AeKey::new_from_signature(&sig).unwrap();
+    fn test_elgamal_aekey_unified_hkdf_separation() {
+        // Same IKM into ElGamalSecretKey::from_seed and AeKey::from_seed
+        // produces independent keys, courtesy of HKDF info-based separation
+        // (b"elgamal" vs b"ae" under the shared HKDF_SALT).
+        let ikm = [0x42u8; 64];
+        let elgamal_secret = ElGamalSecretKey::from_seed(&ikm).unwrap();
+        let ae_key = crate::encryption::auth_encryption::AeKey::from_seed(&ikm).unwrap();
 
         // The first 16 bytes of the ElGamal scalar and the AeKey would only
-        // collide if the salt+info domain separation were broken.
+        // collide if the info-based domain separation were broken.
         let elgamal_bytes = elgamal_secret.as_bytes();
         let ae_bytes: [u8; 16] = (&ae_key).into();
         assert_ne!(&elgamal_bytes[..16], &ae_bytes[..]);

--- a/zk-sdk/src/encryption/mod.rs
+++ b/zk-sdk/src/encryption/mod.rs
@@ -13,6 +13,7 @@
 #[macro_use]
 pub(crate) mod macros;
 pub mod auth_encryption;
+pub mod derivation;
 pub mod discrete_log;
 pub mod elgamal;
 pub mod grouped_elgamal;

--- a/zk-sdk/src/errors.rs
+++ b/zk-sdk/src/errors.rs
@@ -29,6 +29,8 @@ pub enum ElGamalError {
     KeypairDeserialization,
     #[error("failed to deserialize secret key")]
     SecretKeyDeserialization,
+    #[error("rejecting default signature as key material")]
+    DefaultSignatureRejected,
 }
 
 #[derive(Error, Clone, Debug, Eq, PartialEq)]

--- a/zk-sdk/src/sigma_proofs/pubkey_validity.rs
+++ b/zk-sdk/src/sigma_proofs/pubkey_validity.rs
@@ -188,8 +188,11 @@ mod test {
             .unwrap();
 
         // derived ElGamal keypair
-        let keypair =
-            ElGamalKeypair::new_from_signer(&Keypair::new(), Address::default().as_ref()).unwrap();
+        let (keypair, _ae_key) = crate::encryption::derivation::derive_confidential_keys(
+            &Keypair::new(),
+            Address::default().as_ref(),
+        )
+        .unwrap();
 
         let mut prover_transcript = Transcript::new_zk_elgamal_transcript(b"test");
         let mut verifier_transcript = Transcript::new_zk_elgamal_transcript(b"test");


### PR DESCRIPTION
## Summary

Replaces the per-key HKDF construction shipped in #414 with a single HKDF-SHA512 spine driven by a protocol-identified salt (\`solana-conf-bal/v1\`) and key-role \`info\` strings (\`b\"ae\"\` / \`b\"elgamal\"\`). Aligns the SDK byte-for-byte with the [Confidential Balances Key Derivation Standard sRFC draft](https://github.com/solana-foundation/SRFCs) and unblocks reimplementations on platforms other than Rust.

## Why

PR #414's salts (\`solana-zk-sdk:AeKey:v1:hkdf-sha512\` / \`solana-zk-sdk:ElGamalSecretKey:v1:hkdf-sha512\`) tied the wire format to this Rust library's package name. A JavaScript or Swift reimplementation would naturally pick a different package-name-shaped salt and silently derive different keys. \`solana-conf-bal/v1\` identifies the protocol independently of any implementation.

PR #414 also ran two independent HKDF chains (one per key, each with its own salt and its own signature). That works but uses HKDF's \`salt\` as the key-discriminator axis when \`info\` is the textbook choice. Switching to one \`Extract\` + two \`Expand\` calls with different \`info\` halves the signing round-trips (one prompt per session instead of two) and matches the canonical RFC 5869 usage.

## What's in this PR

**New \`zk-sdk/src/encryption/derivation\` module:**
- \`HKDF_SALT = b\"solana-conf-bal/v1\"\`, \`AE_HKDF_INFO = b\"ae\"\`, \`ELGAMAL_HKDF_INFO = b\"elgamal\"\`
- \`derive_confidential_keys(signer, public_seed) -> (ElGamalKeypair, AeKey)\` — sign once, derive both
- \`derive_confidential_keys_from_signature(&Signature) -> (ElGamalKeypair, AeKey)\` — for callers that already have a signature
- \`derive_confidential_keys_from_ikm(&[u8]) -> (ElGamalKeypair, AeKey)\` — universal entry point for non-\`Signer\` adapters (WebAuthn PRF, Secure Enclave HMAC, KMS \`GenerateMac\`, BIP39, direct HKDF over an Ed25519 seed)

**Removed from \`AeKey\`, \`ElGamalSecretKey\`, \`ElGamalKeypair\`:**
- \`new_from_signer\`, \`new_from_signature\`, \`seed_from_signer\`, \`seed_from_signature\`

\`#414\`'s HKDF construction shipped less than a week ago with no production users.

**Kept (now using the unified HKDF spine):**
- \`SeedDerivable::from_seed\` on \`AeKey\` and \`ElGamalSecretKey\`/\`ElGamalKeypair\` — same IKM into both \`AeKey::from_seed\` and \`ElGamalSecretKey::from_seed\` produces independent keys (HKDF \`info\` separation)
- All \`*_legacy\` SHA3-512 methods — \`#[deprecated]\`, retained for accounts provisioned under pre-#414 SDKs, recoverable via the rotation flow

**Wasm-js bindings:** mirror the SDK change. New \`ConfidentialKeys\` type with \`signerMessage\`, \`fromSignature\`, \`fromIkm\`, \`elgamal()\`, \`ae()\` methods. Per-key \`signerMessage\` and \`fromSignature\` on the individual key wrappers removed.

## Granularity

The SDK stays granularity-agnostic. \`public_seed: &[u8]\` is caller-controlled — pass a wallet pubkey for registry-aligned per-wallet keying, or a token-account pubkey for per-account keying. A helper layer (not in this PR) can enforce a convention; the SDK does not.

## Migration

Pre-spec accounts (whether SHA3-512 from the pre-#414 era or the transitional HKDF-SHA512 from #414) are recoverable via the \`*_legacy\` methods on \`AeKey\` / \`ElGamalSecretKey\` / \`ElGamalKeypair\`, and migrate to the new spine via the confidential self-transfer rotation flow described in the sRFC (no leak window, balance stays encrypted on chain throughout).

## Testing

- 102 \`zk-sdk\` lib tests, 26 \`zk-sdk-pod\` tests, all pass
- \`cargo +nightly fmt\` clean
- Nightly CI-strict clippy clean on \`zk-sdk\`, \`zk-sdk-pod\`, \`interface\`
- \`cargo build --target wasm32-unknown-unknown -p solana-zk-sdk-wasm-js\` clean
- Canonical HKDF vectors pinned in \`derivation.rs\` (\`test_derive_confidential_keys_from_ikm_known_vector\`)
- Legacy SHA3-512 vectors still pinned as a regression guard against silent drift in the recovery path

## sRFC alignment

Mirrors the [Confidential Balances Key Derivation Standard sRFC draft](https://github.com/solana-foundation/SRFCs/discussions) byte-for-byte. Adapter 1 (\`Ed25519SigV1\`) signs \`HKDF_SALT || public_seed\` and feeds the signature into the shared spine. Adapters 2-8 (WebAuthn PRF, Secure Enclave HMAC, KMS HMAC, KMS deterministic-sign, EVM-keyed deterministic ECDSA, cached MPC derivation, direct HKDF over a seed) all feed their IKM into \`derive_confidential_keys_from_ikm\` — the SDK doesn't need to know which adapter produced the bytes.