### PR TITLE
Bump record dependency to 0.2.0

### DIFF
--- a/clients-js/package.json
+++ b/clients-js/package.json
@@ -51,7 +51,7 @@
     "@ava/typescript": "^7.0.0",
     "@eslint/js": "^10.0.1",
     "@solana-program/compute-budget": "^0.16.0",
-    "@solana-program/record": "^0.1.0",
+    "@solana-program/record": "^0.2.0",
     "@solana/kit": "^6.10.0",
     "@solana/sysvars": "^6.10.0",
     "@solana/zk-sdk": "0.4.1",

--- a/clients-js/test/_setup.ts
+++ b/clients-js/test/_setup.ts
@@ -1,7 +1,9 @@
 import {
   TransactionMessage,
+  Address,
   Commitment,
   Instruction,
+  InstructionPlan,
   Rpc,
   RpcSubscriptions,
   SolanaRpcApi,
@@ -10,6 +12,7 @@ import {
   TransactionMessageWithFeePayer,
   TransactionSigner,
   airdropFactory,
+  appendTransactionMessageInstructionPlan,
   appendTransactionMessageInstructions,
   assertIsSendableTransaction,
   assertIsTransactionWithBlockhashLifetime,
@@ -21,14 +24,79 @@ import {
   lamports,
   pipe,
   sendAndConfirmTransactionFactory,
+  setTransactionMessageFeePayer,
   setTransactionMessageFeePayerSigner,
   setTransactionMessageLifetimeUsingBlockhash,
   signTransactionMessageWithSigners,
 } from '@solana/kit';
+import {
+  getCreateRecordInstructionPlan,
+  getWriteInstructionPlan,
+  RECORD_CHUNK_SIZE_POST_INITIALIZE,
+  RECORD_META_DATA_SIZE,
+} from '@solana-program/record';
+
+export { RECORD_CHUNK_SIZE_POST_INITIALIZE, RECORD_META_DATA_SIZE };
 
 export type Client = {
   rpc: Rpc<SolanaRpcApi>;
   rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+};
+
+// Flattens an instruction plan into a flat list of instructions by packing it
+// into a throwaway transaction message. Sufficient for the small, single-
+// transaction record plans these tests build.
+export const getInstructionsFromInstructionPlan = (
+  plan: InstructionPlan,
+  feePayer: Address,
+): Instruction[] => {
+  const message = pipe(
+    createTransactionMessage({ version: 0 }),
+    tx => setTransactionMessageFeePayer(feePayer, tx),
+    tx => appendTransactionMessageInstructionPlan(plan, tx),
+  );
+  return [...message.instructions];
+};
+
+// Mirrors the shape of record's former `createRecord` helper: generates a fresh
+// record keypair and returns the instructions that create and initialize it.
+export const createRecord = async (input: {
+  rpc: Rpc<SolanaRpcApi>;
+  payer: TransactionSigner;
+  authority: Address;
+  dataLength: bigint;
+}): Promise<{ recordKeypair: TransactionSigner; ixs: Instruction[] }> => {
+  const recordKeypair = await generateKeyPairSigner();
+  const plan = await getCreateRecordInstructionPlan(
+    {
+      getMinimumBalance: space => input.rpc.getMinimumBalanceForRentExemption(BigInt(space)).send(),
+    },
+    {
+      payer: input.payer,
+      newRecord: recordKeypair,
+      authority: input.authority,
+      dataLength: input.dataLength,
+    },
+  );
+  return { recordKeypair, ixs: getInstructionsFromInstructionPlan(plan, input.payer.address) };
+};
+
+// Mirrors the shape of record's former `createWriteInstruction` helper for the
+// single-transaction writes these tests perform.
+export const createWriteInstruction = (input: {
+  recordAccount: Address;
+  authority: TransactionSigner;
+  offset: bigint;
+  data: Uint8Array;
+}): Instruction => {
+  const plan = getWriteInstructionPlan({
+    recordAccount: input.recordAccount,
+    authority: input.authority,
+    data: input.data,
+    offset: Number(input.offset),
+  });
+  const [instruction] = getInstructionsFromInstructionPlan(plan, input.authority.address);
+  return instruction;
 };
 
 export const createDefaultSolanaClient = (): Client => {

--- a/clients-js/test/verifyBatchedGroupedCiphertext2HandlesValidity.test.ts
+++ b/clients-js/test/verifyBatchedGroupedCiphertext2HandlesValidity.test.ts
@@ -3,6 +3,10 @@ import {
   createDefaultSolanaClient,
   generateKeyPairSignerWithSol,
   sendAndConfirmInstructions,
+  createRecord,
+  createWriteInstruction,
+  RECORD_META_DATA_SIZE,
+  RECORD_CHUNK_SIZE_POST_INITIALIZE,
 } from './_setup';
 import { generateKeyPairSigner } from '@solana/kit';
 import { verifyBatchedGroupedCiphertext2HandlesValidity } from '../src';
@@ -12,12 +16,6 @@ import {
   GroupedElGamalCiphertext2Handles,
   PedersenOpening,
 } from '@solana/zk-sdk/node';
-import {
-  createRecord,
-  createWriteInstruction,
-  RECORD_META_DATA_SIZE,
-  RECORD_CHUNK_SIZE_POST_INITIALIZE,
-} from '@solana-program/record';
 
 const createValidProof = () => {
   const destination1 = new ElGamalKeypair();

--- a/clients-js/test/verifyBatchedGroupedCiphertext3HandlesValidity.test.ts
+++ b/clients-js/test/verifyBatchedGroupedCiphertext3HandlesValidity.test.ts
@@ -3,6 +3,10 @@ import {
   createDefaultSolanaClient,
   generateKeyPairSignerWithSol,
   sendAndConfirmInstructions,
+  createRecord,
+  createWriteInstruction,
+  RECORD_META_DATA_SIZE,
+  RECORD_CHUNK_SIZE_POST_INITIALIZE,
 } from './_setup';
 import { generateKeyPairSigner } from '@solana/kit';
 import { verifyBatchedGroupedCiphertext3HandlesValidity } from '../src';
@@ -12,12 +16,6 @@ import {
   GroupedElGamalCiphertext3Handles,
   PedersenOpening,
 } from '@solana/zk-sdk/node';
-import {
-  createRecord,
-  createWriteInstruction,
-  RECORD_META_DATA_SIZE,
-  RECORD_CHUNK_SIZE_POST_INITIALIZE,
-} from '@solana-program/record';
 
 const createValidProof = () => {
   const destination1 = new ElGamalKeypair();

--- a/clients-js/test/verifyBatchedRangeProofU128.test.ts
+++ b/clients-js/test/verifyBatchedRangeProofU128.test.ts
@@ -3,6 +3,10 @@ import {
   createDefaultSolanaClient,
   generateKeyPairSignerWithSol,
   sendAndConfirmInstructions,
+  createRecord,
+  createWriteInstruction,
+  RECORD_META_DATA_SIZE,
+  RECORD_CHUNK_SIZE_POST_INITIALIZE,
 } from './_setup';
 import { verifyBatchedRangeProofU128 } from '../src';
 import {
@@ -11,12 +15,6 @@ import {
   PedersenOpening,
 } from '@solana/zk-sdk/node';
 import { generateKeyPairSigner } from '@solana/kit';
-import {
-  createRecord,
-  createWriteInstruction,
-  RECORD_META_DATA_SIZE,
-  RECORD_CHUNK_SIZE_POST_INITIALIZE,
-} from '@solana-program/record';
 
 const createValidProof = () => {
   // Sum of bit lengths must be 128

--- a/clients-js/test/verifyBatchedRangeProofU256.test.ts
+++ b/clients-js/test/verifyBatchedRangeProofU256.test.ts
@@ -3,6 +3,10 @@ import {
   createDefaultSolanaClient,
   generateKeyPairSignerWithSol,
   sendAndConfirmInstructions,
+  createRecord,
+  createWriteInstruction,
+  RECORD_META_DATA_SIZE,
+  RECORD_CHUNK_SIZE_POST_INITIALIZE,
 } from './_setup';
 import { verifyBatchedRangeProofU256 } from '../src';
 import {
@@ -11,12 +15,6 @@ import {
   PedersenOpening,
 } from '@solana/zk-sdk/node';
 import { generateKeyPairSigner } from '@solana/kit';
-import {
-  createRecord,
-  createWriteInstruction,
-  RECORD_META_DATA_SIZE,
-  RECORD_CHUNK_SIZE_POST_INITIALIZE,
-} from '@solana-program/record';
 import { getSetComputeUnitLimitInstruction } from '@solana-program/compute-budget';
 
 const createValidProof = () => {

--- a/clients-js/test/verifyBatchedRangeProofU64.test.ts
+++ b/clients-js/test/verifyBatchedRangeProofU64.test.ts
@@ -3,16 +3,14 @@ import {
   createDefaultSolanaClient,
   generateKeyPairSignerWithSol,
   sendAndConfirmInstructions,
-} from './_setup';
-import { verifyBatchedRangeProofU64 } from '../src';
-import { BatchedRangeProofU64Data, PedersenCommitment, PedersenOpening } from '@solana/zk-sdk/node';
-import { generateKeyPairSigner } from '@solana/kit';
-import {
   createRecord,
   createWriteInstruction,
   RECORD_META_DATA_SIZE,
   RECORD_CHUNK_SIZE_POST_INITIALIZE,
-} from '@solana-program/record';
+} from './_setup';
+import { verifyBatchedRangeProofU64 } from '../src';
+import { BatchedRangeProofU64Data, PedersenCommitment, PedersenOpening } from '@solana/zk-sdk/node';
+import { generateKeyPairSigner } from '@solana/kit';
 
 const createValidProof = () => {
   const amount1 = 255n; // 8-bit max

--- a/clients-js/test/verifyCiphertextCiphertextEquality.test.ts
+++ b/clients-js/test/verifyCiphertextCiphertextEquality.test.ts
@@ -3,6 +3,9 @@ import {
   createDefaultSolanaClient,
   generateKeyPairSignerWithSol,
   sendAndConfirmInstructions,
+  createRecord,
+  createWriteInstruction,
+  RECORD_META_DATA_SIZE,
 } from './_setup';
 import { generateKeyPairSigner } from '@solana/kit';
 import { verifyCiphertextCiphertextEquality } from '../src';
@@ -11,11 +14,6 @@ import {
   CiphertextCiphertextEqualityProofData,
   PedersenOpening,
 } from '@solana/zk-sdk/node';
-import {
-  createRecord,
-  createWriteInstruction,
-  RECORD_META_DATA_SIZE,
-} from '@solana-program/record';
 
 test('verifyCiphertextCiphertextEquality: success with valid proof (no context state)', async t => {
   const client = createDefaultSolanaClient();

--- a/clients-js/test/verifyCiphertextCommitmentEquality.test.ts
+++ b/clients-js/test/verifyCiphertextCommitmentEquality.test.ts
@@ -3,6 +3,9 @@ import {
   createDefaultSolanaClient,
   generateKeyPairSignerWithSol,
   sendAndConfirmInstructions,
+  createRecord,
+  createWriteInstruction,
+  RECORD_META_DATA_SIZE,
 } from './_setup';
 import { generateKeyPairSigner } from '@solana/kit';
 import { verifyCiphertextCommitmentEquality } from '../src';
@@ -12,11 +15,6 @@ import {
   PedersenOpening,
   PedersenCommitment,
 } from '@solana/zk-sdk/node';
-import {
-  createRecord,
-  createWriteInstruction,
-  RECORD_META_DATA_SIZE,
-} from '@solana-program/record';
 
 const createValidProof = () => {
   const keypair = new ElGamalKeypair();

--- a/clients-js/test/verifyGroupedCiphertext2HandlesValidity.test.ts
+++ b/clients-js/test/verifyGroupedCiphertext2HandlesValidity.test.ts
@@ -3,6 +3,10 @@ import {
   createDefaultSolanaClient,
   generateKeyPairSignerWithSol,
   sendAndConfirmInstructions,
+  createRecord,
+  createWriteInstruction,
+  RECORD_META_DATA_SIZE,
+  RECORD_CHUNK_SIZE_POST_INITIALIZE,
 } from './_setup';
 import { generateKeyPairSigner } from '@solana/kit';
 import { verifyGroupedCiphertext2HandlesValidity } from '../src';
@@ -12,12 +16,6 @@ import {
   GroupedElGamalCiphertext2Handles,
   PedersenOpening,
 } from '@solana/zk-sdk/node';
-import {
-  createRecord,
-  createWriteInstruction,
-  RECORD_META_DATA_SIZE,
-  RECORD_CHUNK_SIZE_POST_INITIALIZE,
-} from '@solana-program/record';
 
 const createValidProof = () => {
   const destination1 = new ElGamalKeypair();

--- a/clients-js/test/verifyGroupedCiphertext3HandlesValidity.test.ts
+++ b/clients-js/test/verifyGroupedCiphertext3HandlesValidity.test.ts
@@ -3,6 +3,10 @@ import {
   createDefaultSolanaClient,
   generateKeyPairSignerWithSol,
   sendAndConfirmInstructions,
+  createRecord,
+  createWriteInstruction,
+  RECORD_META_DATA_SIZE,
+  RECORD_CHUNK_SIZE_POST_INITIALIZE,
 } from './_setup';
 import { generateKeyPairSigner } from '@solana/kit';
 import { verifyGroupedCiphertext3HandlesValidity } from '../src';
@@ -12,12 +16,6 @@ import {
   GroupedElGamalCiphertext3Handles,
   PedersenOpening,
 } from '@solana/zk-sdk/node';
-import {
-  createRecord,
-  createWriteInstruction,
-  RECORD_META_DATA_SIZE,
-  RECORD_CHUNK_SIZE_POST_INITIALIZE,
-} from '@solana-program/record';
 
 const createValidProof = () => {
   const destination1 = new ElGamalKeypair();

--- a/clients-js/test/verifyPercentageWithCap.test.ts
+++ b/clients-js/test/verifyPercentageWithCap.test.ts
@@ -3,6 +3,9 @@ import {
   createDefaultSolanaClient,
   generateKeyPairSignerWithSol,
   sendAndConfirmInstructions,
+  createRecord,
+  createWriteInstruction,
+  RECORD_META_DATA_SIZE,
 } from './_setup';
 import { generateKeyPairSigner } from '@solana/kit';
 import { verifyPercentageWithCap } from '../src';
@@ -11,11 +14,6 @@ import {
   PedersenOpening,
   PercentageWithCapProofData,
 } from '@solana/zk-sdk/node';
-import {
-  createRecord,
-  createWriteInstruction,
-  RECORD_META_DATA_SIZE,
-} from '@solana-program/record';
 
 test('verifyPercentageWithCap: success with valid proof (no context state)', async t => {
   const client = createDefaultSolanaClient();

--- a/clients-js/test/verifyPubkeyValidity.test.ts
+++ b/clients-js/test/verifyPubkeyValidity.test.ts
@@ -3,15 +3,13 @@ import {
   createDefaultSolanaClient,
   generateKeyPairSignerWithSol,
   sendAndConfirmInstructions,
+  createRecord,
+  createWriteInstruction,
+  RECORD_META_DATA_SIZE,
 } from './_setup';
 import { generateKeyPairSigner } from '@solana/kit';
 import { verifyPubkeyValidity } from '../src';
 import { ElGamalKeypair, PubkeyValidityProofData } from '@solana/zk-sdk/node';
-import {
-  createRecord,
-  createWriteInstruction,
-  RECORD_META_DATA_SIZE,
-} from '@solana-program/record';
 
 test('verifyPubkeyValidity: success with valid proof (no context state)', async t => {
   const client = createDefaultSolanaClient();

--- a/clients-js/test/verifyZeroCiphertext.test.ts
+++ b/clients-js/test/verifyZeroCiphertext.test.ts
@@ -3,15 +3,13 @@ import {
   createDefaultSolanaClient,
   generateKeyPairSignerWithSol,
   sendAndConfirmInstructions,
+  createRecord,
+  createWriteInstruction,
+  RECORD_META_DATA_SIZE,
 } from './_setup';
 import { generateKeyPairSigner } from '@solana/kit';
 import { verifyZeroCiphertext } from '../src';
 import { ElGamalKeypair, ZeroCiphertextProofData } from '@solana/zk-sdk/node';
-import {
-  createRecord,
-  createWriteInstruction,
-  RECORD_META_DATA_SIZE,
-} from '@solana-program/record';
 
 test('verifyZeroCiphertext: success with valid proof (no context state)', async t => {
   const client = createDefaultSolanaClient();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         specifier: ^0.16.0
         version: 0.16.0(@solana/kit@6.10.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana-program/record':
-        specifier: ^0.1.0
-        version: 0.1.0(@solana/kit@6.10.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10))
+        specifier: ^0.2.0
+        version: 0.2.0(@solana/kit@6.10.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/kit':
         specifier: ^6.10.0
         version: 6.10.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -834,10 +834,11 @@ packages:
     peerDependencies:
       '@solana/kit': ^6.4.0
 
-  '@solana-program/record@0.1.0':
-    resolution: {integrity: sha512-g7Ub3wYnzU9+Q/srLxhxMMfiDpt2lKjkG2XPGoXHToM7eOhGWY7fKfMaK8rv1mhpzoKEJwAC+HuK6pcnHVIciQ==}
+  '@solana-program/record@0.2.0':
+    resolution: {integrity: sha512-SH+85fxLlEj/vv8MIg22UR5s8IcCZyNZMsLX4LxX7gjY+FF8OVY8pnScZopzzfp5/dIq1k9+t3RLxG/hV15R3Q==}
+    engines: {node: '>=24.0.0'}
     peerDependencies:
-      '@solana/kit': ^5.0
+      '@solana/kit': ^6.4.0
 
   '@solana-program/system@0.12.2':
     resolution: {integrity: sha512-MaBeOxlvTruQhA7UYkOb3hVTEHPPagOtd+PvTm6a8rGgvEAP0kD4BbC37NceOaR4ABNqdaCmD5OMVRKgrE6KAg==}
@@ -4351,7 +4352,7 @@ snapshots:
     dependencies:
       '@solana/kit': 6.10.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
 
-  '@solana-program/record@0.1.0(@solana/kit@6.10.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10))':
+  '@solana-program/record@0.2.0(@solana/kit@6.10.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/kit': 6.10.0(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
 


### PR DESCRIPTION
This PR bumps the `@solana-program/record` dev dependency from `^0.1.0` to `^0.2.0` so the zk-elgamal-proof JS client can build and test against the latest record release. Record 0.2.0 replaced its former standalone helpers (`createRecord` returning `{ recordKeypair, ixs }` and `createWriteInstruction`) with plan-based builders (`getCreateRecordInstructionPlan` and `getWriteInstructionPlan`), so the test setup now adapts those plan-based builders back into the flat instruction shape the existing AVA harness expects via small local helpers in `_setup.ts`, leaving every test body unchanged. The still-exported `RECORD_META_DATA_SIZE` and `RECORD_CHUNK_SIZE_POST_INITIALIZE` constants are re-exported from the same setup module so the per-test imports collapse to a single source.