### PR TITLE
Fix repository URL in the JS client package.json

### DIFF
--- a/clients-js/package.json
+++ b/clients-js/package.json
@@ -35,7 +35,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/solana-program/zk-elgamal-proof"
+    "url": "git+https://github.com/solana-program/zk-elgamal-proof.git"
   },
   "bugs": {
     "url": "https://github.com/solana-program/zk-elgamal-proof/issues"


### PR DESCRIPTION
This PR normalizes the JS client's `repository.url` to include the `.git` suffix, matching the convention used by the other repos in the solana-program org and ensuring npm provenance verification validates the repository correctly when publishing.