### PR TITLE
feat!: Standardize key derivation on the wallet with a no-seed API

### DIFF
--- a/zk-sdk-wasm-js/README.md
+++ b/zk-sdk-wasm-js/README.md
@@ -50,9 +50,9 @@ const ae = keys.ae();           // AeKey
 
 ### The `public_seed`
 
-`signerMessage` and `prfInput` both take a caller-chosen `public_seed` that scopes the derivation. It is granularity-agnostic: pass a token-account pubkey for per-account keys, or a wallet pubkey for one key across all of a wallet's accounts. The SDK does not enforce a convention, but two wallets must agree on it (and on which adapter they use) to derive the same keys for the same account.
+`signerMessage` and `prfInput` both take a caller-chosen `public_seed` that scopes the derivation. The standard is an **empty seed** (`new Uint8Array(0)`): the derived keys are bound to the wallet alone, one key pair covering all of the wallet's confidential accounts, and they match what the Token-2022 clients and the confidential-transfer docs derive for the same wallet. Two wallets derive the same keys for the same account only if they use the same seed (and the same adapter), which is exactly why the empty seed is the standard.
 
-For single-signer PDA wallets, use `pdaWalletPublicSeed` to bind the derived keys to the wallet program, wallet PDA, mint, and concrete token account:
+A non-empty seed (e.g. a token-account pubkey for per-account keys) is still accepted for callers that need finer granularity, at the cost of that cross-client agreement. For single-signer PDA wallets specifically, use `pdaWalletPublicSeed` to bind the derived keys to the wallet program, wallet PDA, mint, and concrete token account:
 
 ```js
 const publicSeed = ConfidentialKeys.pdaWalletPublicSeed(
@@ -78,7 +78,7 @@ const cred = await navigator.credentials.create({
 const credentialId = new Uint8Array(cred.rawId);
 
 // 2. Per session: evaluate the PRF over our canonical input, then derive.
-const publicSeed = tokenAccount.toBytes();           // your granularity choice
+const publicSeed = new Uint8Array(0);                // standard: wallet-only keys
 const salt = ConfidentialKeys.prfInput(publicSeed);
 
 const assertion = await navigator.credentials.get({
@@ -106,7 +106,7 @@ For a normal Solana wallet, derive from a single `signMessage` over the canonica
 ```js
 import { ConfidentialKeys } from "@solana/zk-sdk";
 
-const message = ConfidentialKeys.signerMessage(tokenAccount.toBytes());
+const message = ConfidentialKeys.signerMessage(new Uint8Array(0));
 const signature = await wallet.signMessage(message);   // 64-byte Ed25519 signature
 const keys = ConfidentialKeys.fromSignature(signature);
 ```

--- a/zk-sdk-wasm-js/README.md
+++ b/zk-sdk-wasm-js/README.md
@@ -40,7 +40,7 @@ There is one entry point per source of key material. Pick the one that matches h
 | Ed25519 wallet signature | `signerMessage` + `fromSignature` | today's universal wallet path |
 | Raw input key material | `fromIkm` | Secure Enclave / KMS HMAC, BIP39 seed, etc. |
 
-All three converge on the same spine, so `fromSignature(sig)`, `fromIkm(bytes)`, and `fromPrf(out)` over the same input bytes produce identical keys. In practice different adapters never produce the same input bytes for the same wallet; see the interchangeability note under The standard message.
+All three converge on the same spine, so `fromSignature(sig)`, `fromIkm(bytes)`, and `fromPrf(out)` over the same input bytes produce identical keys.
 
 ```js
 const keys = ConfidentialKeys.fromPrf(prfOutput);
@@ -50,11 +50,11 @@ const ae = keys.ae();           // AeKey
 
 ### The standard message
 
-`signerMessage()` and `prfInput()` take no arguments (passing one throws) and return the constant standard message, the bytes `solana-conf-bal/v1`. The derived keys are bound to the wallet alone: one key pair covering all of the wallet's confidential accounts. There is nothing to configure, which is the point: every standard client derives the same message because none of them can pass a different seed by accident.
+`signerMessage()` and `prfInput()` take no arguments and return the constant standard message, the bytes `solana-conf-bal/v1`. Passing a seed throws; seed-scoped derivation lives in `signerMessageWithSeed` and `prfInputWithSeed`. The derived keys are bound to the wallet alone, one key pair for all of the wallet's confidential accounts.
 
-The cross-SDK guarantee (byte-identical keys to the Token-2022 clients, the Rust and Go SDKs, and the confidential-transfer docs) applies to the canonical deterministic Ed25519 signing path: the same wallet key signing the same constant message. The adapters are not interchangeable with each other: a WebAuthn PRF evaluation and an Ed25519 signature over the same message produce different input key material and therefore different keys, and PRF/raw-IKM keys are reproducible only while the same credential or key material is used. Pick one adapter per account at provisioning and keep it.
+Keys match the other SDKs (the Token-2022 clients, Rust, Go) on the deterministic Ed25519 path, since they all sign the same constant message with the same wallet key. The PRF and raw-IKM paths feed different input material into the KDF, so they derive different keys for the same wallet and reproduce them only from the same credential or key material. An account keeps whichever adapter provisioned it.
 
-Wallets SHOULD refuse to sign any message starting with `solana-conf-bal/v1` through generic `signMessage` and expose the derivation signature only via a dedicated key-derivation capability: a signature over the derivation message is equivalent to handing out the account's decryption keys.
+Wallets SHOULD refuse to sign any message starting with `solana-conf-bal/v1` through generic `signMessage` and expose the derivation signature only via a dedicated key-derivation capability, since the signature is the account's decryption key material.
 
 ### Non-standard seed scoping
 
@@ -117,7 +117,7 @@ const signature = await wallet.signMessage(message);   // 64-byte Ed25519 signat
 const keys = ConfidentialKeys.fromSignature(signature);
 ```
 
-`wallet.signMessage` here stands for however the integration obtains the derivation signature. A wallet that implements the refusal recommendation above exposes this signature through a dedicated key-derivation capability rather than its generic `signMessage`; a filesystem or server-side signer signs the raw bytes directly. Reproducible derivation additionally requires the signer to be deterministic (RFC 8032) over these exact bytes: a randomized Ed25519 implementation returns a different valid signature each call and therefore different keys.
+`wallet.signMessage` stands in for whatever signing capability the integration has; a wallet that implements the refusal above provides this signature through a dedicated derivation API instead, and a filesystem or server signer just signs the bytes. The signer must be deterministic (RFC 8032): a randomized one returns a different signature, and different keys, on every call.
 
 The all-zero (default) signature is rejected: some signers return it instead of raising an error, and the resulting keys would be predictable.
 

--- a/zk-sdk-wasm-js/README.md
+++ b/zk-sdk-wasm-js/README.md
@@ -48,11 +48,15 @@ const elgamal = keys.elgamal(); // ElGamalKeypair
 const ae = keys.ae();           // AeKey
 ```
 
-### The `public_seed`
+### The standard message
 
-`signerMessage` and `prfInput` both take a caller-chosen `public_seed` that scopes the derivation. The standard is an **empty seed** (`new Uint8Array(0)`): the derived keys are bound to the wallet alone, one key pair covering all of the wallet's confidential accounts, and they match what the Token-2022 clients and the confidential-transfer docs derive for the same wallet. Two wallets derive the same keys for the same account only if they use the same seed (and the same adapter), which is exactly why the empty seed is the standard.
+`signerMessage()` and `prfInput()` take no arguments and return the constant standard message, the bytes `solana-conf-bal/v1`. The derived keys are bound to the wallet alone: one key pair covering all of the wallet's confidential accounts, byte-identical to what the Token-2022 clients, the Rust and Go SDKs, and the confidential-transfer docs derive for the same wallet. There is nothing to configure, which is the point: every standard client derives the same keys because none of them can pass a different seed by accident.
 
