### PR TITLE
Update ci so that we can publish wasm packages

### DIFF
--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -10,6 +10,7 @@ on:
         type: choice
         options:
           - clients-js
+          - zk-sdk-wasm-js
       level:
         description: Version level
         required: true
@@ -41,6 +42,7 @@ jobs:
     outputs:
       SOLANA_CLI_VERSION: ${{ steps.compute.outputs.SOLANA_CLI_VERSION }}
       TARGET: ${{ steps.compute.outputs.TARGET }}
+      WASM_PACK: ${{ steps.compute.outputs.WASM_PACK }}
     steps:
       - name: Git Checkout
         uses: actions/checkout@v4
@@ -55,6 +57,11 @@ jobs:
           echo "SOLANA_CLI_VERSION=$(make solana-cli-version)" >> "$GITHUB_OUTPUT"
           TARGET=$(echo ${{ inputs.package-path }} | sed 's#/#-#')
           echo "TARGET=$TARGET" >> "$GITHUB_OUTPUT"
+          if [ "$TARGET" = "zk-sdk-wasm-js" ]; then
+            echo "WASM_PACK=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "WASM_PACK=false" >> "$GITHUB_OUTPUT"
+          fi
 
   main:
     needs: set_env
@@ -70,4 +77,5 @@ jobs:
       level: ${{ inputs.level }}
       tag: ${{ inputs.tag }}
       create-release: ${{ inputs.create-release }}
+      wasm-pack: ${{ needs.set_env.outputs.WASM_PACK == 'true' }}
     secrets: inherit

--- a/.github/workflows/publish-rust.yml
+++ b/.github/workflows/publish-rust.yml
@@ -13,7 +13,6 @@ on:
           - zk-keygen
           - zk-sdk
           - zk-sdk-pod
-          - zk-sdk-wasm-js
       level:
         description: Level
         required: true

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,15 @@ build-doc-%:
 test-doc-%:
 	cargo $(nightly) test --doc --all-features --manifest-path $(call make-path,$*)/Cargo.toml $(ARGS)
 
+format-check-js-zk-sdk-wasm-js:
+	@echo "No JS format check needed for zk-sdk-wasm-js"
+
+lint-js-zk-sdk-wasm-js:
+	@echo "No JS lint needed for zk-sdk-wasm-js"
+
+test-js-zk-sdk-wasm-js:
+	make test-wasm-js-zk-sdk-wasm-js
+
 format-check-js-%:
 	cd $(call make-path,$*) && pnpm install && pnpm format $(ARGS)
 


### PR DESCRIPTION
#### Problem

I have been manually publishing the wasm package in `zk-sdk-wasm-js` so far, but it would be nice to be able to publish through the CI.

#### Summary of Changes

For the most part, it seems like we can use the existing publish-js script except for the following:
- The current publish-js script in `solana-program/actions` does not install wasm-pack, so I made https://github.com/solana-program/actions/pull/56 upstream.
- Since `zk-sdk-wasm-js` is a wasm package, formatting and linting are irrelevant and testing script should be a little different, so I updated the makefile script accordingly. See inlined comments below.