### PR TITLE
[ci] Build wasm before testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ lint-js-zk-sdk-wasm-js:
 	@echo "No JS lint needed for zk-sdk-wasm-js"
 
 test-js-zk-sdk-wasm-js:
+	make build-wasm-js-zk-sdk-wasm-js
 	make test-wasm-js-zk-sdk-wasm-js
 
 format-check-js-%:


### PR DESCRIPTION
Sorry I tried publishing the wasm package using the CI, but the `make-test-js` was failing on the wasm package because I was not building the wasm package before testing.

Added a line in the makefile to build the wasm package before testing.