-A non-empty seed (e.g. a token-account pubkey for per-account keys) is still accepted for callers that need finer granularity, at the cost of that cross-client agreement. For single-signer PDA wallets specifically, use `pdaWalletPublicSeed` to bind the derived keys to the wallet program, wallet PDA, mint, and concrete token account:
+Wallets SHOULD refuse to sign any message starting with `solana-conf-bal/v1` through generic `signMessage` and expose derivation only via a dedicated flow: a signature over the derivation message is equivalent to handing out the account's decryption keys.
+
+### Non-standard seed scoping
+
+`signerMessageWithSeed(seed)` and `prfInputWithSeed(seed)` build `solana-conf-bal/v1 || seed` for schemes that genuinely need keys scoped more finely than the wallet. Keys derived from a non-empty seed will not match the standard keys other clients derive for the same wallet. For single-signer PDA wallets specifically, use `pdaWalletPublicSeed` to bind the derived keys to the wallet program, wallet PDA, mint, and concrete token account:
 
 ```js
 const publicSeed = ConfidentialKeys.pdaWalletPublicSeed(
@@ -61,6 +65,7 @@ const publicSeed = ConfidentialKeys.pdaWalletPublicSeed(
   mint.toBytes(),
   tokenAccount.toBytes(),
 );
+const message = ConfidentialKeys.signerMessageWithSeed(publicSeed);
 ```
 
 ### Passkeys (WebAuthn PRF)
@@ -77,9 +82,8 @@ const cred = await navigator.credentials.create({
 });
 const credentialId = new Uint8Array(cred.rawId);
 
