### PR TITLE
[zk-sdk-wasm-js] bump `@solana/zk-sdk` version to 0.4.2 for publishing

### DIFF
--- a/zk-sdk-wasm-js/package.json
+++ b/zk-sdk-wasm-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/zk-sdk",
-  "version": "0.3.0",
+  "version": "0.4.2",
   "description": "Universal WASM package for the rust solana-zk-sdk",
   "type": "module",
   "files": [


### PR DESCRIPTION
#### Summary of Changes

The CI scripts were updated to publish wasm packages to NPM (https://github.com/solana-program/actions/pull/56, https://github.com/solana-program/zk-elgamal-proof/pull/499).

Previously, I manually published the `@solana/zk-sdk` library to npm. The latest version in npm is 0.4.2 while it seems like the `package.json` file is still on 0.3.0.

I bumped this version to 0.4.2 to match the latest version on npm. Moving forward, we will always use the CI to publish to npm, so I don't think we will need to manually bump versions any more.