### PR TITLE
Strip wasm-pack .gitignore so publish includes the build output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,9 @@ build-wasm-js-%:
 	wasm-pack build --target nodejs --out-dir dist/node --out-name index $(call make-path,$*)
 	wasm-pack build --target web --out-dir dist/web --out-name index $(call make-path,$*)
 	wasm-pack build --target bundler --out-dir dist/bundler --out-name index $(call make-path,$*)
+	# Remove wasm-pack's generated `.gitignore` files; npm honours them when
+	# packing and would strip the build output from the published tarball.
+	find $(call make-path,$*)/dist -name .gitignore -exec rm -f {} +
 
 test-wasm-js-%:
 	wasm-pack test --node $(call make-path,$*) $(ARGS)


### PR DESCRIPTION
`wasm-pack` writes a `.gitignore` (`*`) into each `dist/` output dir. Since the package uses `files: ["dist"]` and has no `.npmignore`, npm honours those nested `.gitignore` files when packing and strips the build output — which is why `@solana/zk-sdk@0.5.0` published empty (7 files / 40 KB, no `.wasm`).

This removes the generated `.gitignore` files in `build-wasm-js-%` before packing.

Verified with `npm pack --dry-run`: 1 file → 4 files incl. the 2.7 MB `.wasm`.