-// 2. Per session: evaluate the PRF over our canonical input, then derive.
-const publicSeed = new Uint8Array(0);                // standard: wallet-only keys
-const salt = ConfidentialKeys.prfInput(publicSeed);
+// 2. Per session: evaluate the PRF over the standard input, then derive.
+const salt = ConfidentialKeys.prfInput();
 
 const assertion = await navigator.credentials.get({
   publicKey: {
@@ -97,16 +101,16 @@ const keys = ConfidentialKeys.fromPrf(new Uint8Array(prf));
 
 `fromPrf` accepts a 32-byte output (a single `prf.results.first`) or a 64-byte output (`first || second` concatenated), and rejects an all-zero result.
 
-`prfInput` returns the canonical message `solana-conf-bal/v1 || public_seed`, byte-identical to `signerMessage`. It is passed to `prf.eval.first` as-is: browsers apply the mandatory `SHA-256("WebAuthn PRF" || 0x00 || input)` prefixing before the authenticator, so the input length is unconstrained and must not be pre-hashed. A non-browser or direct-CTAP `hmac-secret` consumer must reproduce that prefixing over this message to derive matching keys.
+`prfInput` returns the standard message `solana-conf-bal/v1`, byte-identical to `signerMessage` (`prfInputWithSeed` mirrors `signerMessageWithSeed` for non-standard scoping). It is passed to `prf.eval.first` as-is: browsers apply the mandatory `SHA-256("WebAuthn PRF" || 0x00 || input)` prefixing before the authenticator, so the input must not be pre-hashed. A non-browser or direct-CTAP `hmac-secret` consumer must reproduce that prefixing over this message to derive matching keys.
 
 ### Ed25519 wallet signature
 
-For a normal Solana wallet, derive from a single `signMessage` over the canonical message.
+For a normal Solana wallet, derive from a single `signMessage` over the standard message.
 
 ```js
 import { ConfidentialKeys } from "@solana/zk-sdk";
 
-const message = ConfidentialKeys.signerMessage(new Uint8Array(0));
+const message = ConfidentialKeys.signerMessage();      // constant: "solana-conf-bal/v1"
 const signature = await wallet.signMessage(message);   // 64-byte Ed25519 signature
 const keys = ConfidentialKeys.fromSignature(signature);
 ```

--- a/zk-sdk-wasm-js/README.md
+++ b/zk-sdk-wasm-js/README.md
@@ -40,7 +40,7 @@ There is one entry point per source of key material. Pick the one that matches h
 | Ed25519 wallet signature | `signerMessage` + `fromSignature` | today's universal wallet path |
 | Raw input key material | `fromIkm` | Secure Enclave / KMS HMAC, BIP39 seed, etc. |
 
-All three converge on the same spine, so `fromSignature(sig)`, `fromIkm(bytes)`, and `fromPrf(out)` over the same bytes produce identical keys.
+All three converge on the same spine, so `fromSignature(sig)`, `fromIkm(bytes)`, and `fromPrf(out)` over the same input bytes produce identical keys. In practice different adapters never produce the same input bytes for the same wallet; see the interchangeability note under The standard message.
 
 ```js
 const keys = ConfidentialKeys.fromPrf(prfOutput);
@@ -50,9 +50,11 @@ const ae = keys.ae();           // AeKey
 
 ### The standard message
 
-`signerMessage()` and `prfInput()` take no arguments and return the constant standard message, the bytes `solana-conf-bal/v1`. The derived keys are bound to the wallet alone: one key pair covering all of the wallet's confidential accounts, byte-identical to what the Token-2022 clients, the Rust and Go SDKs, and the confidential-transfer docs derive for the same wallet. There is nothing to configure, which is the point: every standard client derives the same keys because none of them can pass a different seed by accident.
+`signerMessage()` and `prfInput()` take no arguments (passing one throws) and return the constant standard message, the bytes `solana-conf-bal/v1`. The derived keys are bound to the wallet alone: one key pair covering all of the wallet's confidential accounts. There is nothing to configure, which is the point: every standard client derives the same message because none of them can pass a different seed by accident.
 
-Wallets SHOULD refuse to sign any message starting with `solana-conf-bal/v1` through generic `signMessage` and expose derivation only via a dedicated flow: a signature over the derivation message is equivalent to handing out the account's decryption keys.
+The cross-SDK guarantee (byte-identical keys to the Token-2022 clients, the Rust and Go SDKs, and the confidential-transfer docs) applies to the canonical deterministic Ed25519 signing path: the same wallet key signing the same constant message. The adapters are not interchangeable with each other: a WebAuthn PRF evaluation and an Ed25519 signature over the same message produce different input key material and therefore different keys, and PRF/raw-IKM keys are reproducible only while the same credential or key material is used. Pick one adapter per account at provisioning and keep it.
+
+Wallets SHOULD refuse to sign any message starting with `solana-conf-bal/v1` through generic `signMessage` and expose the derivation signature only via a dedicated key-derivation capability: a signature over the derivation message is equivalent to handing out the account's decryption keys.
 
 ### Non-standard seed scoping
 
@@ -105,7 +107,7 @@ const keys = ConfidentialKeys.fromPrf(new Uint8Array(prf));
 
 ### Ed25519 wallet signature
 
-For a normal Solana wallet, derive from a single `signMessage` over the standard message.
+For a normal Solana wallet, derive from a single deterministic Ed25519 signature over the standard message.
 
 ```js
 import { ConfidentialKeys } from "@solana/zk-sdk";
@@ -114,6 +116,8 @@ const message = ConfidentialKeys.signerMessage();      // constant: "solana-conf
 const signature = await wallet.signMessage(message);   // 64-byte Ed25519 signature
 const keys = ConfidentialKeys.fromSignature(signature);
 ```
+
+`wallet.signMessage` here stands for however the integration obtains the derivation signature. A wallet that implements the refusal recommendation above exposes this signature through a dedicated key-derivation capability rather than its generic `signMessage`; a filesystem or server-side signer signs the raw bytes directly. Reproducible derivation additionally requires the signer to be deterministic (RFC 8032) over these exact bytes: a randomized Ed25519 implementation returns a different valid signature each call and therefore different keys.
 
 The all-zero (default) signature is rejected: some signers return it instead of raising an error, and the resulting keys would be predictable.
 

--- a/zk-sdk-wasm-js/README.md
+++ b/zk-sdk-wasm-js/README.md
@@ -50,7 +50,7 @@ const ae = keys.ae();           // AeKey
 
 ### The standard message
 
-`signerMessage()` and `prfInput()` take no arguments and return the constant standard message, the bytes `solana-conf-bal/v1`. Passing a seed throws; seed-scoped derivation lives in `signerMessageWithSeed` and `prfInputWithSeed`. The derived keys are bound to the wallet alone, one key pair for all of the wallet's confidential accounts.
+`signerMessage()` and `prfInput()` take no arguments and return the constant standard message, the bytes `solana-conf-bal/v1`. Seed-scoped derivation lives in `signerMessageWithSeed` and `prfInputWithSeed`. The derived keys are bound to the wallet alone, one key pair for all of the wallet's confidential accounts.
 
 Keys match the other SDKs (the Token-2022 clients, Rust, Go) on the deterministic Ed25519 path, since they all sign the same constant message with the same wallet key. The PRF and raw-IKM paths feed different input material into the KDF, so they derive different keys for the same wallet and reproduce them only from the same credential or key material. An account keeps whichever adapter provisioned it.
 

--- a/zk-sdk-wasm-js/src/encryption/derivation.rs
+++ b/zk-sdk-wasm-js/src/encryption/derivation.rs
@@ -52,9 +52,11 @@ impl ConfidentialKeys {
     /// `fromSignature`.
     ///
     /// The message is `b"solana-conf-bal/v1" || public_seed`. `public_seed`
-    /// is caller-controlled and granularity-agnostic; pass a wallet pubkey
-    /// for per-wallet keying or a token-account pubkey for per-account
-    /// keying.
+    /// is caller-controlled; the standard is an empty seed, which binds the
+    /// derived keys to the signing wallet alone and matches the keys other
+    /// standard clients derive. Pass a non-empty seed (e.g. a token-account
+    /// pubkey) only when finer granularity is worth losing that cross-client
+    /// agreement.
     #[wasm_bindgen(js_name = "signerMessage")]
     pub fn signer_message(public_seed: Uint8Array) -> Vec<u8> {
         confidential_derivation_message(&public_seed.to_vec())

--- a/zk-sdk-wasm-js/src/encryption/derivation.rs
+++ b/zk-sdk-wasm-js/src/encryption/derivation.rs
@@ -52,9 +52,9 @@ impl ConfidentialKeys {
     /// `solana-conf-bal/v1` a Solana wallet signs once to derive its
     /// `ConfidentialKeys` pair via `fromSignature`.
     ///
-    /// The derived keys are bound to the signing wallet alone — one ElGamal
+    /// The derived keys are bound to the signing wallet alone (one ElGamal
     /// keypair and one AES key across all of the wallet's mints and token
-    /// accounts — and match what every other standard client derives for the
+    /// accounts) and match what every other standard client derives for the
     /// same wallet.
     ///
     /// Wallets SHOULD recognize these exact bytes, expose the signature only

--- a/zk-sdk-wasm-js/src/encryption/derivation.rs
+++ b/zk-sdk-wasm-js/src/encryption/derivation.rs
@@ -62,9 +62,18 @@ impl ConfidentialKeys {
     /// `signMessage` request whose message starts with this prefix: the
     /// resulting signature is the input key material for the wallet's
     /// confidential-balance decryption keys.
+    ///
+    /// Takes no arguments; passing one throws. JavaScript otherwise drops
+    /// extra arguments silently, so a caller on the pre-rename seeded
+    /// convention would derive different keys than intended without noticing.
     #[wasm_bindgen(js_name = "signerMessage")]
-    pub fn signer_message() -> Vec<u8> {
-        STANDARD_DERIVATION_MESSAGE.to_vec()
+    pub fn signer_message(unexpected_seed: Option<Uint8Array>) -> Result<Vec<u8>, JsValue> {
+        if unexpected_seed.is_some() {
+            return Err(JsValue::from_str(
+                "signerMessage takes no arguments; for seed-scoped (non-standard) derivation use signerMessageWithSeed",
+            ));
+        }
+        Ok(STANDARD_DERIVATION_MESSAGE.to_vec())
     }
 
     /// Returns the non-standard, seed-scoped derivation message:
@@ -91,9 +100,17 @@ impl ConfidentialKeys {
     /// prefixing before the authenticator, so this message is passed as-is.
     /// Non-browser / direct-CTAP `hmac-secret` consumers MUST reproduce that
     /// prefixing over this message to derive byte-identical keys.
+    ///
+    /// Takes no arguments; passing one throws (see `signerMessage`). For
+    /// seed-scoped PRF input use `prfInputWithSeed`.
     #[wasm_bindgen(js_name = "prfInput")]
-    pub fn prf_input() -> Vec<u8> {
-        STANDARD_DERIVATION_MESSAGE.to_vec()
+    pub fn prf_input(unexpected_seed: Option<Uint8Array>) -> Result<Vec<u8>, JsValue> {
+        if unexpected_seed.is_some() {
+            return Err(JsValue::from_str(
+                "prfInput takes no arguments; for seed-scoped (non-standard) derivation use prfInputWithSeed",
+            ));
+        }
+        Ok(STANDARD_DERIVATION_MESSAGE.to_vec())
     }
 
     /// Returns the non-standard, seed-scoped WebAuthn PRF evaluation input:
@@ -227,12 +244,22 @@ mod tests {
         // The standard message is the bare protocol identifier: what a wallet
         // signs once to derive its wallet-level keys, and the exact prefix
         // wallets should refuse through generic signMessage.
-        let msg = ConfidentialKeys::signer_message();
+        let msg = ConfidentialKeys::signer_message(None).unwrap();
         assert_eq!(msg, b"solana-conf-bal/v1");
         assert_eq!(
             msg,
             ConfidentialKeys::signer_message_with_seed(Uint8Array::from([].as_ref()))
         );
+    }
+
+    #[wasm_bindgen_test]
+    fn test_standard_messages_reject_a_seed_argument() {
+        // JavaScript drops extra arguments silently, so the pre-rename seeded
+        // calling convention must fail loudly instead of deriving the
+        // standard keys.
+        let seed = Uint8Array::from([7u8; 32].as_ref());
+        assert!(ConfidentialKeys::signer_message(Some(seed.clone())).is_err());
+        assert!(ConfidentialKeys::prf_input(Some(seed)).is_err());
     }
 
     #[wasm_bindgen_test]
@@ -338,8 +365,8 @@ mod tests {
         // The passkey PRF input is the same canonical message as the Ed25519
         // signing path, in both the standard and the seeded variants.
         assert_eq!(
-            ConfidentialKeys::prf_input(),
-            ConfidentialKeys::signer_message()
+            ConfidentialKeys::prf_input(None).unwrap(),
+            ConfidentialKeys::signer_message(None).unwrap()
         );
 
         let seed = [9u8; 32];

--- a/zk-sdk-wasm-js/src/encryption/derivation.rs
+++ b/zk-sdk-wasm-js/src/encryption/derivation.rs
@@ -6,6 +6,7 @@ use {
         confidential_derivation_message, derive_confidential_keys_from_ikm,
         derive_confidential_keys_from_signature,
         pda_wallet_public_seed as sdk_pda_wallet_public_seed, PDA_WALLET_PUBLIC_SEED_FIELD_LEN,
+        STANDARD_DERIVATION_MESSAGE,
     },
     wasm_bindgen::prelude::{wasm_bindgen, JsValue},
 };
@@ -47,42 +48,67 @@ pub struct ConfidentialKeys {
 
 #[wasm_bindgen]
 impl ConfidentialKeys {
-    /// Returns the canonical derivation message a Solana signer must sign
-    /// in order to deterministically derive a `ConfidentialKeys` pair via
-    /// `fromSignature`.
+    /// Returns THE standard derivation message: the constant bytes
+    /// `solana-conf-bal/v1` a Solana wallet signs once to derive its
+    /// `ConfidentialKeys` pair via `fromSignature`.
     ///
-    /// The message is `b"solana-conf-bal/v1" || public_seed`. `public_seed`
-    /// is caller-controlled; the standard is an empty seed, which binds the
-    /// derived keys to the signing wallet alone and matches the keys other
-    /// standard clients derive. Pass a non-empty seed (e.g. a token-account
-    /// pubkey) only when finer granularity is worth losing that cross-client
-    /// agreement.
+    /// The derived keys are bound to the signing wallet alone — one ElGamal
+    /// keypair and one AES key across all of the wallet's mints and token
+    /// accounts — and match what every other standard client derives for the
+    /// same wallet.
+    ///
+    /// Wallets SHOULD recognize these exact bytes, expose the signature only
+    /// through a dedicated key-derivation API, and refuse any generic
+    /// `signMessage` request whose message starts with this prefix: the
+    /// resulting signature is the input key material for the wallet's
+    /// confidential-balance decryption keys.
     #[wasm_bindgen(js_name = "signerMessage")]
-    pub fn signer_message(public_seed: Uint8Array) -> Vec<u8> {
+    pub fn signer_message() -> Vec<u8> {
+        STANDARD_DERIVATION_MESSAGE.to_vec()
+    }
+
+    /// Returns the NON-STANDARD, seed-scoped derivation message:
+    /// `b"solana-conf-bal/v1" || public_seed`.
+    ///
+    /// Use this only for schemes that genuinely need keys scoped more finely
+    /// than the wallet (single-signer PDA wallets via `pdaWalletPublicSeed`,
+    /// custom application keying). Keys derived from a non-empty seed will NOT
+    /// match the standard keys other clients derive for the same wallet; for
+    /// standard wallet-level keys use `signerMessage`.
+    #[wasm_bindgen(js_name = "signerMessageWithSeed")]
+    pub fn signer_message_with_seed(public_seed: Uint8Array) -> Vec<u8> {
         confidential_derivation_message(&public_seed.to_vec())
     }
 
-    /// Returns the canonical WebAuthn PRF evaluation input for `fromPrf`.
+    /// Returns the standard WebAuthn PRF evaluation input for `fromPrf`:
+    /// byte-identical to `signerMessage` (the constant `solana-conf-bal/v1`).
     ///
-    /// Byte-identical to `signerMessage`: `b"solana-conf-bal/v1" || public_seed`.
     /// Pass it to the authenticator as the `prf.eval.first` salt. The same
     /// canonical message is signed in the Ed25519 path and PRF-evaluated in the
-    /// passkey path, so a single seed convention drives both adapters.
+    /// passkey path, so both adapters derive wallet-level keys by default.
     ///
     /// Browsers apply the mandatory `SHA-256("WebAuthn PRF" || 0x00 || input)`
-    /// prefixing before the authenticator, so this message is passed as-is and
-    /// may be any length. Non-browser / direct-CTAP `hmac-secret` consumers MUST
-    /// reproduce that prefixing over this message to derive byte-identical keys.
+    /// prefixing before the authenticator, so this message is passed as-is.
+    /// Non-browser / direct-CTAP `hmac-secret` consumers MUST reproduce that
+    /// prefixing over this message to derive byte-identical keys.
     #[wasm_bindgen(js_name = "prfInput")]
-    pub fn prf_input(public_seed: Uint8Array) -> Vec<u8> {
+    pub fn prf_input() -> Vec<u8> {
+        STANDARD_DERIVATION_MESSAGE.to_vec()
+    }
+
+    /// Returns the NON-STANDARD, seed-scoped WebAuthn PRF evaluation input:
+    /// byte-identical to `signerMessageWithSeed`. See `signerMessageWithSeed`
+    /// for when a seed is appropriate; see `prfInput` for the standard path.
+    #[wasm_bindgen(js_name = "prfInputWithSeed")]
+    pub fn prf_input_with_seed(public_seed: Uint8Array) -> Vec<u8> {
         confidential_derivation_message(&public_seed.to_vec())
     }
 
     /// Returns the canonical `public_seed` for single-signer PDA wallet accounts.
     ///
     /// The output is `program_id || wallet_pda || mint || token_account`.
-    /// Pass it to `signerMessage` or `prfInput` so PDA/passkey wallets use a
-    /// consistent seed convention across implementations.
+    /// Pass it to `signerMessageWithSeed` or `prfInputWithSeed` so PDA/passkey
+    /// wallets use a consistent seed convention across implementations.
     #[wasm_bindgen(js_name = "pdaWalletPublicSeed")]
     pub fn pda_wallet_public_seed(
         program_id: Uint8Array,
@@ -197,10 +223,23 @@ mod tests {
     use {super::*, solana_zk_sdk::encryption::derivation::HKDF_SALT, wasm_bindgen_test::*};
 
     #[wasm_bindgen_test]
-    fn test_signer_message_format() {
+    fn test_signer_message_is_standard_constant() {
+        // The standard message is the bare protocol identifier: what a wallet
+        // signs once to derive its wallet-level keys, and the exact prefix
+        // wallets should refuse through generic signMessage.
+        let msg = ConfidentialKeys::signer_message();
+        assert_eq!(msg, b"solana-conf-bal/v1");
+        assert_eq!(
+            msg,
+            ConfidentialKeys::signer_message_with_seed(Uint8Array::from([].as_ref()))
+        );
+    }
+
+    #[wasm_bindgen_test]
+    fn test_signer_message_with_seed_format() {
         let seed = [7u8; 32];
         let expected = [HKDF_SALT, seed.as_ref()].concat();
-        let msg = ConfidentialKeys::signer_message(Uint8Array::from(seed.as_ref()));
+        let msg = ConfidentialKeys::signer_message_with_seed(Uint8Array::from(seed.as_ref()));
         assert_eq!(msg, expected);
     }
 
@@ -209,10 +248,39 @@ mod tests {
         // Sanity-check that the message uses the SRFC-aligned protocol
         // identifier rather than a per-key magic string.
         let seed = [0u8; 32];
-        let msg = ConfidentialKeys::signer_message(Uint8Array::from(seed.as_ref()));
+        let msg = ConfidentialKeys::signer_message_with_seed(Uint8Array::from(seed.as_ref()));
         assert!(msg.starts_with(b"solana-conf-bal/v1"));
         assert!(!msg.starts_with(b"AeKey"));
         assert!(!msg.starts_with(b"ElGamalSecretKey"));
+    }
+
+    #[wasm_bindgen_test]
+    fn test_from_signature_standard_vector() {
+        // Canonical cross-SDK vector for the standard (wallet-level) path.
+        // The signature is ed25519_sign(seed = 0x1122...ff00 twice, message =
+        // signerMessage()); the expected keys are pinned identically in the
+        // zk-sdk Rust tests, the solana-go fixtures (keypair_a_empty_seed),
+        // and the Token-2022 JS client tests.
+        let signature: [u8; 64] = [
+            0x61, 0xdd, 0xf9, 0x56, 0xab, 0xdf, 0xb6, 0xe0, 0xc4, 0x4a, 0x3b, 0x81, 0x6f, 0x4b,
+            0x8d, 0xd4, 0x22, 0xbd, 0x99, 0x54, 0xaa, 0xea, 0x4d, 0xb4, 0xab, 0x6c, 0x5e, 0xf0,
+            0x7a, 0x61, 0x86, 0x1f, 0xa4, 0xd0, 0x28, 0xc8, 0x5d, 0x46, 0x3e, 0x6e, 0x95, 0xcb,
+            0xc9, 0xb9, 0xa5, 0xa3, 0xf5, 0x1f, 0x27, 0x2e, 0xab, 0x0f, 0x54, 0xf9, 0x1e, 0xda,
+            0x15, 0x93, 0x63, 0x8d, 0x25, 0xc5, 0xe8, 0x0b,
+        ];
+        let expected_ae: [u8; 16] = [
+            0x64, 0x17, 0xee, 0xdb, 0xcb, 0xe9, 0xc6, 0x4a, 0x72, 0x39, 0x57, 0x19, 0xec, 0x98,
+            0xcf, 0x6b,
+        ];
+        let expected_elgamal: [u8; 32] = [
+            0xbe, 0x5c, 0xce, 0x95, 0x1f, 0x42, 0xa2, 0xa8, 0x67, 0x7d, 0x1a, 0x56, 0xf0, 0x3a,
+            0xae, 0x7b, 0xff, 0x79, 0x5b, 0x38, 0xcf, 0x1c, 0x56, 0xc8, 0xcf, 0x3a, 0x4d, 0xae,
+            0x7d, 0x60, 0xe2, 0x05,
+        ];
+
+        let keys = ConfidentialKeys::from_signature(Uint8Array::from(signature.as_ref())).unwrap();
+        assert_eq!(keys.ae().to_bytes(), expected_ae);
+        assert_eq!(keys.elgamal().secret().to_bytes(), expected_elgamal);
     }
 
     #[wasm_bindgen_test]
@@ -268,10 +336,15 @@ mod tests {
     #[wasm_bindgen_test]
     fn test_prf_input_matches_signer_message() {
         // The passkey PRF input is the same canonical message as the Ed25519
-        // signing path, so a single seed convention drives both adapters.
+        // signing path, in both the standard and the seeded variants.
+        assert_eq!(
+            ConfidentialKeys::prf_input(),
+            ConfidentialKeys::signer_message()
+        );
+
         let seed = [9u8; 32];
-        let prf = ConfidentialKeys::prf_input(Uint8Array::from(seed.as_ref()));
-        let signer = ConfidentialKeys::signer_message(Uint8Array::from(seed.as_ref()));
+        let prf = ConfidentialKeys::prf_input_with_seed(Uint8Array::from(seed.as_ref()));
+        let signer = ConfidentialKeys::signer_message_with_seed(Uint8Array::from(seed.as_ref()));
         assert_eq!(prf, signer);
         assert!(prf.starts_with(b"solana-conf-bal/v1"));
     }

--- a/zk-sdk-wasm-js/src/encryption/derivation.rs
+++ b/zk-sdk-wasm-js/src/encryption/derivation.rs
@@ -48,7 +48,7 @@ pub struct ConfidentialKeys {
 
 #[wasm_bindgen]
 impl ConfidentialKeys {
-    /// Returns THE standard derivation message: the constant bytes
+    /// Returns the standard derivation message: the constant bytes
     /// `solana-conf-bal/v1` a Solana wallet signs once to derive its
     /// `ConfidentialKeys` pair via `fromSignature`.
     ///
@@ -67,7 +67,7 @@ impl ConfidentialKeys {
         STANDARD_DERIVATION_MESSAGE.to_vec()
     }
 
-    /// Returns the NON-STANDARD, seed-scoped derivation message:
+    /// Returns the non-standard, seed-scoped derivation message:
     /// `b"solana-conf-bal/v1" || public_seed`.
     ///
     /// Use this only for schemes that genuinely need keys scoped more finely
@@ -96,7 +96,7 @@ impl ConfidentialKeys {
         STANDARD_DERIVATION_MESSAGE.to_vec()
     }
 
-    /// Returns the NON-STANDARD, seed-scoped WebAuthn PRF evaluation input:
+    /// Returns the non-standard, seed-scoped WebAuthn PRF evaluation input:
     /// byte-identical to `signerMessageWithSeed`. See `signerMessageWithSeed`
     /// for when a seed is appropriate; see `prfInput` for the standard path.
     #[wasm_bindgen(js_name = "prfInputWithSeed")]

--- a/zk-sdk-wasm-js/src/encryption/derivation.rs
+++ b/zk-sdk-wasm-js/src/encryption/derivation.rs
@@ -63,16 +63,9 @@ impl ConfidentialKeys {
     /// resulting signature is the input key material for the wallet's
     /// confidential-balance decryption keys.
     ///
-    /// Throws if given an argument; seed-scoped derivation is
-    /// `signerMessageWithSeed`.
     #[wasm_bindgen(js_name = "signerMessage")]
-    pub fn signer_message(seed: Option<Uint8Array>) -> Result<Vec<u8>, JsValue> {
-        if seed.is_some() {
-            return Err(JsValue::from_str(
-                "signerMessage takes no seed; use signerMessageWithSeed",
-            ));
-        }
-        Ok(STANDARD_DERIVATION_MESSAGE.to_vec())
+    pub fn signer_message() -> Vec<u8> {
+        STANDARD_DERIVATION_MESSAGE.to_vec()
     }
 
     /// Returns the non-standard, seed-scoped derivation message:
@@ -100,16 +93,9 @@ impl ConfidentialKeys {
     /// Non-browser / direct-CTAP `hmac-secret` consumers MUST reproduce that
     /// prefixing over this message to derive byte-identical keys.
     ///
-    /// Throws if given an argument; seed-scoped PRF input is
-    /// `prfInputWithSeed`.
     #[wasm_bindgen(js_name = "prfInput")]
-    pub fn prf_input(seed: Option<Uint8Array>) -> Result<Vec<u8>, JsValue> {
-        if seed.is_some() {
-            return Err(JsValue::from_str(
-                "prfInput takes no seed; use prfInputWithSeed",
-            ));
-        }
-        Ok(STANDARD_DERIVATION_MESSAGE.to_vec())
+    pub fn prf_input() -> Vec<u8> {
+        STANDARD_DERIVATION_MESSAGE.to_vec()
     }
 
     /// Returns the non-standard, seed-scoped WebAuthn PRF evaluation input:
@@ -243,21 +229,12 @@ mod tests {
         // The standard message is the bare protocol identifier: what a wallet
         // signs once to derive its wallet-level keys, and the exact prefix
         // wallets should refuse through generic signMessage.
-        let msg = ConfidentialKeys::signer_message(None).unwrap();
+        let msg = ConfidentialKeys::signer_message();
         assert_eq!(msg, b"solana-conf-bal/v1");
         assert_eq!(
             msg,
             ConfidentialKeys::signer_message_with_seed(Uint8Array::from([].as_ref()))
         );
-    }
-
-    #[wasm_bindgen_test]
-    fn test_standard_messages_reject_a_seed_argument() {
-        // A stray seed argument must fail, not silently return the standard
-        // message.
-        let seed = Uint8Array::from([7u8; 32].as_ref());
-        assert!(ConfidentialKeys::signer_message(Some(seed.clone())).is_err());
-        assert!(ConfidentialKeys::prf_input(Some(seed)).is_err());
     }
 
     #[wasm_bindgen_test]
@@ -363,8 +340,8 @@ mod tests {
         // The passkey PRF input is the same canonical message as the Ed25519
         // signing path, in both the standard and the seeded variants.
         assert_eq!(
-            ConfidentialKeys::prf_input(None).unwrap(),
-            ConfidentialKeys::signer_message(None).unwrap()
+            ConfidentialKeys::prf_input(),
+            ConfidentialKeys::signer_message()
         );
 
         let seed = [9u8; 32];

--- a/zk-sdk-wasm-js/src/encryption/derivation.rs
+++ b/zk-sdk-wasm-js/src/encryption/derivation.rs
@@ -63,14 +63,13 @@ impl ConfidentialKeys {
     /// resulting signature is the input key material for the wallet's
     /// confidential-balance decryption keys.
     ///
-    /// Takes no arguments; passing one throws. JavaScript otherwise drops
-    /// extra arguments silently, so a caller on the pre-rename seeded
-    /// convention would derive different keys than intended without noticing.
+    /// Throws if given an argument; seed-scoped derivation is
+    /// `signerMessageWithSeed`.
     #[wasm_bindgen(js_name = "signerMessage")]
-    pub fn signer_message(unexpected_seed: Option<Uint8Array>) -> Result<Vec<u8>, JsValue> {
-        if unexpected_seed.is_some() {
+    pub fn signer_message(seed: Option<Uint8Array>) -> Result<Vec<u8>, JsValue> {
+        if seed.is_some() {
             return Err(JsValue::from_str(
-                "signerMessage takes no arguments; for seed-scoped (non-standard) derivation use signerMessageWithSeed",
+                "signerMessage takes no seed; use signerMessageWithSeed",
             ));
         }
         Ok(STANDARD_DERIVATION_MESSAGE.to_vec())
@@ -101,13 +100,13 @@ impl ConfidentialKeys {
     /// Non-browser / direct-CTAP `hmac-secret` consumers MUST reproduce that
     /// prefixing over this message to derive byte-identical keys.
     ///
-    /// Takes no arguments; passing one throws (see `signerMessage`). For
-    /// seed-scoped PRF input use `prfInputWithSeed`.
+    /// Throws if given an argument; seed-scoped PRF input is
+    /// `prfInputWithSeed`.
     #[wasm_bindgen(js_name = "prfInput")]
-    pub fn prf_input(unexpected_seed: Option<Uint8Array>) -> Result<Vec<u8>, JsValue> {
-        if unexpected_seed.is_some() {
+    pub fn prf_input(seed: Option<Uint8Array>) -> Result<Vec<u8>, JsValue> {
+        if seed.is_some() {
             return Err(JsValue::from_str(
-                "prfInput takes no arguments; for seed-scoped (non-standard) derivation use prfInputWithSeed",
+                "prfInput takes no seed; use prfInputWithSeed",
             ));
         }
         Ok(STANDARD_DERIVATION_MESSAGE.to_vec())
@@ -254,9 +253,8 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_standard_messages_reject_a_seed_argument() {
-        // JavaScript drops extra arguments silently, so the pre-rename seeded
-        // calling convention must fail loudly instead of deriving the
-        // standard keys.
+        // A stray seed argument must fail, not silently return the standard
+        // message.
         let seed = Uint8Array::from([7u8; 32].as_ref());
         assert!(ConfidentialKeys::signer_message(Some(seed.clone())).is_err());
         assert!(ConfidentialKeys::prf_input(Some(seed)).is_err());

--- a/zk-sdk/src/encryption/derivation.rs
+++ b/zk-sdk/src/encryption/derivation.rs
@@ -28,10 +28,14 @@
 //!               )
 //! ```
 //!
-//! `public_seed` in the signing path is caller-controlled and granularity-
-//! agnostic: pass a wallet pubkey for registry-aligned per-wallet keying, or
-//! a token-account pubkey for per-account keying. The SDK does not enforce
-//! either convention.
+//! `public_seed` in the signing path is caller-controlled, but the ecosystem
+//! standard is wallet-only keying: pass an empty seed (`b""`) so the derived
+//! keys are bound to the signing wallet alone. This is what the Token-2022
+//! clients and the confidential-transfer documentation derive, so an empty
+//! seed is what makes keys portable across wallets and tooling. Non-empty
+//! seeds (a token-account pubkey, [`pda_wallet_public_seed`]) remain
+//! supported for callers that need finer granularity, at the cost of not
+//! matching the keys other clients derive for the same wallet.
 
 use {
     crate::{
@@ -83,9 +87,11 @@ const MAXIMUM_IKM_LEN: usize = 65535;
 ///
 /// This single message is the input to every signing-style adapter: it is what an
 /// Ed25519 `Signer` signs ([`derive_confidential_keys`]) and what a WebAuthn passkey
-/// evaluates as its PRF input. `public_seed` is caller-controlled and granularity-
-/// agnostic; pass a wallet pubkey for per-wallet keying or a token-account pubkey for
-/// per-account keying.
+/// evaluates as its PRF input. `public_seed` is caller-controlled; the standard is
+/// an empty seed (`b""`), which binds the derived keys to the wallet alone and
+/// matches the keys other standard clients derive. Pass a non-empty seed (e.g. a
+/// token-account pubkey) only when finer granularity is worth losing that
+/// cross-client agreement.
 ///
 /// WebAuthn note: browsers apply the mandatory `SHA-256("WebAuthn PRF" || 0x00 || input)`
 /// prefixing before the authenticator, so this message is passed to `prf.eval` as-is.
@@ -125,8 +131,10 @@ pub fn pda_wallet_public_seed(
 /// confidential-balances key pair.
 ///
 /// The signed message is [`confidential_derivation_message`]. `public_seed` is
-/// caller-controlled and granularity-agnostic; pass a wallet pubkey for
-/// per-wallet keying or a token-account pubkey for per-account keying.
+/// caller-controlled; the standard is an empty seed (`b""`), which binds the
+/// derived keys to `signer`'s wallet alone and matches the keys other standard
+/// clients derive. Pass a non-empty seed (e.g. a token-account pubkey) only
+/// when finer granularity is worth losing that cross-client agreement.
 pub fn derive_confidential_keys(
     signer: &dyn Signer,
     public_seed: &[u8],

--- a/zk-sdk/src/encryption/derivation.rs
+++ b/zk-sdk/src/encryption/derivation.rs
@@ -6,10 +6,16 @@
 //! signing message are protocol-identified (`solana-conf-bal/v1`) so that
 //! independent reimplementations on any platform derive byte-identical keys.
 //!
-//! Callers have three entry points:
+//! Callers have four entry points:
 //!
-//! - [`derive_confidential_keys`]: sign once with a Solana `Signer`, derive
-//!   both keys.
+//! - [`derive_confidential_keys`]: THE standard derivation. Sign
+//!   [`STANDARD_DERIVATION_MESSAGE`] once with a Solana `Signer`, derive both
+//!   keys. Keys are bound to the signing wallet alone and match what every
+//!   other standard client derives for the same wallet.
+//! - [`derive_confidential_keys_with_seed`]: non-standard, finer-grained
+//!   keying for callers that scope keys with a `public_seed` (single-signer
+//!   PDA wallets via [`pda_wallet_public_seed`], custom schemes). Keys derived
+//!   with a non-empty seed will not match other clients' standard keys.
 //! - [`derive_confidential_keys_from_signature`]: when the caller already
 //!   holds a signature over the canonical message (e.g. produced via a
 //!   wallet-adapter signing flow or a KMS deterministic-sign call).
@@ -28,14 +34,17 @@
 //!               )
 //! ```
 //!
-//! `public_seed` in the signing path is caller-controlled, but the ecosystem
-//! standard is wallet-only keying: pass an empty seed (`b""`) so the derived
-//! keys are bound to the signing wallet alone. This is what the Token-2022
-//! clients and the confidential-transfer documentation derive, so an empty
-//! seed is what makes keys portable across wallets and tooling. Non-empty
-//! seeds (a token-account pubkey, [`pda_wallet_public_seed`]) remain
-//! supported for callers that need finer granularity, at the cost of not
-//! matching the keys other clients derive for the same wallet.
+//! The standard is wallet-level keying with no seed: [`derive_confidential_keys`]
+//! signs the constant [`STANDARD_DERIVATION_MESSAGE`], so one wallet maps to one
+//! ElGamal keypair and one AE key across all mints and token accounts, and every
+//! standard client (Token-2022 JS/Rust/CLI, solana-go, this crate) derives the
+//! same bytes for the same wallet. The seeded path exists only for schemes that
+//! genuinely need scoped keys, at the cost of that cross-client agreement.
+//!
+//! Wallet guidance: expose derivation through a dedicated API and refuse to sign
+//! messages starting with `solana-conf-bal/v1` through generic `signMessage` —
+//! a signature over the derivation message is equivalent to handing out the
+//! decryption keys.
 
 use {
     crate::{
@@ -68,6 +77,18 @@ pub const AE_HKDF_INFO: &[u8] = b"ae";
 /// HKDF info string for the ElGamal secret scalar.
 pub const ELGAMAL_HKDF_INFO: &[u8] = b"elgamal";
 
+/// The standard derivation message: what a wallet signs to derive its
+/// confidential-balances keys via [`derive_confidential_keys`]. Equal to
+/// [`confidential_derivation_message`] with an empty seed, i.e. the constant
+/// bytes `solana-conf-bal/v1`.
+///
+/// Wallets SHOULD recognize these exact bytes, expose the signature only
+/// through a dedicated key-derivation API, and refuse any generic
+/// `signMessage` request whose message starts with this prefix: the resulting
+/// signature is the input key material for the wallet's confidential-balance
+/// decryption keys.
+pub const STANDARD_DERIVATION_MESSAGE: &[u8] = HKDF_SALT;
+
 /// Byte length of a Solana address or pubkey field in a PDA-wallet public seed.
 pub const PDA_WALLET_PUBLIC_SEED_FIELD_LEN: usize = 32;
 
@@ -86,12 +107,10 @@ const MAXIMUM_IKM_LEN: usize = 65535;
 /// The canonical confidential-balances derivation message: `HKDF_SALT || public_seed`.
 ///
 /// This single message is the input to every signing-style adapter: it is what an
-/// Ed25519 `Signer` signs ([`derive_confidential_keys`]) and what a WebAuthn passkey
-/// evaluates as its PRF input. `public_seed` is caller-controlled; the standard is
-/// an empty seed (`b""`), which binds the derived keys to the wallet alone and
-/// matches the keys other standard clients derive. Pass a non-empty seed (e.g. a
-/// token-account pubkey) only when finer granularity is worth losing that
-/// cross-client agreement.
+/// Ed25519 `Signer` signs and what a WebAuthn passkey evaluates as its PRF input.
+/// With an empty seed it equals [`STANDARD_DERIVATION_MESSAGE`], the standard
+/// wallet-level derivation. A non-empty seed is the non-standard, scoped path
+/// used by [`derive_confidential_keys_with_seed`].
 ///
 /// WebAuthn note: browsers apply the mandatory `SHA-256("WebAuthn PRF" || 0x00 || input)`
 /// prefixing before the authenticator, so this message is passed to `prf.eval` as-is.
@@ -111,8 +130,8 @@ pub fn confidential_derivation_message(public_seed: &[u8]) -> Vec<u8> {
 /// ```
 ///
 /// Use this output as the `public_seed` for [`confidential_derivation_message`],
-/// [`derive_confidential_keys`], or the wasm `ConfidentialKeys.prfInput`
-/// passkey path.
+/// [`derive_confidential_keys_with_seed`], or the wasm
+/// `ConfidentialKeys.prfInputWithSeed` passkey path.
 pub fn pda_wallet_public_seed(
     program_id: &[u8; PDA_WALLET_PUBLIC_SEED_FIELD_LEN],
     wallet_pda: &[u8; PDA_WALLET_PUBLIC_SEED_FIELD_LEN],
@@ -127,15 +146,30 @@ pub fn pda_wallet_public_seed(
     seed
 }
 
-/// Signs the canonical derivation message with `signer` and derives the
-/// confidential-balances key pair.
+/// THE standard confidential-balances derivation: signs
+/// [`STANDARD_DERIVATION_MESSAGE`] once with `signer` and derives the key pair
+/// from that single signature.
 ///
-/// The signed message is [`confidential_derivation_message`]. `public_seed` is
-/// caller-controlled; the standard is an empty seed (`b""`), which binds the
-/// derived keys to `signer`'s wallet alone and matches the keys other standard
-/// clients derive. Pass a non-empty seed (e.g. a token-account pubkey) only
-/// when finer granularity is worth losing that cross-client agreement.
+/// The keys are bound to `signer`'s wallet alone — one ElGamal keypair and one
+/// AE key across all of the wallet's mints and token accounts — and are
+/// byte-identical to what every other standard client (Token-2022 JS/Rust/CLI,
+/// solana-go) derives for the same wallet.
 pub fn derive_confidential_keys(
+    signer: &dyn Signer,
+) -> Result<(ElGamalKeypair, AeKey), Box<dyn error::Error>> {
+    derive_confidential_keys_with_seed(signer, b"")
+}
+
+/// Non-standard, scoped derivation: signs the canonical derivation message for
+/// `public_seed` and derives the confidential-balances key pair.
+///
+/// The signed message is [`confidential_derivation_message`]. Use this only
+/// for schemes that genuinely need keys scoped more finely than the wallet —
+/// single-signer PDA wallets ([`pda_wallet_public_seed`]) or custom
+/// application keying. Keys derived with a non-empty seed will NOT match the
+/// standard keys other clients derive for the same wallet; for the standard
+/// wallet-level keys use [`derive_confidential_keys`].
+pub fn derive_confidential_keys_with_seed(
     signer: &dyn Signer,
     public_seed: &[u8],
 ) -> Result<(ElGamalKeypair, AeKey), Box<dyn error::Error>> {
@@ -200,8 +234,8 @@ mod tests {
         let keypair = Keypair::new();
         let public_seed = [0x11u8; 32];
 
-        let (kp_a, ae_a) = derive_confidential_keys(&keypair, &public_seed).unwrap();
-        let (kp_b, ae_b) = derive_confidential_keys(&keypair, &public_seed).unwrap();
+        let (kp_a, ae_a) = derive_confidential_keys_with_seed(&keypair, &public_seed).unwrap();
+        let (kp_b, ae_b) = derive_confidential_keys_with_seed(&keypair, &public_seed).unwrap();
 
         assert_eq!(kp_a.secret().as_bytes(), kp_b.secret().as_bytes());
         assert_eq!(
@@ -215,8 +249,8 @@ mod tests {
         let kp1 = Keypair::new();
         let kp2 = Keypair::new();
 
-        let (elgamal1, ae1) = derive_confidential_keys(&kp1, Address::default().as_ref()).unwrap();
-        let (elgamal2, ae2) = derive_confidential_keys(&kp2, Address::default().as_ref()).unwrap();
+        let (elgamal1, ae1) = derive_confidential_keys_with_seed(&kp1, Address::default().as_ref()).unwrap();
+        let (elgamal2, ae2) = derive_confidential_keys_with_seed(&kp2, Address::default().as_ref()).unwrap();
 
         assert_ne!(elgamal1.secret().as_bytes(), elgamal2.secret().as_bytes());
         assert_ne!(
@@ -232,7 +266,7 @@ mod tests {
         let keypair = Keypair::new();
         let public_seed = [0x22u8; 32];
 
-        let (kp_signer, ae_signer) = derive_confidential_keys(&keypair, &public_seed).unwrap();
+        let (kp_signer, ae_signer) = derive_confidential_keys_with_seed(&keypair, &public_seed).unwrap();
 
         let message = confidential_derivation_message(&public_seed);
         let sig = keypair.sign_message(&message);
@@ -242,6 +276,65 @@ mod tests {
         assert_eq!(
             <[u8; AE_KEY_LEN]>::from(&ae_signer),
             <[u8; AE_KEY_LEN]>::from(&ae_sig)
+        );
+    }
+
+    #[test]
+    fn test_derive_confidential_keys_standard_vector() {
+        // Canonical cross-SDK vector for the standard (wallet-level, no seed)
+        // path. The same inputs and outputs are pinned in the Go port
+        // (solana-go zkencryption kdf_vectors.json, `keypair_a_empty_seed`)
+        // and the Token-2022 JS client tests; drift in any implementation
+        // fails that implementation's CI.
+        let signer_seed: [u8; 32] = [
+            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee,
+            0xff, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc,
+            0xdd, 0xee, 0xff, 0x00,
+        ];
+        let keypair = Keypair::new_from_array(signer_seed);
+
+        let (kp, ae) = derive_confidential_keys(&keypair).unwrap();
+
+        let expected_ae: [u8; AE_KEY_LEN] = [
+            0x64, 0x17, 0xee, 0xdb, 0xcb, 0xe9, 0xc6, 0x4a, 0x72, 0x39, 0x57, 0x19, 0xec, 0x98,
+            0xcf, 0x6b,
+        ];
+        let expected_elgamal: [u8; 32] = [
+            0xbe, 0x5c, 0xce, 0x95, 0x1f, 0x42, 0xa2, 0xa8, 0x67, 0x7d, 0x1a, 0x56, 0xf0, 0x3a,
+            0xae, 0x7b, 0xff, 0x79, 0x5b, 0x38, 0xcf, 0x1c, 0x56, 0xc8, 0xcf, 0x3a, 0x4d, 0xae,
+            0x7d, 0x60, 0xe2, 0x05,
+        ];
+
+        assert_eq!(<[u8; AE_KEY_LEN]>::from(&ae), expected_ae);
+        assert_eq!(kp.secret().as_bytes(), &expected_elgamal);
+    }
+
+    #[test]
+    fn test_derive_confidential_keys_standard_matches_empty_seed() {
+        // The no-seed standard entry point, the seeded path with an empty
+        // seed, and `_from_signature` over STANDARD_DERIVATION_MESSAGE must
+        // all produce the same keys.
+        let keypair = Keypair::new();
+
+        let (kp_std, ae_std) = derive_confidential_keys(&keypair).unwrap();
+        let (kp_seeded, ae_seeded) = derive_confidential_keys_with_seed(&keypair, b"").unwrap();
+
+        let sig = keypair.sign_message(STANDARD_DERIVATION_MESSAGE);
+        let (kp_sig, ae_sig) = derive_confidential_keys_from_signature(&sig).unwrap();
+
+        assert_eq!(kp_std.secret().as_bytes(), kp_seeded.secret().as_bytes());
+        assert_eq!(kp_std.secret().as_bytes(), kp_sig.secret().as_bytes());
+        assert_eq!(
+            <[u8; AE_KEY_LEN]>::from(&ae_std),
+            <[u8; AE_KEY_LEN]>::from(&ae_seeded)
+        );
+        assert_eq!(
+            <[u8; AE_KEY_LEN]>::from(&ae_std),
+            <[u8; AE_KEY_LEN]>::from(&ae_sig)
+        );
+        assert_eq!(
+            STANDARD_DERIVATION_MESSAGE,
+            confidential_derivation_message(b"").as_slice()
         );
     }
 
@@ -385,6 +478,6 @@ mod tests {
         // the signer-side path must surface a rejection rather than
         // silently producing predictable keys.
         let null_signer = NullSigner::new(&solana_address::Address::default());
-        assert!(derive_confidential_keys(&null_signer, &[0x11u8; 32]).is_err());
+        assert!(derive_confidential_keys_with_seed(&null_signer, &[0x11u8; 32]).is_err());
     }
 }

--- a/zk-sdk/src/encryption/derivation.rs
+++ b/zk-sdk/src/encryption/derivation.rs
@@ -36,13 +36,13 @@
 //!
 //! The standard is wallet-level keying with no seed: [`derive_confidential_keys`]
 //! signs the constant [`STANDARD_DERIVATION_MESSAGE`], so one wallet maps to one
-//! ElGamal keypair and one AE key across all mints and token accounts, and every
-//! standard client (Token-2022 JS/Rust/CLI, solana-go, this crate) derives the
-//! same bytes for the same wallet. The seeded path exists only for schemes that
+//! ElGamal keypair and one AES key across all mints and token accounts, and
+//! every standard client (Token-2022 JavaScript/Rust/CLI, solana-go, this
+//! crate) derives the same bytes for the same wallet. The seeded path exists only for schemes that
 //! genuinely need scoped keys, at the cost of that cross-client agreement.
 //!
 //! Wallet guidance: expose derivation through a dedicated API and refuse to sign
-//! messages starting with `solana-conf-bal/v1` through generic `signMessage` —
+//! messages starting with `solana-conf-bal/v1` through generic `signMessage`:
 //! a signature over the derivation message is equivalent to handing out the
 //! decryption keys.
 
@@ -150,10 +150,10 @@ pub fn pda_wallet_public_seed(
 /// [`STANDARD_DERIVATION_MESSAGE`] once with `signer` and derives the key pair
 /// from that single signature.
 ///
-/// The keys are bound to `signer`'s wallet alone — one ElGamal keypair and one
-/// AE key across all of the wallet's mints and token accounts — and are
-/// byte-identical to what every other standard client (Token-2022 JS/Rust/CLI,
-/// solana-go) derives for the same wallet.
+/// The keys are bound to `signer`'s wallet alone (one ElGamal keypair and one
+/// AES key across all of the wallet's mints and token accounts) and are
+/// byte-identical to what every other standard client (Token-2022
+/// JavaScript/Rust/CLI, solana-go) derives for the same wallet.
 pub fn derive_confidential_keys(
     signer: &dyn Signer,
 ) -> Result<(ElGamalKeypair, AeKey), Box<dyn error::Error>> {
@@ -164,7 +164,7 @@ pub fn derive_confidential_keys(
 /// `public_seed` and derives the confidential-balances key pair.
 ///
 /// The signed message is [`confidential_derivation_message`]. Use this only
-/// for schemes that genuinely need keys scoped more finely than the wallet —
+/// for schemes that genuinely need keys scoped more finely than the wallet:
 /// single-signer PDA wallets ([`pda_wallet_public_seed`]) or custom
 /// application keying. Keys derived with a non-empty seed will NOT match the
 /// standard keys other clients derive for the same wallet; for the standard
@@ -249,8 +249,10 @@ mod tests {
         let kp1 = Keypair::new();
         let kp2 = Keypair::new();
 
-        let (elgamal1, ae1) = derive_confidential_keys_with_seed(&kp1, Address::default().as_ref()).unwrap();
-        let (elgamal2, ae2) = derive_confidential_keys_with_seed(&kp2, Address::default().as_ref()).unwrap();
+        let (elgamal1, ae1) =
+            derive_confidential_keys_with_seed(&kp1, Address::default().as_ref()).unwrap();
+        let (elgamal2, ae2) =
+            derive_confidential_keys_with_seed(&kp2, Address::default().as_ref()).unwrap();
 
         assert_ne!(elgamal1.secret().as_bytes(), elgamal2.secret().as_bytes());
         assert_ne!(
@@ -266,7 +268,8 @@ mod tests {
         let keypair = Keypair::new();
         let public_seed = [0x22u8; 32];
 
-        let (kp_signer, ae_signer) = derive_confidential_keys_with_seed(&keypair, &public_seed).unwrap();
+        let (kp_signer, ae_signer) =
+            derive_confidential_keys_with_seed(&keypair, &public_seed).unwrap();
 
         let message = confidential_derivation_message(&public_seed);
         let sig = keypair.sign_message(&message);

--- a/zk-sdk/src/encryption/derivation.rs
+++ b/zk-sdk/src/encryption/derivation.rs
@@ -8,7 +8,7 @@
 //!
 //! Callers have four entry points:
 //!
-//! - [`derive_confidential_keys`]: THE standard derivation. Sign
+//! - [`derive_confidential_keys`]: the standard derivation. Sign
 //!   [`STANDARD_DERIVATION_MESSAGE`] once with a Solana `Signer`, derive both
 //!   keys. Keys are bound to the signing wallet alone and match what every
 //!   other standard client derives for the same wallet.
@@ -146,7 +146,7 @@ pub fn pda_wallet_public_seed(
     seed
 }
 
-/// THE standard confidential-balances derivation: signs
+/// the standard confidential-balances derivation: signs
 /// [`STANDARD_DERIVATION_MESSAGE`] once with `signer` and derives the key pair
 /// from that single signature.
 ///

--- a/zk-sdk/src/sigma_proofs/pubkey_validity.rs
+++ b/zk-sdk/src/sigma_proofs/pubkey_validity.rs
@@ -166,7 +166,6 @@ mod test {
         super::*,
         bytemuck::Zeroable,
         curve25519_dalek::traits::Identity,
-        solana_address::Address,
         solana_keypair::Keypair,
         solana_zk_sdk_pod::{
             encryption::elgamal::PodElGamalPubkey, sigma_proofs::PodPubkeyValidityProof,
@@ -188,11 +187,8 @@ mod test {
             .unwrap();
 
         // derived ElGamal keypair
-        let (keypair, _ae_key) = crate::encryption::derivation::derive_confidential_keys(
-            &Keypair::new(),
-            Address::default().as_ref(),
-        )
-        .unwrap();
+        let (keypair, _ae_key) =
+            crate::encryption::derivation::derive_confidential_keys(&Keypair::new()).unwrap();
 
         let mut prover_transcript = Transcript::new_zk_elgamal_transcript(b"test");
         let mut verifier_transcript = Transcript::new_zk_elgamal_transcript(b"test");


### PR DESCRIPTION
## Summary

Makes wallet-level keying the enforced standard instead of a documented convention. The core problem this closes: every entry point took a caller-chosen `public_seed`, so two correct-looking clients could silently derive different keys for the same wallet. Now the standard path has no seed parameter at all.

- `derive_confidential_keys(signer)` is THE standard: one signature over the constant message `solana-conf-bal/v1`, keys bound to the wallet alone, byte-identical across all standard clients. The seeded variant moves to `derive_confidential_keys_with_seed` for PDA wallets (`pda_wallet_public_seed`) and custom schemes that knowingly opt out.
- wasm bindings get the same split: `signerMessage()` / `prfInput()` are now no-arg, `signerMessageWithSeed` / `prfInputWithSeed` cover non-standard scoping. README reworked accordingly.
- New `STANDARD_DERIVATION_MESSAGE` const: the exact bytes wallets should expose only via a dedicated derivation API and refuse through generic `signMessage` (a signature over it is equivalent to handing out the decryption keys).
- Pins the cross-SDK empty-seed test vector (same wallet seed and expected key bytes as solana-go's `keypair_a_empty_seed` fixture and the token-2022 JS client tests, plus a precomputed-signature variant in the wasm tests), so derivation drift in any implementation fails that repo's CI.

This is a breaking change to `derive_confidential_keys` and the wasm `signerMessage`/`prfInput` signatures, so it needs a semver-major zk-sdk release and a minor bump of @solana/zk-sdk (0.x). The KDF itself is unchanged: keys derived with an empty seed on 7.0.1 are identical to the new standard path.

Companion PRs: solana-program/token-2022#1432, solana-foundation/solana-go#495, solana-foundation/solana-com#2045.

Refs: ECO-504