### PR TITLE
deps: Migrate from tiny-bip39 to canonical upstream bip39

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +69,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bip39"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.6",
+ "rand_core 0.6.4",
+ "serde",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
+dependencies = [
+ "hex-conservative",
 ]
 
 [[package]]
@@ -385,6 +413,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fda06d18ac606267c40c04e41b9947729bf8b9efe74bd4e82b61a5f26a510b9f"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,16 +615,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest",
- "hmac",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,12 +751,6 @@ checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_version"
@@ -1029,7 +1050,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc905b200a95f2ea9146e43f2a7181e3aeb55de6bc12afb36462d00a3c7310de"
 dependencies = [
  "hmac",
- "pbkdf2 0.11.0",
+ "pbkdf2",
  "sha2",
 ]
 
@@ -1099,6 +1120,7 @@ dependencies = [
  "aes-gcm-siv",
  "base64",
  "bincode",
+ "bip39",
  "bytemuck",
  "curve25519-dalek",
  "hkdf",
@@ -1120,8 +1142,7 @@ dependencies = [
  "solana-zk-elgamal-proof-interface",
  "solana-zk-sdk-pod",
  "subtle",
- "thiserror 2.0.18",
- "tiny-bip39",
+ "thiserror",
  "zeroize",
 ]
 
@@ -1137,7 +1158,7 @@ dependencies = [
  "solana-nullable",
  "solana-zk-sdk",
  "solana-zk-sdk-pod",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -1191,31 +1212,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -1227,23 +1228,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tiny-bip39"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a30fd743a02bf35236f6faf99adb03089bb77e91c998dac2c2ad76bb424f668c"
-dependencies = [
- "once_cell",
- "pbkdf2 0.12.2",
- "rand 0.8.6",
- "rustc-hash",
- "sha2",
- "thiserror 1.0.69",
- "unicode-normalization",
- "wasm-bindgen",
- "zeroize",
 ]
 
 [[package]]
@@ -1456,7 +1440,7 @@ dependencies = [
  "pastey",
  "proc-macro2",
  "quote",
- "thiserror 2.0.18",
+ "thiserror",
  "wincode-derive",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ config = "scripts/spellcheck.toml"
 aes-gcm-siv = "0.11.1"
 base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }
 bincode = "1.3.3"
+bip39 = { version = "2.2.2", features = ["rand"] }
 bytemuck = "1.25.0"
 bytemuck_derive = "1.10.2"
 curve25519-dalek = { version = "4.1.3", features = ["digest", "rand_core"] }
@@ -55,7 +56,6 @@ solana-zk-sdk-pod = { path = "zk-sdk-pod", version = "0.1.2" }
 solana-zk-sdk-wasm-js = { path = "zk-sdk-wasm-js", version = "0.1.0" }
 subtle = "2.6.1"
 thiserror = { version = "2.0.18", default-features = false }
-tiny-bip39 = "2.0.0"
 wasm-bindgen = "0.2"
 wasm-bindgen-test = "0.3"
 zeroize = { version = "1.8", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ js-sys = "0.3.77"
 merlin = { version = "3", default-features = false }
 num-derive = "0.4"
 num-traits = { version = "0.2", default-features = false }
-rand = "0.8.5"
+rand = "0.8.6"
 serde = { version = "1.0.228", default-features = false }
 serde_derive = "1.0.219"
 serde_json = "1.0.150"

--- a/zk-keygen/Cargo.toml
+++ b/zk-keygen/Cargo.toml
@@ -23,6 +23,7 @@ name = "solana-zk-keygen"
 path = "src/main.rs"
 
 [dependencies]
+bip39 = { workspace = true, features = ["all-languages"] }
 bs58 = { workspace = true }
 clap = { version = "3.1.5", features = ["cargo", "derive"] }
 dirs-next = { workspace = true }
@@ -33,7 +34,6 @@ solana-signer = { workspace = true }
 solana-version = { workspace = true }
 solana-zk-sdk = { workspace = true }
 thiserror = { workspace = true }
-tiny-bip39 = { workspace = true }
 
 [dev-dependencies]
 solana-address = { workspace = true, features = ["rand"] }

--- a/zk-keygen/src/main.rs
+++ b/zk-keygen/src/main.rs
@@ -1,5 +1,5 @@
 use {
-    bip39::{Mnemonic, MnemonicType, Seed},
+    bip39::Mnemonic,
     clap::{crate_description, crate_name, Arg, ArgMatches, Command, PossibleValue},
     solana_clap_v3_utils::{
         input_parsers::{signer::SignerSourceParserBuilder, STDOUT_OUTFILE_TOKEN},
@@ -176,12 +176,11 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
             }
 
             let word_count = try_get_word_count(matches)?.unwrap();
-            let mnemonic_type = MnemonicType::for_word_count(word_count)?;
             let language = try_get_language(matches)?.unwrap();
 
-            let mnemonic = Mnemonic::new(mnemonic_type, language);
+            let mnemonic = Mnemonic::generate_in(language, word_count)?;
             let (passphrase, passphrase_message) = acquire_passphrase_and_message(matches).unwrap();
-            let seed = Seed::new(&mnemonic, &passphrase);
+            let seed = mnemonic.to_seed(&passphrase);
 
             let silent = matches.try_contains_id("silent")?;
 
@@ -191,14 +190,14 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                         eprintln!("Generating a new ElGamal keypair");
                     }
 
-                    let elgamal_keypair = ElGamalKeypair::from_seed(seed.as_bytes())?;
+                    let elgamal_keypair = ElGamalKeypair::from_seed(&seed)?;
                     if let Some(outfile) = outfile {
                         output_encodable_key(&elgamal_keypair, outfile, "new ElGamal keypair")
                             .map_err(|err| format!("Unable to write {outfile}: {err}"))?;
                     }
 
                     if !silent {
-                        let phrase: &str = mnemonic.phrase();
+                        let phrase = mnemonic.to_string();
                         let divider = String::from_utf8(vec![b'='; phrase.len()]).unwrap();
                         println!(
                             "{}\npubkey: {}\n{}\nSave this seed phrase{} to recover your new ElGamal keypair:\n{}\n{}",
@@ -211,14 +210,14 @@ fn do_main(matches: &ArgMatches) -> Result<(), Box<dyn error::Error>> {
                         eprintln!("Generating a new AES128 encryption key");
                     }
 
-                    let aes_key = AeKey::from_seed(seed.as_bytes())?;
+                    let aes_key = AeKey::from_seed(&seed)?;
                     if let Some(outfile) = outfile {
                         output_encodable_key(&aes_key, outfile, "new AES128 key")
                             .map_err(|err| format!("Unable to write {outfile}: {err}"))?;
                     }
 
                     if !silent {
-                        let phrase: &str = mnemonic.phrase();
+                        let phrase = mnemonic.to_string();
                         let divider = String::from_utf8(vec![b'='; phrase.len()]).unwrap();
                         println!(
                             "{}\nSave this seed phrase{} to recover your new AES128 key:\n{}\n{}",

--- a/zk-sdk/Cargo.toml
+++ b/zk-sdk/Cargo.toml
@@ -40,9 +40,9 @@ thiserror = { workspace = true }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [dev-dependencies]
+bip39 = { workspace = true }
 solana-address = { workspace = true, features = ["atomic", "bytemuck"] }
 solana-keypair = { workspace = true }
-tiny-bip39 = { workspace = true }
 
 [lints]
 workspace = true

--- a/zk-sdk/src/encryption/elgamal.rs
+++ b/zk-sdk/src/encryption/elgamal.rs
@@ -1086,7 +1086,7 @@ mod tests {
     use {
         super::*,
         crate::encryption::pedersen::Pedersen,
-        bip39::{Language, Mnemonic, MnemonicType, Seed},
+        bip39::{Language, Mnemonic},
         std::fs::{self, File},
     };
 
@@ -1377,12 +1377,13 @@ mod tests {
 
     #[test]
     fn test_keypair_from_seed_phrase_and_passphrase() {
-        let mnemonic = Mnemonic::new(MnemonicType::Words12, Language::English);
+        let mnemonic = Mnemonic::generate_in(Language::English, 12).unwrap();
         let passphrase = "42";
-        let seed = Seed::new(&mnemonic, passphrase);
-        let expected_keypair = ElGamalKeypair::from_seed(seed.as_bytes()).unwrap();
+        let seed = mnemonic.to_seed(passphrase);
+        let expected_keypair = ElGamalKeypair::from_seed(seed.as_ref()).unwrap();
         let keypair =
-            ElGamalKeypair::from_seed_phrase_and_passphrase(mnemonic.phrase(), passphrase).unwrap();
+            ElGamalKeypair::from_seed_phrase_and_passphrase(&mnemonic.to_string(), passphrase)
+                .unwrap();
         assert_eq!(keypair.public, expected_keypair.public);
     }
 


### PR DESCRIPTION
`tiny-bip39` is no longer being maintained.

See also https://github.com/anza-xyz/agave/pull/12134