### PR TITLE
feat: Add WebAuthn PRF passkey derivation adapter

### DIFF
--- a/scripts/solana.dic
+++ b/scripts/solana.dic
@@ -1,4 +1,4 @@
-1003
+1007
 config
 metadata
 json
@@ -86,8 +86,12 @@ PRF
 ECDSA
 SHA512
 WebAuthn
+WebAssembly
 authenticator/S
 passkey/S
+bundler/S
+iOS
+AWS
 crypto
 pseudorandom
 reimplementations

--- a/scripts/solana.dic
+++ b/scripts/solana.dic
@@ -1,4 +1,4 @@
-1000
+1003
 config
 metadata
 json
@@ -83,8 +83,11 @@ HMAC
 IKM
 KMS
 PRF
+ECDSA
 SHA512
 WebAuthn
+authenticator/S
+passkey/S
 crypto
 pseudorandom
 reimplementations

--- a/zk-sdk-wasm-js/README.md
+++ b/zk-sdk-wasm-js/README.md
@@ -1,0 +1,121 @@
+# `@solana/zk-sdk`
+
+WebAssembly bindings for the Rust [`solana-zk-sdk`](https://github.com/solana-program/zk-elgamal-proof/tree/main/zk-sdk). Use it from Node, the browser, or a bundler to generate the zero-knowledge proofs used by the Token-2022 confidential-balances extension, and to derive the ElGamal and AES keys those balances are encrypted under.
+
+## Install
+
+```sh
+npm install @solana/zk-sdk
+```
+
+The package ships three builds, one per `wasm-pack` target:
+
+| Import | Target | Init |
+|---|---|---|
+| `@solana/zk-sdk/node` | Node.js | none, ready on import |
+| `@solana/zk-sdk/web` | browser, no bundler | call the default `init()` once before use |
+| `@solana/zk-sdk/bundler` | Vite / webpack / etc. (package default) | none, the bundler loads the wasm |
+
+```js
+// Node
+import { ConfidentialKeys } from "@solana/zk-sdk/node";
+
+// Bundler (Vite, webpack)
+import { ConfidentialKeys } from "@solana/zk-sdk/bundler";
+
+// Browser without a bundler
+import init, { ConfidentialKeys } from "@solana/zk-sdk/web";
+await init();
+```
+
+## Confidential-balances key derivation
+
+A confidential token account is encrypted under two keys: an **ElGamal keypair** (the balance ciphertext) and an **AES key** (the `decryptable_available_balance` fast-path). `ConfidentialKeys` derives both deterministically from a single source of key material, through a shared HKDF-SHA512 chain identified by the protocol string `solana-conf-bal/v1`. Re-deriving from the same input always yields the same keys, on any platform that implements the same chain.
+
+There is one entry point per source of key material. Pick the one that matches how your wallet holds its secret:
+
+| Source | Method | Notes |
+|---|---|---|
+| WebAuthn passkey | `prfInput` + `fromPrf` | the only viable path for passkeys |
+| Ed25519 wallet signature | `signerMessage` + `fromSignature` | today's universal wallet path |
+| Raw input key material | `fromIkm` | Secure Enclave / KMS HMAC, BIP39 seed, etc. |
+
+All three converge on the same spine, so `fromSignature(sig)`, `fromIkm(bytes)`, and `fromPrf(out)` over the same bytes produce identical keys.
+
+```js
+const keys = ConfidentialKeys.fromPrf(prfOutput);
+const elgamal = keys.elgamal(); // ElGamalKeypair
+const ae = keys.ae();           // AeKey
+```
+
+### The `public_seed`
+
+`signerMessage` and `prfInput` both take a caller-chosen `public_seed` that scopes the derivation. It is granularity-agnostic: pass a token-account pubkey for per-account keys, or a wallet pubkey for one key across all of a wallet's accounts. The SDK does not enforce a convention, but two wallets must agree on it (and on which adapter they use) to derive the same keys for the same account.
+
+### Passkeys (WebAuthn PRF)
+
+Passkey ECDSA signing is randomized by spec, so signature-based derivation is impossible on passkey authenticators. The PRF (`hmac-secret`) extension is deterministic by construction and is the only path. PRF must be enabled when the credential is **registered**; legacy credentials that predate it cannot be used.
+
+```js
+import { ConfidentialKeys } from "@solana/zk-sdk/bundler";
+
+// 1. One-time, at credential registration (pure WebAuthn, not this SDK).
+//    Enabling PRF here is mandatory.
+const cred = await navigator.credentials.create({
+  publicKey: { /* rp, user, challenge, pubKeyCredParams */, extensions: { prf: {} } },
+});
+const credentialId = new Uint8Array(cred.rawId);
+
+// 2. Per session: evaluate the PRF over our canonical input, then derive.
+const publicSeed = tokenAccount.toBytes();           // your granularity choice
+const salt = ConfidentialKeys.prfInput(publicSeed);
+
+const assertion = await navigator.credentials.get({
+  publicKey: {
+    challenge: crypto.getRandomValues(new Uint8Array(32)),
+    allowCredentials: [{ id: credentialId, type: "public-key" }],
+    extensions: { prf: { eval: { first: salt } } },
+  },
+});
+
+const prf = assertion.getClientExtensionResults().prf?.results?.first;
+if (!prf) throw new Error("authenticator returned no PRF result");
+
+const keys = ConfidentialKeys.fromPrf(new Uint8Array(prf));
+```
+
+`fromPrf` accepts a 32-byte output (a single `prf.results.first`) or a 64-byte output (`first || second` concatenated), and rejects an all-zero result.
+
+`prfInput` returns the canonical message `solana-conf-bal/v1 || public_seed`, byte-identical to `signerMessage`. It is passed to `prf.eval.first` as-is: browsers apply the mandatory `SHA-256("WebAuthn PRF" || 0x00 || input)` prefixing before the authenticator, so the input length is unconstrained and must not be pre-hashed. A non-browser or direct-CTAP `hmac-secret` consumer must reproduce that prefixing over this message to derive matching keys.
+
+### Ed25519 wallet signature
+
+For a normal Solana wallet, derive from a single `signMessage` over the canonical message.
+
+```js
+import { ConfidentialKeys } from "@solana/zk-sdk/web";
+
+const message = ConfidentialKeys.signerMessage(tokenAccount.toBytes());
+const signature = await wallet.signMessage(message);   // 64-byte Ed25519 signature
+const keys = ConfidentialKeys.fromSignature(signature);
+```
+
+The all-zero (default) signature is rejected: some signers return it instead of raising an error, and the resulting keys would be predictable.
+
+### Raw input key material
+
+When the wallet exposes an HMAC/HKDF primitive directly (iOS Secure Enclave, AWS KMS `GenerateMac`, a BIP39 seed, HKDF over an Ed25519 seed), pass that output straight in.
+
+```js
+const keys = ConfidentialKeys.fromIkm(ikm); // 32 to 65535 bytes
+```
+
+## Things to get right
+
+- **Identity bindings are forever.** WebAuthn PRF output is bound to the Relying Party ID; the signature path is bound to the signing key; raw IKM is bound to its source. Change the binding and the old balance can no longer be decrypted. Commit to a stable RP ID at provisioning and never change it.
+- **Cache the derived keys for the session.** Do not re-prompt for a signature or device unlock per transfer. Derive once, hold the keys in memory, wipe on background.
+- **Back up device-bound keys.** Deterministic derivation does not survive device or credential loss. Passkey and Secure Enclave wallets need an explicit recovery path (synced credentials or wrapped-key escrow).
+
+## Background
+
+The derivation scheme and the per-wallet adapter typology are described in the Solana confidential-balances single-signer derivation framework. The Rust spine and its test vectors live in [`zk-sdk/src/encryption/derivation.rs`](https://github.com/solana-program/zk-elgamal-proof/blob/main/zk-sdk/src/encryption/derivation.rs).

--- a/zk-sdk-wasm-js/src/encryption/derivation.rs
+++ b/zk-sdk-wasm-js/src/encryption/derivation.rs
@@ -3,13 +3,18 @@ use {
     js_sys::Uint8Array,
     solana_signature::Signature,
     solana_zk_sdk::encryption::derivation::{
-        derive_confidential_keys_from_ikm, derive_confidential_keys_from_signature, HKDF_SALT,
+        confidential_derivation_message, derive_confidential_keys_from_ikm,
+        derive_confidential_keys_from_signature,
     },
     wasm_bindgen::prelude::{wasm_bindgen, JsValue},
 };
 
 /// Byte length of an ed25519 signature.
 const SIGNATURE_LEN: usize = 64;
+
+/// Accepted byte lengths for a WebAuthn PRF output: 32 bytes for a single
+/// `prf.results.first` evaluation, 64 bytes for `first || second` concatenated.
+const PRF_OUTPUT_LENS: [usize; 2] = [32, 64];
 
 /// Container returned by the unified confidential-balances key derivation.
 ///
@@ -36,7 +41,25 @@ impl ConfidentialKeys {
     pub fn signer_message(public_seed: Uint8Array) -> Vec<u8> {
         let mut seed = vec![0u8; public_seed.length() as usize];
         public_seed.copy_to(&mut seed);
-        [HKDF_SALT, seed.as_ref()].concat()
+        confidential_derivation_message(&seed)
+    }
+
+    /// Returns the canonical WebAuthn PRF evaluation input for `fromPrf`.
+    ///
+    /// Byte-identical to `signerMessage`: `b"solana-conf-bal/v1" || public_seed`.
+    /// Pass it to the authenticator as the `prf.eval.first` salt. The same
+    /// canonical message is signed in the Ed25519 path and PRF-evaluated in the
+    /// passkey path, so a single seed convention drives both adapters.
+    ///
+    /// Browsers apply the mandatory `SHA-256("WebAuthn PRF" || 0x00 || input)`
+    /// prefixing before the authenticator, so this message is passed as-is and
+    /// may be any length. Non-browser / direct-CTAP `hmac-secret` consumers MUST
+    /// reproduce that prefixing over this message to derive byte-identical keys.
+    #[wasm_bindgen(js_name = "prfInput")]
+    pub fn prf_input(public_seed: Uint8Array) -> Vec<u8> {
+        let mut seed = vec![0u8; public_seed.length() as usize];
+        public_seed.copy_to(&mut seed);
+        confidential_derivation_message(&seed)
     }
 
     /// Derives a `ConfidentialKeys` pair from a 64-byte ed25519 signature
@@ -81,6 +104,41 @@ impl ConfidentialKeys {
             .map_err(|e| JsValue::from_str(&e.to_string()))
     }
 
+    /// Derives a `ConfidentialKeys` pair from a WebAuthn PRF output (the
+    /// passkey adapter).
+    ///
+    /// A passkey's ECDSA signing is randomized by spec, so signature-based
+    /// derivation is structurally broken on passkey authenticators. The PRF
+    /// (`hmac-secret`) extension is deterministic by construction and is the
+    /// only viable path: evaluate `prf` over the salt returned by `prfInput`,
+    /// then pass the result here.
+    ///
+    /// Accepts a 32-byte output (single `prf.results.first`) or a 64-byte
+    /// output (`first || second` concatenated). The all-zero output is rejected
+    /// as a non-functioning authenticator.
+    #[wasm_bindgen(js_name = "fromPrf")]
+    pub fn from_prf(prf_output: Uint8Array) -> Result<ConfidentialKeys, JsValue> {
+        let len = prf_output.length() as usize;
+        if !PRF_OUTPUT_LENS.contains(&len) {
+            return Err(JsValue::from_str(&format!(
+                "Invalid PRF output length: expected 32 or 64, got {len}"
+            )));
+        }
+        let mut bytes = vec![0u8; len];
+        prf_output.copy_to(&mut bytes);
+
+        if bytes.iter().all(|&b| b == 0) {
+            return Err(JsValue::from_str("Rejecting all-zero PRF output"));
+        }
+
+        derive_confidential_keys_from_ikm(&bytes)
+            .map(|(elgamal, ae)| Self {
+                elgamal: elgamal.into(),
+                ae: ae.into(),
+            })
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
     /// Returns the ElGamal keypair component.
     pub fn elgamal(&self) -> ElGamalKeypair {
         ElGamalKeypair {
@@ -98,7 +156,7 @@ impl ConfidentialKeys {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, wasm_bindgen_test::*};
+    use {super::*, solana_zk_sdk::encryption::derivation::HKDF_SALT, wasm_bindgen_test::*};
 
     #[wasm_bindgen_test]
     fn test_signer_message_format() {
@@ -167,5 +225,71 @@ mod tests {
     fn test_from_ikm_rejects_short() {
         let too_short = vec![0u8; 31];
         assert!(ConfidentialKeys::from_ikm(Uint8Array::from(too_short.as_slice())).is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_prf_input_matches_signer_message() {
+        // The passkey PRF input is the same canonical message as the Ed25519
+        // signing path, so a single seed convention drives both adapters.
+        let seed = [9u8; 32];
+        let prf = ConfidentialKeys::prf_input(Uint8Array::from(seed.as_ref()));
+        let signer = ConfidentialKeys::signer_message(Uint8Array::from(seed.as_ref()));
+        assert_eq!(prf, signer);
+        assert!(prf.starts_with(b"solana-conf-bal/v1"));
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_prf_determinism() {
+        let prf_output = [3u8; 32];
+        let out = Uint8Array::from(prf_output.as_ref());
+
+        let keys_a = ConfidentialKeys::from_prf(out.clone()).unwrap();
+        let keys_b = ConfidentialKeys::from_prf(out).unwrap();
+        assert_eq!(
+            keys_a.elgamal().secret().to_bytes(),
+            keys_b.elgamal().secret().to_bytes()
+        );
+        assert_eq!(keys_a.ae().to_bytes(), keys_b.ae().to_bytes());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_prf_matches_from_ikm_over_same_bytes() {
+        // A PRF output is just IKM into the shared spine, so `fromPrf` and
+        // `fromIkm` over identical bytes must agree.
+        let prf_output = [5u8; 32];
+        let from_prf = ConfidentialKeys::from_prf(Uint8Array::from(prf_output.as_ref())).unwrap();
+        let from_ikm = ConfidentialKeys::from_ikm(Uint8Array::from(prf_output.as_ref())).unwrap();
+
+        assert_eq!(
+            from_prf.elgamal().secret().to_bytes(),
+            from_ikm.elgamal().secret().to_bytes()
+        );
+        assert_eq!(from_prf.ae().to_bytes(), from_ikm.ae().to_bytes());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_prf_accepts_64_byte_output() {
+        // `first || second` concatenation is a valid 64-byte PRF output.
+        let prf_output = [7u8; 64];
+        assert!(ConfidentialKeys::from_prf(Uint8Array::from(prf_output.as_ref())).is_ok());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_prf_rejects_wrong_length() {
+        for len in [31usize, 33, 48, 63, 65] {
+            let bad = vec![1u8; len];
+            assert!(
+                ConfidentialKeys::from_prf(Uint8Array::from(bad.as_slice())).is_err(),
+                "length {len} should be rejected"
+            );
+        }
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_prf_rejects_all_zero() {
+        let zero_32 = vec![0u8; 32];
+        assert!(ConfidentialKeys::from_prf(Uint8Array::from(zero_32.as_slice())).is_err());
+        let zero_64 = vec![0u8; 64];
+        assert!(ConfidentialKeys::from_prf(Uint8Array::from(zero_64.as_slice())).is_err());
     }
 }

--- a/zk-sdk-wasm-js/src/encryption/derivation.rs
+++ b/zk-sdk-wasm-js/src/encryption/derivation.rs
@@ -39,9 +39,7 @@ impl ConfidentialKeys {
     /// keying.
     #[wasm_bindgen(js_name = "signerMessage")]
     pub fn signer_message(public_seed: Uint8Array) -> Vec<u8> {
-        let mut seed = vec![0u8; public_seed.length() as usize];
-        public_seed.copy_to(&mut seed);
-        confidential_derivation_message(&seed)
+        confidential_derivation_message(&public_seed.to_vec())
     }
 
     /// Returns the canonical WebAuthn PRF evaluation input for `fromPrf`.
@@ -57,9 +55,7 @@ impl ConfidentialKeys {
     /// reproduce that prefixing over this message to derive byte-identical keys.
     #[wasm_bindgen(js_name = "prfInput")]
     pub fn prf_input(public_seed: Uint8Array) -> Vec<u8> {
-        let mut seed = vec![0u8; public_seed.length() as usize];
-        public_seed.copy_to(&mut seed);
-        confidential_derivation_message(&seed)
+        confidential_derivation_message(&public_seed.to_vec())
     }
 
     /// Derives a `ConfidentialKeys` pair from a 64-byte ed25519 signature
@@ -111,23 +107,25 @@ impl ConfidentialKeys {
     /// derivation is structurally broken on passkey authenticators. The PRF
     /// (`hmac-secret`) extension is deterministic by construction and is the
     /// only viable path: evaluate `prf` over the salt returned by `prfInput`,
-    /// then pass the result here.
+    /// then pass the result here as a `Uint8Array`. The browser exposes
+    /// `prf.results.first` as a raw `ArrayBuffer`, so wrap it with
+    /// `new Uint8Array(result)` before calling.
     ///
     /// Accepts a 32-byte output (single `prf.results.first`) or a 64-byte
     /// output (`first || second` concatenated). The all-zero output is rejected
     /// as a non-functioning authenticator.
     #[wasm_bindgen(js_name = "fromPrf")]
     pub fn from_prf(prf_output: Uint8Array) -> Result<ConfidentialKeys, JsValue> {
-        let len = prf_output.length() as usize;
-        if !PRF_OUTPUT_LENS.contains(&len) {
+        let bytes = prf_output.to_vec();
+        if !PRF_OUTPUT_LENS.contains(&bytes.len()) {
             return Err(JsValue::from_str(&format!(
-                "Invalid PRF output length: expected 32 or 64, got {len}"
+                "Invalid PRF output length: expected 32 or 64, got {}",
+                bytes.len()
             )));
         }
-        let mut bytes = vec![0u8; len];
-        prf_output.copy_to(&mut bytes);
 
-        if bytes.iter().all(|&b| b == 0) {
+        let is_all_zero = bytes.iter().fold(0u8, |acc, &b| acc | b) == 0;
+        if is_all_zero {
             return Err(JsValue::from_str("Rejecting all-zero PRF output"));
         }
 

--- a/zk-sdk/src/encryption/derivation.rs
+++ b/zk-sdk/src/encryption/derivation.rs
@@ -73,17 +73,33 @@ const MINIMUM_IKM_LEN: usize = 32;
 /// [`derive_confidential_keys_from_ikm`] directly.
 const MAXIMUM_IKM_LEN: usize = 65535;
 
+/// The canonical confidential-balances derivation message: `HKDF_SALT || public_seed`.
+///
+/// This single message is the input to every signing-style adapter: it is what an
+/// Ed25519 `Signer` signs ([`derive_confidential_keys`]) and what a WebAuthn passkey
+/// evaluates as its PRF input. `public_seed` is caller-controlled and granularity-
+/// agnostic; pass a wallet pubkey for per-wallet keying or a token-account pubkey for
+/// per-account keying.
+///
+/// WebAuthn note: browsers apply the mandatory `SHA-256("WebAuthn PRF" || 0x00 || input)`
+/// prefixing before the authenticator, so this message is passed to `prf.eval` as-is.
+/// Non-browser / direct-CTAP `hmac-secret` consumers MUST reproduce that prefixing over
+/// this message to derive byte-identical keys.
+pub fn confidential_derivation_message(public_seed: &[u8]) -> Vec<u8> {
+    [HKDF_SALT, public_seed].concat()
+}
+
 /// Signs the canonical derivation message with `signer` and derives the
 /// confidential-balances key pair.
 ///
-/// The signed message is `HKDF_SALT || public_seed`. `public_seed` is
+/// The signed message is [`confidential_derivation_message`]. `public_seed` is
 /// caller-controlled and granularity-agnostic; pass a wallet pubkey for
 /// per-wallet keying or a token-account pubkey for per-account keying.
 pub fn derive_confidential_keys(
     signer: &dyn Signer,
     public_seed: &[u8],
 ) -> Result<(ElGamalKeypair, AeKey), Box<dyn error::Error>> {
-    let message = [HKDF_SALT, public_seed].concat();
+    let message = confidential_derivation_message(public_seed);
     let signature = signer.try_sign_message(&message)?;
     derive_confidential_keys_from_signature(&signature).map_err(Into::into)
 }
@@ -178,7 +194,7 @@ mod tests {
 
         let (kp_signer, ae_signer) = derive_confidential_keys(&keypair, &public_seed).unwrap();
 
-        let message = [HKDF_SALT, public_seed.as_ref()].concat();
+        let message = confidential_derivation_message(&public_seed);
         let sig = keypair.sign_message(&message);
         let (kp_sig, ae_sig) = derive_confidential_keys_from_signature(&sig).unwrap();
 
@@ -187,6 +203,17 @@ mod tests {
             <[u8; AE_KEY_LEN]>::from(&ae_signer),
             <[u8; AE_KEY_LEN]>::from(&ae_sig)
         );
+    }
+
+    #[test]
+    fn test_confidential_derivation_message_format() {
+        // The canonical message is `HKDF_SALT || public_seed`, the single
+        // input shared by the Ed25519 signing path and the WebAuthn PRF path.
+        let public_seed = [0x44u8; 32];
+        let message = confidential_derivation_message(&public_seed);
+        assert_eq!(message, [HKDF_SALT, public_seed.as_ref()].concat());
+        assert!(message.starts_with(b"solana-conf-bal/v1"));
+        assert!(message.ends_with(&public_seed));
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #417, adding the next adapter from the single-signer derivation typology: passkeys (adapter 2).

Passkey ECDSA signing is randomized by spec, so signature based derivation is structurally broken on passkey authenticators. The WebAuthn PRF (hmac-secret) extension is deterministic by construction and is the only viable path. A PRF output is just IKM, so it feeds the existing `solana-conf-bal/v1` HKDF spine directly: no new crypto, just the adapter surface around it.

What's here:

- Core: `confidential_derivation_message(public_seed)`, the one canonical message that gets signed in the Ed25519 path and PRF evaluated in the passkey path. `derive_confidential_keys` and the wasm `signerMessage` now route through it so there's a single source of truth for the convention.
- wasm-js: `prfInput(public_seed)` returns the canonical PRF eval salt (byte identical to `signerMessage`), and `fromPrf(prfOutput)` validates the output (32 bytes for a single `prf.results.first`, or 64 for `first || second`), rejects all zero, and derives through the spine.

On the salt convention: the PRF input is the raw canonical message, not a pre-hash. Browsers always apply the mandatory `SHA-256("WebAuthn PRF" || 0x00 || input)` prefixing before the authenticator, so the input can be any length and pre-hashing buys nothing (the browser re-hashes it anyway) while inviting a divergence footgun for anyone tempted to use a 32 byte value as a raw CTAP salt. The doc comments spell out that non-browser / direct-CTAP consumers must reproduce that prefixing to interoperate. This nails down sRFC open question #3.

Secure Enclave HMAC, KMS HMAC, deterministic ECDSA, etc. are deliberately left for separate follow-up PRs to keep this one easy to review.