### PR TITLE
Add repository metadata to @solana/zk-sdk package

### DIFF
--- a/zk-sdk-wasm-js/package.json
+++ b/zk-sdk-wasm-js/package.json
@@ -28,5 +28,14 @@
   "scripts": {
     "build": "make -C .. build-wasm-js-zk-sdk-wasm-js",
     "prepublishOnly": "pnpm build"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/solana-program/zk-elgamal-proof.git",
+    "directory": "zk-sdk-wasm-js"
+  },
+  "bugs": {
+    "url": "https://github.com/solana-program/zk-elgamal-proof/issues"
+  },
+  "homepage": "https://github.com/solana-program/zk-elgamal-proof#readme"
 }


### PR DESCRIPTION
This PR adds the `repository`, `bugs`, and `homepage` fields to the zk-sdk-wasm-js package manifest.

The Publish JS workflow runs `npm publish` with npm provenance enabled (`NPM_CONFIG_PROVENANCE: "true"`), which requires a valid `repository.url` in `package.json`. The `@solana/zk-sdk` package was missing this field, causing the publish to abort with exit code 2. The added fields mirror the sibling `clients-js` package, with a `directory` hint pointing at the package's location within the monorepo.