### PR TITLE
zk-sdk-wasm-js: Add a conditional root export and serve Node the CJS build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ test-wasm-js-%:
 	wasm-pack test --headless --firefox $(call make-path,$*) --features test-browser $(ARGS)
 	wasm-pack test --headless --chrome $(call make-path,$*) --features test-browser $(ARGS)
 	pnpm i --dir $(call make-path,$*)/examples/node-integration && pnpm test --dir $(call make-path,$*)/examples/node-integration
+	pnpm i --dir $(call make-path,$*)/examples/node-esm-integration && pnpm test --dir $(call make-path,$*)/examples/node-esm-integration
 	pnpm i --dir $(call make-path,$*)/examples/web-integration && \
 		pnpm i --dir $(call make-path,$*)/examples/vite-integration && \
 		pnpm i --dir $(call make-path,$*)/examples/webpack-integration && \

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,12 @@ importers:
 
   zk-sdk-wasm-js: {}
 
+  zk-sdk-wasm-js/examples/node-esm-integration:
+    dependencies:
+      '@solana/zk-sdk':
+        specifier: file:../..
+        version: link:../..
+
   zk-sdk-wasm-js/examples/node-integration:
     dependencies:
       '@solana/zk-sdk':

--- a/zk-sdk-wasm-js/README.md
+++ b/zk-sdk-wasm-js/README.md
@@ -8,25 +8,25 @@ WebAssembly bindings for the Rust [`solana-zk-sdk`](https://github.com/solana-pr
 npm install @solana/zk-sdk
 ```
 
-The package ships three builds, one per `wasm-pack` target:
+The package ships three builds, one per `wasm-pack` target. Import the package root and the right one is selected for you; the subpaths are there when you need to pin a build explicitly:
 
 | Import | Target | Init |
 |---|---|---|
+| `@solana/zk-sdk` | anywhere — `node` gets the Node build, browser bundlers get the bundler build | none, ready on import |
 | `@solana/zk-sdk/node` | Node.js | none, ready on import |
 | `@solana/zk-sdk/web` | browser, no bundler | call the default `init()` once before use |
-| `@solana/zk-sdk/bundler` | Vite / webpack / etc. (package default) | none, the bundler loads the wasm |
+| `@solana/zk-sdk/bundler` | Vite / webpack / etc. | none, the bundler loads the wasm |
 
 ```js
-// Node
-import { ConfidentialKeys } from "@solana/zk-sdk/node";
-
-// Bundler (Vite, webpack)
-import { ConfidentialKeys } from "@solana/zk-sdk/bundler";
+// Anywhere
+import { ConfidentialKeys } from "@solana/zk-sdk";
 
 // Browser without a bundler
 import init, { ConfidentialKeys } from "@solana/zk-sdk/web";
 await init();
 ```
+
+The `web` build is the one case the root export cannot pick for you: it needs an explicit `init()`, so import it by subpath. `@solana/zk-sdk/bundler` also resolves to the Node build under the `node` condition — the ESM bundler build cannot load its `.wasm` outside a bundler, so a Node runtime (including the server side of a bundled app) is always served the Node build.
 
 ## Confidential-balances key derivation
 
@@ -68,7 +68,7 @@ const publicSeed = ConfidentialKeys.pdaWalletPublicSeed(
 Passkey ECDSA signing is randomized by spec, so signature-based derivation is impossible on passkey authenticators. The PRF (`hmac-secret`) extension is deterministic by construction and is the only path. PRF must be enabled when the credential is **registered**; legacy credentials that predate it cannot be used.
 
 ```js
-import { ConfidentialKeys } from "@solana/zk-sdk/bundler";
+import { ConfidentialKeys } from "@solana/zk-sdk";
 
 // 1. One-time, at credential registration (pure WebAuthn, not this SDK).
 //    Enabling PRF here is mandatory.
@@ -104,7 +104,7 @@ const keys = ConfidentialKeys.fromPrf(new Uint8Array(prf));
 For a normal Solana wallet, derive from a single `signMessage` over the canonical message.
 
 ```js
-import { ConfidentialKeys } from "@solana/zk-sdk/web";
+import { ConfidentialKeys } from "@solana/zk-sdk";
 
 const message = ConfidentialKeys.signerMessage(tokenAccount.toBytes());
 const signature = await wallet.signMessage(message);   // 64-byte Ed25519 signature

--- a/zk-sdk-wasm-js/README.md
+++ b/zk-sdk-wasm-js/README.md
@@ -12,13 +12,13 @@ The package ships three builds, one per `wasm-pack` target. Import the package r
 
 | Import | Target | Init |
 |---|---|---|
-| `@solana/zk-sdk` | anywhere — `node` gets the Node build, browser bundlers get the bundler build | none, ready on import |
+| `@solana/zk-sdk` | Node and bundlers — `node` gets the Node build, browser bundlers get the bundler build | none, ready on import |
 | `@solana/zk-sdk/node` | Node.js | none, ready on import |
 | `@solana/zk-sdk/web` | browser, no bundler | call the default `init()` once before use |
 | `@solana/zk-sdk/bundler` | Vite / webpack / etc. | none, the bundler loads the wasm |
 
 ```js
-// Anywhere
+// Node or a bundler
 import { ConfidentialKeys } from "@solana/zk-sdk";
 
 // Browser without a bundler

--- a/zk-sdk-wasm-js/examples/node-esm-integration/README.md
+++ b/zk-sdk-wasm-js/examples/node-esm-integration/README.md
@@ -4,7 +4,7 @@ Native ESM (`"type": "module"`) counterpart of `../node-integration`. It covers 
 imports a Node ESM consumer actually writes: the root `@solana/zk-sdk` specifier, and
 `@solana/zk-sdk/bundler` as imported by packages like `@solana-program/token-2022`.
 
-You must first build the WASM artifacts. From the root directory of the WASM crate (`zk-sdk-wasm-js`):
+You must first build the WASM artifacts. From this directory:
 
 ```bash
 make -C ../../.. build-wasm-js-zk-sdk-wasm-js

--- a/zk-sdk-wasm-js/examples/node-esm-integration/README.md
+++ b/zk-sdk-wasm-js/examples/node-esm-integration/README.md
@@ -1,0 +1,23 @@
+## How to Run
+
+Native ESM (`"type": "module"`) counterpart of `../node-integration`. It covers the
+imports a Node ESM consumer actually writes: the root `@solana/zk-sdk` specifier, and
+`@solana/zk-sdk/bundler` as imported by packages like `@solana-program/token-2022`.
+
+You must first build the WASM artifacts. From the root directory of the WASM crate (`zk-sdk-wasm-js`):
+
+```bash
+make -C ../../.. build-wasm-js-zk-sdk-wasm-js
+```
+
+Install the dependencies:
+
+```bash
+pnpm install
+```
+
+Run the test script:
+
+```bash
+pnpm test
+```

--- a/zk-sdk-wasm-js/examples/node-esm-integration/index.test.js
+++ b/zk-sdk-wasm-js/examples/node-esm-integration/index.test.js
@@ -1,14 +1,24 @@
 import assert from "assert";
-// The root export: no build hardcoded, resolved by condition.
-import { PubkeyValidityProofData, ElGamalKeypair } from "@solana/zk-sdk";
-// The bundler subpath, which packages such as `@solana-program/token-2022`
-// import directly. Under the `node` condition it must serve the Node build,
-// or it fails to load (`ERR_UNKNOWN_FILE_EXTENSION` on the `.wasm`).
-import { ElGamalKeypair as BundlerElGamalKeypair } from "@solana/zk-sdk/bundler";
 
 console.log("--- Running Node.js (ESM) integration tests ---");
 
 try {
+  // Dynamic imports, so a resolution failure lands in the catch below with a
+  // readable message instead of an uncaught `ERR_*` before this file runs.
+
+  // The root export: no build hardcoded, resolved by condition.
+  const { PubkeyValidityProofData, ElGamalKeypair } =
+    await import("@solana/zk-sdk");
+  // The bundler subpath, which packages such as `@solana-program/token-2022`
+  // import directly. Under the `node` condition it must serve the Node build,
+  // or it fails to load (`ERR_UNKNOWN_FILE_EXTENSION` on the `.wasm`).
+  const { ElGamalKeypair: BundlerElGamalKeypair } =
+    await import("@solana/zk-sdk/bundler");
+  // The Node subpath, which an app may pin explicitly while a dependency still
+  // imports `/bundler` — the mixed case that happens in practice.
+  const { ElGamalKeypair: NodeElGamalKeypair } =
+    await import("@solana/zk-sdk/node");
+
   const keypair = new ElGamalKeypair();
   assert.ok(keypair, "Keypair creation failed");
 
@@ -17,7 +27,7 @@ try {
 
   proof.verify();
 
-  // Both specifiers must resolve to the same build, so the WASM module is
+  // All three specifiers must resolve to the same build, so the WASM module is
   // instantiated once and class identities match across them. A second
   // instance shows up as `expected instance of ElGamalKeypair` when a keypair
   // from one is passed to the other.
@@ -26,9 +36,17 @@ try {
     BundlerElGamalKeypair,
     "Root and bundler imports resolved to different WASM instances",
   );
+  assert.strictEqual(
+    ElGamalKeypair,
+    NodeElGamalKeypair,
+    "Root and node imports resolved to different WASM instances",
+  );
 
   const bundlerKeypair = new BundlerElGamalKeypair();
   new PubkeyValidityProofData(bundlerKeypair).verify();
+
+  const nodeKeypair = new NodeElGamalKeypair();
+  new PubkeyValidityProofData(nodeKeypair).verify();
 
   console.log("✅ Node.js (ESM) integration tests passed!");
 } catch (error) {

--- a/zk-sdk-wasm-js/examples/node-esm-integration/index.test.js
+++ b/zk-sdk-wasm-js/examples/node-esm-integration/index.test.js
@@ -1,0 +1,37 @@
+import assert from "assert";
+// The root export: no build hardcoded, resolved by condition.
+import { PubkeyValidityProofData, ElGamalKeypair } from "@solana/zk-sdk";
+// The bundler subpath, which packages such as `@solana-program/token-2022`
+// import directly. Under the `node` condition it must serve the Node build,
+// or it fails to load (`ERR_UNKNOWN_FILE_EXTENSION` on the `.wasm`).
+import { ElGamalKeypair as BundlerElGamalKeypair } from "@solana/zk-sdk/bundler";
+
+console.log("--- Running Node.js (ESM) integration tests ---");
+
+try {
+  const keypair = new ElGamalKeypair();
+  assert.ok(keypair, "Keypair creation failed");
+
+  const proof = new PubkeyValidityProofData(keypair);
+  assert.ok(proof, "Proof creation failed");
+
+  proof.verify();
+
+  // Both specifiers must resolve to the same build, so the WASM module is
+  // instantiated once and class identities match across them. A second
+  // instance shows up as `expected instance of ElGamalKeypair` when a keypair
+  // from one is passed to the other.
+  assert.strictEqual(
+    ElGamalKeypair,
+    BundlerElGamalKeypair,
+    "Root and bundler imports resolved to different WASM instances",
+  );
+
+  const bundlerKeypair = new BundlerElGamalKeypair();
+  new PubkeyValidityProofData(bundlerKeypair).verify();
+
+  console.log("✅ Node.js (ESM) integration tests passed!");
+} catch (error) {
+  console.error("❌ Node.js (ESM) integration tests failed:", error);
+  process.exit(1);
+}

--- a/zk-sdk-wasm-js/examples/node-esm-integration/package.json
+++ b/zk-sdk-wasm-js/examples/node-esm-integration/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "example-node-esm-integration",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node index.test.js"
+  },
+  "dependencies": {
+    "@solana/zk-sdk": "file:../.."
+  }
+}

--- a/zk-sdk-wasm-js/examples/node-integration/README.md
+++ b/zk-sdk-wasm-js/examples/node-integration/README.md
@@ -1,6 +1,6 @@
 ## How to Run
 
-You must first build the WASM artifacts. From the root directory of the WASM crate (`zk-sdk-wasm-js`):
+You must first build the WASM artifacts. From this directory:
 
 ```bash
 make -C ../../.. build-wasm-js-zk-sdk-wasm-js

--- a/zk-sdk-wasm-js/package.json
+++ b/zk-sdk-wasm-js/package.json
@@ -6,9 +6,24 @@
   "files": [
     "dist"
   ],
+  "main": "./dist/node/index.js",
   "types": "./dist/node/index.d.ts",
   "browser": "./dist/bundler/index.js",
   "exports": {
+    ".": {
+      "node": {
+        "types": "./dist/node/index.d.ts",
+        "default": "./dist/node/index.js"
+      },
+      "browser": {
+        "types": "./dist/bundler/index.d.ts",
+        "default": "./dist/bundler/index.js"
+      },
+      "default": {
+        "types": "./dist/bundler/index.d.ts",
+        "default": "./dist/bundler/index.js"
+      }
+    },
     "./node": {
       "import": "./dist/node/index.js",
       "require": "./dist/node/index.js",
@@ -20,9 +35,13 @@
       "types": "./dist/web/index.d.ts"
     },
     "./bundler": {
+      "node": {
+        "types": "./dist/node/index.d.ts",
+        "default": "./dist/node/index.js"
+      },
+      "types": "./dist/bundler/index.d.ts",
       "import": "./dist/bundler/index.js",
-      "default": "./dist/bundler/index.js",
-      "types": "./dist/bundler/index.d.ts"
+      "default": "./dist/bundler/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
#### Problem

`@solana/zk-sdk` ships three mutually exclusive wasm-bindgen builds -- `./node` (CJS, loads the wasm through `fs`), `./web` (`fetch`, browser only) and `./bundler` (ESM `import ... from './index_bg.wasm'`) -- and no root export. There is therefore no specifier a library can import that works in both Node and the browser: every consumer has to hardcode one environment.

`@solana-program/token-2022` hardcodes `@solana/zk-sdk/bundler`, which cannot load under Node:

    import { ElGamalKeypair } from '@solana/zk-sdk/bundler';
    TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".wasm"

Forcing `--experimental-wasm-modules` on does not fix it -- it instantiates a second wasm module whose class identities do not match the `./node` build, so a keypair derived through one is rejected by the other ("expected instance of ElGamalKeypair"). Every Node consumer of token-2022's confidential features (CLIs, backends, scripts, tests) is affected. The resolution matrix under Node ESM today:

    @solana/zk-sdk          -> ERR_PACKAGE_PATH_NOT_EXPORTED
    @solana/zk-sdk/bundler  -> ERR_UNKNOWN_FILE_EXTENSION
    @solana/zk-sdk/web      -> loads, wasm never initializes (`fetch` cannot
                               read `file:`)
    @solana/zk-sdk/node     -> works

`examples/node-integration/` shows Node is an intended target; it is CJS and requires `./node` directly, which is why the gap was never caught here.

#### Summary of changes

Add a conditional root `.` export: the `node` condition resolves to the Node build, `browser` (set by webpack, Vite and friends) to the bundler build, and `default` to the bundler build as well. `web` stays subpath-only because it requires an explicit `init()` and would otherwise hand back an uninitialized module. The three existing subpaths are untouched, so this half is purely additive.

Give `./bundler` a `node` condition too, resolving to the Node build. The ESM wasm build cannot load in a Node runtime under any circumstance, so the only behaviours available at that specifier are "works" or "throws"; this also serves SSR, where webpack and Vite set the `node` condition and want the Node build. It means existing consumers such as token-2022 are fixed by this release alone, with no changes on their side. Both conditions nest `types` alongside the JS so the declaration flavour always matches the file served -- without that, `attw` reports the `./bundler` node branch as "masquerading as ESM".

Add `"main"` for `moduleResolution: node10` consumers, which previously failed to resolve the root at all. It points at the Node build, which is safe under the package's `"type": "module"` because wasm-pack writes a `dist/node/package.json` with no `"type"` field, scoping that directory to CommonJS.

Add `examples/node-esm-integration/`, a native-ESM counterpart to the existing CJS example, and wire it into `make test-wasm-js-%`. It imports the root specifier and `./bundler`, and asserts that the two resolve to the same class, which pins the single-wasm-instance property the dual-instance failure above violates. Both errors quoted in Problem reproduce with this test against the current exports map.

Finally, document the root import in the README and keep `./web` as the explicit-`init()` exception.